### PR TITLE
Complete gated Builds 121–130

### DIFF
--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -20,6 +20,7 @@ from app.schemas.document import (
 )
 from app.services import documents
 from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
+from app.services.request_context import get_request_audit_context
 from app.services.signed_download import DEFAULT_TTL_SECONDS, create_download_token, verify_download_token
 
 router = APIRouter()
@@ -35,6 +36,7 @@ def create_document(payload: DocumentCreate, db: DBSession) -> DocumentRead:
 
 @router.post("/upload", response_model=DocumentUploadResponse, status_code=status.HTTP_201_CREATED)
 async def upload_document(
+    request: Request,
     db: DBSession,
     file: UploadFile = File(...),
     title: str | None = Form(default=None),
@@ -52,11 +54,15 @@ async def upload_document(
         description=description,
         revision=revision,
     )
+    context = get_request_audit_context(request)
     emit_document_audit_event(
         DocumentAuditEvent(
             action="upload",
             document_id=response.document.id,
             project_id=project_id,
+            actor=context.actor,
+            request_id=context.request_id,
+            metadata={"filename": response.original_filename, "size_bytes": response.size_bytes},
         )
     )
     return response
@@ -87,24 +93,51 @@ def attachment_manifest(payload: RFQAttachmentManifestRequest, db: DBSession) ->
 
 
 @router.get("/signed-download")
-def signed_download(token: str, db: DBSession) -> FileResponse:
+def signed_download(token: str, request: Request, db: DBSession) -> FileResponse:
+    context = get_request_audit_context(request)
     try:
         document_id = verify_download_token(token)
     except ValueError as exc:
-        emit_document_audit_event(DocumentAuditEvent(action="signed_download", outcome="denied"))
+        emit_document_audit_event(
+            DocumentAuditEvent(
+                action="signed_download",
+                outcome="denied",
+                actor=context.actor,
+                request_id=context.request_id,
+            )
+        )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
 
     document = documents.get_document(db, document_id)
     path = documents.get_document_file_path(db, document_id)
     filename = document.metadata.get("original_filename") or document.title
-    emit_document_audit_event(DocumentAuditEvent(action="signed_download", document_id=document_id))
+    emit_document_audit_event(
+        DocumentAuditEvent(
+            action="signed_download",
+            document_id=document_id,
+            project_id=document.project_id,
+            actor=context.actor,
+            request_id=context.request_id,
+            metadata={"filename": filename},
+        )
+    )
     return FileResponse(path, filename=filename)
 
 
 @router.get("/{document_id}/download-token")
-def document_download_token(document_id: UUID, db: DBSession) -> dict[str, str | int]:
-    documents.get_document(db, document_id)
-    emit_document_audit_event(DocumentAuditEvent(action="download_token_issued", document_id=document_id))
+def document_download_token(document_id: UUID, request: Request, db: DBSession) -> dict[str, str | int]:
+    document = documents.get_document(db, document_id)
+    context = get_request_audit_context(request)
+    emit_document_audit_event(
+        DocumentAuditEvent(
+            action="download_token_issued",
+            document_id=document_id,
+            project_id=document.project_id,
+            actor=context.actor,
+            request_id=context.request_id,
+            metadata={"expires_in": DEFAULT_TTL_SECONDS},
+        )
+    )
     return {
         "token": create_download_token(document_id),
         "expires_in": DEFAULT_TTL_SECONDS,
@@ -117,11 +150,21 @@ def read_document(document_id: UUID, db: DBSession) -> DocumentRead:
 
 
 @router.get("/{document_id}/download")
-def download_document(document_id: UUID, db: DBSession) -> FileResponse:
+def download_document(document_id: UUID, request: Request, db: DBSession) -> FileResponse:
     document = documents.get_document(db, document_id)
     path = documents.get_document_file_path(db, document_id)
     filename = document.metadata.get("original_filename") or document.title
-    emit_document_audit_event(DocumentAuditEvent(action="direct_download", document_id=document_id))
+    context = get_request_audit_context(request)
+    emit_document_audit_event(
+        DocumentAuditEvent(
+            action="direct_download",
+            document_id=document_id,
+            project_id=document.project_id,
+            actor=context.actor,
+            request_id=context.request_id,
+            metadata={"filename": filename},
+        )
+    )
     return FileResponse(path, filename=filename)
 
 

--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
@@ -19,7 +19,11 @@ from app.schemas.document import (
     RFQAttachmentManifestRequest,
 )
 from app.services import documents
-from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
+from app.services.document_audit import (
+    DocumentAuditEvent,
+    emit_document_audit_event,
+    list_recent_document_audit_events,
+)
 from app.services.request_context import get_request_audit_context
 from app.services.signed_download import DEFAULT_TTL_SECONDS, create_download_token, verify_download_token
 
@@ -87,6 +91,12 @@ def list_documents(
     )
 
 
+@router.get("/audit-events")
+def document_audit_events(limit: int = Query(default=50, ge=1, le=200)) -> dict[str, Any]:
+    items = list_recent_document_audit_events(limit)
+    return {"items": items, "total": len(items)}
+
+
 @router.post("/attachment-manifest", response_model=RFQAttachmentManifest)
 def attachment_manifest(payload: RFQAttachmentManifestRequest, db: DBSession) -> RFQAttachmentManifest:
     return documents.build_attachment_manifest(db, payload.document_ids)
@@ -138,10 +148,7 @@ def document_download_token(document_id: UUID, request: Request, db: DBSession) 
             metadata={"expires_in": DEFAULT_TTL_SECONDS},
         )
     )
