### PR TITLE
Validate main after Builds 121–130

### DIFF
--- a/docs/validation-main-after-build-130.md
+++ b/docs/validation-main-after-build-130.md
@@ -1,0 +1,5 @@
+# Main Validation After Build 130
+
+This marker exists only to trigger GitHub Actions against the exact `main` baseline produced by merging gated Builds 121–130.
+
+Validation target: `682091d26747aad3e68f23cd23718a8fe7816d80`


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 121–130. This PR contains only a validation marker and must pass backend and frontend CI before Build 131 begins.