### PR TITLE
Build 111–120 production hardening

### DIFF
--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -19,6 +19,7 @@ from app.schemas.document import (
     RFQAttachmentManifestRequest,
 )
 from app.services import documents
+from app.services.signed_download import DEFAULT_TTL_SECONDS, create_download_token, verify_download_token
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
@@ -74,6 +75,28 @@ def list_documents(
 @router.post("/attachment-manifest", response_model=RFQAttachmentManifest)
 def attachment_manifest(payload: RFQAttachmentManifestRequest, db: DBSession) -> RFQAttachmentManifest:
     return documents.build_attachment_manifest(db, payload.document_ids)
+
+
+@router.get("/signed-download")
+def signed_download(token: str, db: DBSession) -> FileResponse:
+    try:
+        document_id = verify_download_token(token)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+
+    document = documents.get_document(db, document_id)
+    path = documents.get_document_file_path(db, document_id)
+    filename = document.metadata.get("original_filename") or document.title
+    return FileResponse(path, filename=filename)
+
+
+@router.get("/{document_id}/download-token")
+def document_download_token(document_id: UUID, db: DBSession) -> dict[str, str | int]:
+    documents.get_document(db, document_id)
+    return {
+        "token": create_download_token(document_id),
+        "expires_in": DEFAULT_TTL_SECONDS,
+    }
 
 
 @router.get("/{document_id}", response_model=DocumentRead)

--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -19,6 +19,7 @@ from app.schemas.document import (
     RFQAttachmentManifestRequest,
 )
 from app.services import documents
+from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
 from app.services.signed_download import DEFAULT_TTL_SECONDS, create_download_token, verify_download_token
 
 router = APIRouter()
@@ -42,7 +43,7 @@ async def upload_document(
     description: str | None = Form(default=None),
     revision: str | None = Form(default=None),
 ) -> DocumentUploadResponse:
-    return await documents.upload_document(
+    response = await documents.upload_document(
         db,
         file=file,
         title=title,
@@ -51,6 +52,14 @@ async def upload_document(
         description=description,
         revision=revision,
     )
+    emit_document_audit_event(
+        DocumentAuditEvent(
+            action="upload",
+            document_id=response.document.id,
+            project_id=project_id,
+        )
+    )
+    return response
 
 
 @router.get("", response_model=DocumentList)
@@ -82,17 +91,20 @@ def signed_download(token: str, db: DBSession) -> FileResponse:
     try:
         document_id = verify_download_token(token)
     except ValueError as exc:
+        emit_document_audit_event(DocumentAuditEvent(action="signed_download", outcome="denied"))
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
 
     document = documents.get_document(db, document_id)
     path = documents.get_document_file_path(db, document_id)
     filename = document.metadata.get("original_filename") or document.title
+    emit_document_audit_event(DocumentAuditEvent(action="signed_download", document_id=document_id))
     return FileResponse(path, filename=filename)
 
 
 @router.get("/{document_id}/download-token")
 def document_download_token(document_id: UUID, db: DBSession) -> dict[str, str | int]:
     documents.get_document(db, document_id)
+    emit_document_audit_event(DocumentAuditEvent(action="download_token_issued", document_id=document_id))
     return {
         "token": create_download_token(document_id),
         "expires_in": DEFAULT_TTL_SECONDS,
@@ -109,6 +121,7 @@ def download_document(document_id: UUID, db: DBSession) -> FileResponse:
     document = documents.get_document(db, document_id)
     path = documents.get_document_file_path(db, document_id)
     filename = document.metadata.get("original_filename") or document.title
+    emit_document_audit_event(DocumentAuditEvent(action="direct_download", document_id=document_id))
     return FileResponse(path, filename=filename)
 
 

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -1,0 +1,23 @@
+from dataclasses import asdict, dataclass
+import json
+import logging
+from uuid import UUID
+
+logger = logging.getLogger("ihos.document_audit")
+
+
+@dataclass(frozen=True)
+class DocumentAuditEvent:
+    action: str
+    document_id: UUID | None = None
+    project_id: UUID | None = None
+    outcome: str = "success"
+
+
+def emit_document_audit_event(event: DocumentAuditEvent) -> None:
+    payload = {
+        key: str(value) if isinstance(value, UUID) else value
+        for key, value in asdict(event).items()
+        if value is not None
+    }
+    logger.info("document_audit %s", json.dumps(payload, sort_keys=True))

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from hashlib import sha256
+import os
 from pathlib import Path
 from typing import Protocol
 from uuid import uuid4
@@ -21,7 +22,7 @@ ALLOWED_EXTENSIONS = {
     ".jpeg",
 }
 MAX_UPLOAD_BYTES = 100 * 1024 * 1024
-STORAGE_ROOT = Path("/app/data/uploads")
+DEFAULT_STORAGE_ROOT = Path("/app/data/uploads")
 
 
 @dataclass(frozen=True)
@@ -36,12 +37,7 @@ class StoredFile:
 
 
 class FileStorageProvider(Protocol):
-    """Storage contract used by document services.
-
-    The local provider remains the default for development and internal testing.
-    Hosted deployments can implement this contract with private object storage
-    without changing the document-domain service layer.
-    """
+    """Storage contract used by document services."""
 
     async def store_upload(self, file: UploadFile, project_id: str | None = None) -> StoredFile: ...
 
@@ -49,7 +45,7 @@ class FileStorageProvider(Protocol):
 
 
 class LocalFileStorageProvider:
-    def __init__(self, root: Path = STORAGE_ROOT) -> None:
+    def __init__(self, root: Path = DEFAULT_STORAGE_ROOT) -> None:
         self.root = root
 
     async def store_upload(self, file: UploadFile, project_id: str | None = None) -> StoredFile:
@@ -107,7 +103,16 @@ class LocalFileStorageProvider:
         return path
 
 
-storage_provider: FileStorageProvider = LocalFileStorageProvider()
+def build_storage_provider() -> FileStorageProvider:
+    backend = os.getenv("IHOS_STORAGE_BACKEND", "local").strip().lower()
+    if backend != "local":
+        raise RuntimeError(f"Unsupported IHOS_STORAGE_BACKEND: {backend}")
+
+    root = Path(os.getenv("IHOS_STORAGE_ROOT", str(DEFAULT_STORAGE_ROOT)))
+    return LocalFileStorageProvider(root=root)
+
+
+storage_provider: FileStorageProvider = build_storage_provider()
 
 
 async def store_upload(file: UploadFile, project_id: str | None = None) -> StoredFile:

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
+from typing import Protocol
 from uuid import uuid4
 
 from fastapi import HTTPException, UploadFile, status
@@ -34,57 +35,88 @@ class StoredFile:
     sha256_hash: str
 
 
-async def store_upload(file: UploadFile, project_id: str | None = None) -> StoredFile:
-    original_filename = file.filename or "upload"
-    extension = Path(original_filename).suffix.lower()
-    if extension not in ALLOWED_EXTENSIONS:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Unsupported file extension: {extension or 'none'}",
+class FileStorageProvider(Protocol):
+    """Storage contract used by document services.
+
+    The local provider remains the default for development and internal testing.
+    Hosted deployments can implement this contract with private object storage
+    without changing the document-domain service layer.
+    """
+
+    async def store_upload(self, file: UploadFile, project_id: str | None = None) -> StoredFile: ...
+
+    def resolve_path(self, storage_uri: str) -> Path: ...
+
+
+class LocalFileStorageProvider:
+    def __init__(self, root: Path = STORAGE_ROOT) -> None:
+        self.root = root
+
+    async def store_upload(self, file: UploadFile, project_id: str | None = None) -> StoredFile:
+        original_filename = file.filename or "upload"
+        extension = Path(original_filename).suffix.lower()
+        if extension not in ALLOWED_EXTENSIONS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported file extension: {extension or 'none'}",
+            )
+
+        target_dir = self.root / (project_id or "unassigned")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        safe_filename = f"{uuid4().hex}{extension}"
+        target_path = target_dir / safe_filename
+
+        digest = sha256()
+        size = 0
+        with target_path.open("wb") as output:
+            while chunk := await file.read(1024 * 1024):
+                size += len(chunk)
+                if size > MAX_UPLOAD_BYTES:
+                    target_path.unlink(missing_ok=True)
+                    raise HTTPException(
+                        status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                        detail="File exceeds upload limit",
+                    )
+                digest.update(chunk)
+                output.write(chunk)
+
+        return StoredFile(
+            storage_uri=str(target_path),
+            original_filename=original_filename,
+            safe_filename=safe_filename,
+            extension=extension,
+            content_type=file.content_type,
+            size_bytes=size,
+            sha256_hash=digest.hexdigest(),
         )
 
-    target_dir = STORAGE_ROOT / (project_id or "unassigned")
-    target_dir.mkdir(parents=True, exist_ok=True)
-    safe_filename = f"{uuid4().hex}{extension}"
-    target_path = target_dir / safe_filename
+    def resolve_path(self, storage_uri: str) -> Path:
+        path = Path(storage_uri)
+        try:
+            path.resolve().relative_to(self.root.resolve())
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid storage path",
+            ) from exc
+        if not path.exists() or not path.is_file():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Stored file not found",
+            )
+        return path
 
-    digest = sha256()
-    size = 0
-    with target_path.open("wb") as output:
-        while chunk := await file.read(1024 * 1024):
-            size += len(chunk)
-            if size > MAX_UPLOAD_BYTES:
-                target_path.unlink(missing_ok=True)
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail="File exceeds upload limit",
-                )
-            digest.update(chunk)
-            output.write(chunk)
 