-    return {
-        "token": create_download_token(document_id),
-        "expires_in": DEFAULT_TTL_SECONDS,
-    }
+    return {"token": create_download_token(document_id), "expires_in": DEFAULT_TTL_SECONDS}
 
 
 @router.get("/{document_id}", response_model=DocumentRead)
@@ -174,11 +181,7 @@ def document_integrity(document_id: UUID, db: DBSession) -> DocumentIntegrity:
 
 
 @router.patch("/{document_id}", response_model=DocumentRead)
-def update_document(
-    document_id: UUID,
-    payload: DocumentUpdate,
-    db: DBSession,
-) -> DocumentRead:
+def update_document(document_id: UUID, payload: DocumentUpdate, db: DBSession) -> DocumentRead:
     return documents.update_document(db, document_id, payload)
 
 

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -1,3 +1,4 @@
+from collections import deque
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 import json
@@ -6,6 +7,8 @@ from typing import Any
 from uuid import UUID
 
 logger = logging.getLogger("ihos.document_audit")
+MAX_RECENT_EVENTS = 200
+_recent_events: deque[dict[str, Any]] = deque(maxlen=MAX_RECENT_EVENTS)
 
 
 @dataclass(frozen=True)
@@ -36,4 +39,14 @@ def emit_document_audit_event(event: DocumentAuditEvent) -> None:
         for key, value in asdict(event).items()
         if value not in (None, {}, [])
     }
+    _recent_events.appendleft(payload)
     logger.info("document_audit %s", json.dumps(payload, sort_keys=True))
+
+
+def list_recent_document_audit_events(limit: int = 50) -> list[dict[str, Any]]:
+    bounded_limit = max(1, min(limit, MAX_RECENT_EVENTS))
+    return list(_recent_events)[:bounded_limit]
+
+
+def clear_recent_document_audit_events() -> None:
+    _recent_events.clear()

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -1,6 +1,8 @@
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
 import json
 import logging
+from typing import Any
 from uuid import UUID
 
 logger = logging.getLogger("ihos.document_audit")
@@ -12,12 +14,26 @@ class DocumentAuditEvent:
     document_id: UUID | None = None
     project_id: UUID | None = None
     outcome: str = "success"
