### PR TITLE
Validate repaired main baseline

### DIFF
--- a/docs/main-ci-validation.md
+++ b/docs/main-ci-validation.md
@@ -4,4 +4,5 @@ This marker records the post-merge validation of the repaired Iron House OS base
 
 - Trusted baseline: Builds 43–110 repaired and merged.
 - Main merge commit: `bffa8ba038d48473bcc216090c9a183f77f8bf25`.
-- Required gate: backend and frontend CI must pass on `main` before Build 111 begins.
+- Validation branch base: `45d7f2c79e7521049d2eb61086f24bc24bf0a0b0` from `main`.
+- Required gate: backend and frontend CI must pass before Build 111 begins.


### PR DESCRIPTION
Runs the full backend and frontend CI suite against the current `main` baseline after the completed Build 43–110 repair and merge.

This PR contains only the validation marker update. It must be green before Build 111 begins.