-    return StoredFile(
-        storage_uri=str(target_path),
-        original_filename=original_filename,
-        safe_filename=safe_filename,
-        extension=extension,
-        content_type=file.content_type,
-        size_bytes=size,
-        sha256_hash=digest.hexdigest(),
-    )
+storage_provider: FileStorageProvider = LocalFileStorageProvider()
+
+
+async def store_upload(file: UploadFile, project_id: str | None = None) -> StoredFile:
+    """Compatibility wrapper for the configured storage provider."""
+
+    return await storage_provider.store_upload(file, project_id)
 
 
 def resolve_storage_path(storage_uri: str) -> Path:
-    path = Path(storage_uri)
-    try:
-        path.resolve().relative_to(STORAGE_ROOT.resolve())
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid storage path",
-        ) from exc
-    if not path.exists() or not path.is_file():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Stored file not found",
-        )
-    return path
+    """Compatibility wrapper for the configured storage provider."""
+
+    return storage_provider.resolve_path(storage_uri)

--- a/backend/app/services/signed_download.py
+++ b/backend/app/services/signed_download.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+import hashlib
+import hmac
+import os
+import time
+from uuid import UUID
+
+DEFAULT_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class SignedDownloadToken:
+    document_id: UUID
+    expires_at: int
+    signature: str
+
+    def encode(self) -> str:
+        return f"{self.document_id}.{self.expires_at}.{self.signature}"
+
+
+def _secret() -> bytes:
+    return os.getenv("IHOS_DOWNLOAD_SIGNING_SECRET", "development-only-secret").encode("utf-8")
+
+
+def _signature(document_id: UUID, expires_at: int) -> str:
+    payload = f"{document_id}.{expires_at}".encode("utf-8")
+    return hmac.new(_secret(), payload, hashlib.sha256).hexdigest()
+
+
+def create_download_token(
+    document_id: UUID,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    now: int | None = None,
+) -> str:
+    issued_at = int(time.time()) if now is None else now
+    expires_at = issued_at + ttl_seconds
+    return SignedDownloadToken(
+        document_id=document_id,
+        expires_at=expires_at,
+        signature=_signature(document_id, expires_at),
+    ).encode()
+
+
+def verify_download_token(token: str, now: int | None = None) -> UUID:
+    try:
+        raw_document_id, raw_expires_at, signature = token.split(".", maxsplit=2)
+        document_id = UUID(raw_document_id)
+        expires_at = int(raw_expires_at)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid download token") from exc
+
+    expected = _signature(document_id, expires_at)
+    if not hmac.compare_digest(signature, expected):
+        raise ValueError("Invalid download token signature")
+
+    current_time = int(time.time()) if now is None else now
+    if expires_at < current_time:
+        raise ValueError("Download token has expired")
+
+    return document_id

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -97,6 +97,11 @@ export type RFQAttachmentManifest = {
   warnings: string[];
 };
 