+    actor: str | None = None
+    request_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+def _serialize(value: Any) -> Any:
+    if isinstance(value, (UUID, datetime)):
+        return value.isoformat() if isinstance(value, datetime) else str(value)
+    if isinstance(value, dict):
+        return {str(key): _serialize(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_serialize(item) for item in value]
+    return value
 
 
 def emit_document_audit_event(event: DocumentAuditEvent) -> None:
     payload = {
-        key: str(value) if isinstance(value, UUID) else value
+        key: _serialize(value)
         for key, value in asdict(event).items()
-        if value is not None
+        if value not in (None, {}, [])
     }
     logger.info("document_audit %s", json.dumps(payload, sort_keys=True))

--- a/backend/app/services/request_context.py
+++ b/backend/app/services/request_context.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from uuid import uuid4
+
+from fastapi import Request
+
+
+@dataclass(frozen=True)
+class RequestAuditContext:
+    actor: str | None
+    request_id: str
+
+
+def get_request_audit_context(request: Request) -> RequestAuditContext:
+    actor = request.headers.get("x-ihos-actor") or request.headers.get("x-forwarded-user")
+    request_id = request.headers.get("x-request-id") or f"req-{uuid4().hex}"
+    return RequestAuditContext(actor=actor, request_id=request_id)

--- a/backend/tests/test_document_audit.py
+++ b/backend/tests/test_document_audit.py
@@ -1,0 +1,33 @@
+import json
+import logging
+from uuid import uuid4
+
+from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
+
+
+def test_document_audit_event_serializes_context(caplog) -> None:
+    document_id = uuid4()
+    project_id = uuid4()
+
+    with caplog.at_level(logging.INFO, logger="ihos.document_audit"):
+        emit_document_audit_event(
+            DocumentAuditEvent(
+                action="document.downloaded",
+                document_id=document_id,
+                project_id=project_id,
+                actor="user@example.com",
+                request_id="req-123",
+                metadata={"size_bytes": 42, "tags": ["rfq", "current"]},
+            )
+        )
+
+    message = caplog.records[-1].getMessage()
+    payload = json.loads(message.removeprefix("document_audit "))
+
+    assert payload["action"] == "document.downloaded"
+    assert payload["document_id"] == str(document_id)
+    assert payload["project_id"] == str(project_id)
+    assert payload["actor"] == "user@example.com"
+    assert payload["request_id"] == "req-123"
+    assert payload["metadata"] == {"size_bytes": 42, "tags": ["rfq", "current"]}
+    assert payload["occurred_at"].endswith("+00:00")

--- a/backend/tests/test_request_context.py
+++ b/backend/tests/test_request_context.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from app.services.request_context import get_request_audit_context
+
+app = FastAPI()
+
+
+@app.get("/context")
+def context(request: Request) -> dict[str, str | None]:
+    audit_context = get_request_audit_context(request)
+    return {"actor": audit_context.actor, "request_id": audit_context.request_id}
+
+
+client = TestClient(app)
+
+
+def test_request_context_uses_forwarded_headers() -> None:
+    response = client.get(
+        "/context",
+        headers={"x-ihos-actor": "jeremie", "x-request-id": "req-fixed"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"actor": "jeremie", "request_id": "req-fixed"}
+
+
+def test_request_context_generates_request_id() -> None:
+    response = client.get("/context")
+
+    assert response.status_code == 200
+    assert response.json()["actor"] is None
+    assert response.json()["request_id"].startswith("req-")

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -102,6 +102,22 @@ export type SignedDownloadTokenResponse = {
   expires_in: number;
 };
 
+export type DocumentAuditEvent = {
+  action: string;
+  document_id?: string;
+  project_id?: string;
+  outcome: string;
+  actor?: string;
+  request_id?: string;
+  metadata?: Record<string, unknown>;
+  occurred_at: string;
+};
+
+export type DocumentAuditEventList = {
+  items: DocumentAuditEvent[];
+  total: number;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -188,6 +204,8 @@ export const documentsApi = {
     request<SignedDownloadTokenResponse>(`/documents/${id}/download-token`),
   signedDownloadUrl: (token: string) =>
     `${API_BASE_URL}/documents/signed-download?token=${encodeURIComponent(token)}`,
+  recentAuditEvents: (limit = 50) =>
+    request<DocumentAuditEventList>(`/documents/audit-events?limit=${limit}`),
   integrity: (id: string) => request<DocumentIntegrity>(`/documents/${id}/integrity`),
   attachmentManifest: (documentIds: string[]) =>
     request<RFQAttachmentManifest>("/documents/attachment-manifest", {

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+import { DocumentAuditEventList, documentsApi } from "../api/documents";
+
+export function DocumentAuditPanel() {
+  const [events, setEvents] = useState<DocumentAuditEventList | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  async function loadEvents() {
+    setIsLoading(true);
+    setError(null);
+    try {
+      setEvents(await documentsApi.recentAuditEvents(50));
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to load audit events");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-iron-950">Recent Document Activity</h2>
+          <p className="mt-1 text-sm text-iron-500">Review recent uploads, download-token issuance, downloads, actors, and correlation IDs.</p>
+        </div>
+        <button type="button" onClick={loadEvents} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
+          {isLoading ? "Loading..." : "Load activity"}
+        </button>
+      </div>
+
+      {error ? <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
+
+      {events ? (
+        <div className="mt-4 overflow-hidden rounded-md border border-iron-100">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500">
+              <tr><th className="px-3 py-2">Time</th><th className="px-3 py-2">Action</th><th className="px-3 py-2">Outcome</th><th className="px-3 py-2">Actor</th><th className="px-3 py-2">Request</th></tr>
+            </thead>
+            <tbody>
+              {events.items.map((event, index) => (
+                <tr key={`${event.request_id ?? "event"}-${event.occurred_at}-${index}`} className="border-t border-iron-100">
+                  <td className="px-3 py-2 text-iron-700">{new Date(event.occurred_at).toLocaleString()}</td>
+                  <td className="px-3 py-2 font-medium text-iron-950">{event.action}</td>
+                  <td className="px-3 py-2 text-iron-700">{event.outcome}</td>
+                  <td className="px-3 py-2 text-iron-700">{event.actor ?? "system"}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-iron-600">{event.request_id ?? "-"}</td>
+                </tr>
+              ))}
+              {events.items.length === 0 ? <tr><td className="px-3 py-3 text-iron-500" colSpan={5}>No recent document activity.</td></tr> : null}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/DocumentOperationsPage.tsx
+++ b/frontend/src/pages/DocumentOperationsPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { DocumentAuditPanel } from "../components/DocumentAuditPanel";
 import { DocumentUploadPanel } from "../components/DocumentUploadPanel";
 import { ProjectDocumentBrowser } from "../components/ProjectDocumentBrowser";
 import { RFQAttachmentManifestPanel } from "../components/RFQAttachmentManifestPanel";
@@ -12,7 +13,7 @@ export function DocumentOperationsPage() {
       <div className="border-b border-iron-100 pb-6">
         <h1 className="text-3xl font-semibold text-iron-950">Document Operations</h1>
         <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-500">
-          Build 109 document operations page for upload, project browsing, drawing revisions, downloads, and RFQ attachment manifests.
+          Upload, browse, secure, audit, and package project documents for estimating and RFQ workflows.
         </p>
       </div>
 
@@ -26,6 +27,7 @@ export function DocumentOperationsPage() {
       <DocumentUploadPanel projectId={projectId || null} />
       <ProjectDocumentBrowser projectId={projectId || null} />
       <RFQAttachmentManifestPanel />
+      <DocumentAuditPanel />
     </section>
   );
 }


### PR DESCRIPTION
Completes the individually gated Iron House OS build sequence from Build 121 through Build 130.

## Gate rule followed

No build advanced until both backend and frontend CI checks were green.

## Completed builds

- Build 121: enriched structured document audit events.
- Build 122: audit serialization and metadata tests.
- Build 123: request actor and correlation-ID context service.
- Build 124: request context wired into document upload and download audit events.
- Build 125: request-context tests.
- Build 126: bounded recent document-audit event buffer.
- Build 127: recent document-audit API endpoint.
- Build 128: frontend audit-event API client.
- Build 129: recent document-activity panel.
- Build 130: audit panel integrated into Document Operations.

## Final validation

CI run `29131793075` passed backend installation, Ruff lint, pytest, frontend installation, lint, tests, and production build.

## Branch

`build/build-121-to-130-gated`

## Next step

Merge this PR into `main`, validate the resulting main baseline, then begin Build 131.