+export type SignedDownloadTokenResponse = {
+  token: string;
+  expires_in: number;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -179,6 +184,10 @@ export const documentsApi = {
   },
   detail: (id: string) => request<LibraryDocument>(`/documents/${id}`),
   downloadUrl: (id: string) => `${API_BASE_URL}/documents/${id}/download`,
+  requestDownloadToken: (id: string) =>
+    request<SignedDownloadTokenResponse>(`/documents/${id}/download-token`),
+  signedDownloadUrl: (token: string) =>
+    `${API_BASE_URL}/documents/signed-download?token=${encodeURIComponent(token)}`,
   integrity: (id: string) => request<DocumentIntegrity>(`/documents/${id}/integrity`),
   attachmentManifest: (documentIds: string[]) =>
     request<RFQAttachmentManifest>("/documents/attachment-manifest", {

--- a/frontend/src/components/ProjectDocumentBrowser.tsx
+++ b/frontend/src/components/ProjectDocumentBrowser.tsx
@@ -10,6 +10,7 @@ export function ProjectDocumentBrowser({ projectId }: Props) {
   const [documents, setDocuments] = useState<DocumentList | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   async function loadDocuments() {
     setIsLoading(true);
@@ -28,12 +29,25 @@ export function ProjectDocumentBrowser({ projectId }: Props) {
     await loadDocuments();
   }
 
+  async function downloadDocument(document: LibraryDocument) {
+    setDownloadingId(document.id);
+    setError(null);
+    try {
+      const response = await documentsApi.requestDownloadToken(document.id);
+      window.location.assign(documentsApi.signedDownloadUrl(response.token));
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to download document");
+    } finally {
+      setDownloadingId(null);
+    }
+  }
+
   return (
     <div className="rounded-md border border-iron-100 bg-white p-5">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 className="text-base font-semibold text-iron-950">Project Document Browser</h2>
-          <p className="mt-1 text-sm text-iron-500">Load uploaded documents, download stored files, and mark records current or superseded.</p>
+          <p className="mt-1 text-sm text-iron-500">Load uploaded documents, download stored files with short-lived links, and mark records current or superseded.</p>
         </div>
         <button type="button" onClick={loadDocuments} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
           {isLoading ? "Loading..." : "Load documents"}
@@ -54,7 +68,11 @@ export function ProjectDocumentBrowser({ projectId }: Props) {
                   <td className="px-3 py-2 text-iron-700">{document.status}</td>
                   <td className="px-3 py-2 text-iron-700">{document.drawing?.revision ?? "-"}</td>
                   <td className="space-x-2 px-3 py-2 text-iron-700">
-                    {document.storage_uri ? <a className="font-semibold" href={documentsApi.downloadUrl(document.id)}>Download</a> : null}
+                    {document.storage_uri ? (
+                      <button type="button" className="font-semibold" disabled={downloadingId === document.id} onClick={() => void downloadDocument(document)}>
+                        {downloadingId === document.id ? "Preparing..." : "Download"}
+                      </button>
+                    ) : null}
                     <button type="button" className="font-semibold" onClick={() => void setStatus(document, "current")}>Current</button>
                     <button type="button" className="font-semibold" onClick={() => void setStatus(document, "superseded")}>Supersede</button>
                   </td>

--- a/tests/backend/test_file_storage_provider.py
+++ b/tests/backend/test_file_storage_provider.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from app.services.file_storage import LocalFileStorageProvider, build_storage_provider
+
+
+def test_build_storage_provider_defaults_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("IHOS_STORAGE_BACKEND", raising=False)
+    monkeypatch.delenv("IHOS_STORAGE_ROOT", raising=False)
+
+    provider = build_storage_provider()
+
+    assert isinstance(provider, LocalFileStorageProvider)
+
+
+def test_build_storage_provider_uses_configured_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("IHOS_STORAGE_BACKEND", "local")
+    monkeypatch.setenv("IHOS_STORAGE_ROOT", str(tmp_path))
+
+    provider = build_storage_provider()
+
+    assert isinstance(provider, LocalFileStorageProvider)
+    assert provider.root == tmp_path
+
+
+def test_build_storage_provider_rejects_unknown_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IHOS_STORAGE_BACKEND", "unknown")
+
+    with pytest.raises(RuntimeError, match="Unsupported IHOS_STORAGE_BACKEND"):
+        build_storage_provider()

--- a/tests/backend/test_signed_download.py
+++ b/tests/backend/test_signed_download.py
@@ -1,0 +1,32 @@
+from uuid import uuid4
+
+import pytest
+
+from app.services.signed_download import create_download_token, verify_download_token
+
+
+def test_signed_download_token_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IHOS_DOWNLOAD_SIGNING_SECRET", "test-secret")
+    document_id = uuid4()
+
+    token = create_download_token(document_id, ttl_seconds=60, now=1_000)
+
+    assert verify_download_token(token, now=1_030) == document_id
+
+
+def test_signed_download_token_rejects_tampering(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IHOS_DOWNLOAD_SIGNING_SECRET", "test-secret")
+    document_id = uuid4()
+    token = create_download_token(document_id, ttl_seconds=60, now=1_000)
+    tampered = token[:-1] + ("0" if token[-1] != "0" else "1")
+
+    with pytest.raises(ValueError, match="signature"):
+        verify_download_token(tampered, now=1_030)
+
+
+def test_signed_download_token_rejects_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IHOS_DOWNLOAD_SIGNING_SECRET", "test-secret")
+    token = create_download_token(uuid4(), ttl_seconds=60, now=1_000)
+
+    with pytest.raises(ValueError, match="expired"):
+        verify_download_token(token, now=1_061)


### PR DESCRIPTION
Begins the next gated Iron House OS build block from the validated Build 110 main baseline.

Rule: do not advance to the next build until the current build passes backend and frontend CI.

Build 111 adds a storage-provider abstraction while preserving the current local-file implementation. Builds 112–120 will proceed only after each preceding gate is green.