### PR TITLE
Complete gated Builds 131–140

### DIFF
--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -22,7 +22,9 @@ from app.services import documents
 from app.services.document_audit import (
     DocumentAuditEvent,
     emit_document_audit_event,
+    export_document_audit_events_csv,
     list_recent_document_audit_events,
+    summarize_document_audit_events,
 )
 from app.services.request_context import get_request_audit_context
 from app.services.signed_download import DEFAULT_TTL_SECONDS, create_download_token, verify_download_token
@@ -107,6 +109,34 @@ def document_audit_events(
         project_id=project_id,
     )
     return {"items": items, "total": len(items)}
+
+
+@router.get("/audit-events/summary")
+def document_audit_summary() -> dict[str, Any]:
+    return summarize_document_audit_events()
+
+
+@router.get("/audit-events/export.csv")
+def document_audit_export(
+    limit: int = Query(default=200, ge=1, le=200),
+    action: str | None = Query(default=None),
+    outcome: str | None = Query(default=None),
+    actor: str | None = Query(default=None),
+    project_id: UUID | None = Query(default=None),
+) -> Response:
+    events = list_recent_document_audit_events(
+        limit,
+        action=action,
+        outcome=outcome,
+        actor=actor,
+        project_id=project_id,
+    )
+    csv_text = export_document_audit_events_csv(events)
+    return Response(
+        content=csv_text,
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=document-audit-events.csv"},
+    )
 
 
 @router.post("/attachment-manifest", response_model=RFQAttachmentManifest)

--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -92,8 +92,20 @@ def list_documents(
 
 
 @router.get("/audit-events")
-def document_audit_events(limit: int = Query(default=50, ge=1, le=200)) -> dict[str, Any]:
-    items = list_recent_document_audit_events(limit)
+def document_audit_events(
+    limit: int = Query(default=50, ge=1, le=200),
+    action: str | None = Query(default=None),
+    outcome: str | None = Query(default=None),
+    actor: str | None = Query(default=None),
+    project_id: UUID | None = Query(default=None),
+) -> dict[str, Any]:
+    items = list_recent_document_audit_events(
+        limit,
+        action=action,
+        outcome=outcome,
+        actor=actor,
+        project_id=project_id,
+    )
     return {"items": items, "total": len(items)}
 
 

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -1,6 +1,8 @@
 from collections import Counter, deque
+import csv
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
+from io import StringIO
 import json
 import logging
 from typing import Any
@@ -71,6 +73,27 @@ def summarize_document_audit_events() -> dict[str, Any]:
         "by_action": dict(Counter(event.get("action", "unknown") for event in events)),
         "by_outcome": dict(Counter(event.get("outcome", "success") for event in events)),
     }
+
+
+def export_document_audit_events_csv(events: list[dict[str, Any]]) -> str:
+    output = StringIO()
+    fieldnames = [
+        "occurred_at",
+        "action",
+        "outcome",
+        "actor",
+        "request_id",
+        "project_id",
+        "document_id",
+        "metadata",
+    ]
+    writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
+    writer.writeheader()
+    for event in events:
+        row = dict(event)
+        row["metadata"] = json.dumps(row.get("metadata", {}), sort_keys=True)
+        writer.writerow(row)
+    return output.getvalue()
 
 
 def clear_recent_document_audit_events() -> None:

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -43,9 +43,25 @@ def emit_document_audit_event(event: DocumentAuditEvent) -> None:
     logger.info("document_audit %s", json.dumps(payload, sort_keys=True))
 
 
-def list_recent_document_audit_events(limit: int = 50) -> list[dict[str, Any]]:
+def list_recent_document_audit_events(
+    limit: int = 50,
+    *,
+    action: str | None = None,
+    outcome: str | None = None,
+    actor: str | None = None,
+    project_id: UUID | str | None = None,
+) -> list[dict[str, Any]]:
     bounded_limit = max(1, min(limit, MAX_RECENT_EVENTS))
-    return list(_recent_events)[:bounded_limit]
+    expected_project_id = str(project_id) if project_id is not None else None
+    filtered = (
+        event
+        for event in _recent_events
+        if (action is None or event.get("action") == action)
+        and (outcome is None or event.get("outcome", "success") == outcome)
+        and (actor is None or event.get("actor") == actor)
+        and (expected_project_id is None or event.get("project_id") == expected_project_id)
+    )
+    return list(filtered)[:bounded_limit]
 
 
 def clear_recent_document_audit_events() -> None:

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -1,4 +1,4 @@
-from collections import deque
+from collections import Counter, deque
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 import json
@@ -62,6 +62,15 @@ def list_recent_document_audit_events(
         and (expected_project_id is None or event.get("project_id") == expected_project_id)
     )
     return list(filtered)[:bounded_limit]
+
+
+def summarize_document_audit_events() -> dict[str, Any]:
+    events = list(_recent_events)
+    return {
+        "total": len(events),
+        "by_action": dict(Counter(event.get("action", "unknown") for event in events)),
+        "by_outcome": dict(Counter(event.get("outcome", "success") for event in events)),
+    }
 
 
 def clear_recent_document_audit_events() -> None:

--- a/backend/tests/test_document_audit.py
+++ b/backend/tests/test_document_audit.py
@@ -1,3 +1,5 @@
+import csv
+from io import StringIO
 import json
 import logging
 from uuid import uuid4
@@ -6,6 +8,7 @@ from app.services.document_audit import (
     DocumentAuditEvent,
     clear_recent_document_audit_events,
     emit_document_audit_event,
+    export_document_audit_events_csv,
     list_recent_document_audit_events,
     summarize_document_audit_events,
 )
@@ -67,3 +70,14 @@ def test_document_audit_summary_counts_actions_and_outcomes() -> None:
     assert summary["total"] == 3
     assert summary["by_action"] == {"upload": 2, "signed_download": 1}
     assert summary["by_outcome"] == {"success": 2, "denied": 1}
+
+
+def test_document_audit_csv_export_serializes_metadata() -> None:
+    csv_text = export_document_audit_events_csv(
+        [{"occurred_at": "2026-07-10T00:00:00+00:00", "action": "upload", "outcome": "success", "metadata": {"filename": "plan.pdf"}}]
+    )
+    rows = list(csv.DictReader(StringIO(csv_text)))
+
+    assert len(rows) == 1
+    assert rows[0]["action"] == "upload"
+    assert json.loads(rows[0]["metadata"]) == {"filename": "plan.pdf"}

--- a/backend/tests/test_document_audit.py
+++ b/backend/tests/test_document_audit.py
@@ -7,6 +7,7 @@ from app.services.document_audit import (
     clear_recent_document_audit_events,
     emit_document_audit_event,
     list_recent_document_audit_events,
+    summarize_document_audit_events,
 )
 
 
@@ -53,3 +54,16 @@ def test_recent_document_audit_events_support_filters() -> None:
     assert len(list_recent_document_audit_events(actor="jeremie")) == 1
     assert len(list_recent_document_audit_events(project_id=project_id)) == 1
     assert list_recent_document_audit_events(action="missing") == []
+
+
+def test_document_audit_summary_counts_actions_and_outcomes() -> None:
+    clear_recent_document_audit_events()
+    emit_document_audit_event(DocumentAuditEvent(action="upload"))
+    emit_document_audit_event(DocumentAuditEvent(action="upload"))
+    emit_document_audit_event(DocumentAuditEvent(action="signed_download", outcome="denied"))
+
+    summary = summarize_document_audit_events()
+
+    assert summary["total"] == 3
+    assert summary["by_action"] == {"upload": 2, "signed_download": 1}
+    assert summary["by_outcome"] == {"success": 2, "denied": 1}

--- a/backend/tests/test_document_audit.py
+++ b/backend/tests/test_document_audit.py
@@ -2,7 +2,12 @@ import json
 import logging
 from uuid import uuid4
 
-from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
+from app.services.document_audit import (
+    DocumentAuditEvent,
+    clear_recent_document_audit_events,
+    emit_document_audit_event,
+    list_recent_document_audit_events,
+)
 
 
 def test_document_audit_event_serializes_context(caplog) -> None:
@@ -31,3 +36,20 @@ def test_document_audit_event_serializes_context(caplog) -> None:
     assert payload["request_id"] == "req-123"
     assert payload["metadata"] == {"size_bytes": 42, "tags": ["rfq", "current"]}
     assert payload["occurred_at"].endswith("+00:00")
+
+
+def test_recent_document_audit_events_support_filters() -> None:
+    clear_recent_document_audit_events()
+    project_id = uuid4()
+    emit_document_audit_event(
+        DocumentAuditEvent(action="upload", project_id=project_id, actor="jeremie", outcome="success")
+    )
+    emit_document_audit_event(
+        DocumentAuditEvent(action="signed_download", actor="supplier", outcome="denied")
+    )
+
+    assert len(list_recent_document_audit_events(action="upload")) == 1
+    assert len(list_recent_document_audit_events(outcome="denied")) == 1
+    assert len(list_recent_document_audit_events(actor="jeremie")) == 1
+    assert len(list_recent_document_audit_events(project_id=project_id)) == 1
+    assert list_recent_document_audit_events(action="missing") == []

--- a/frontend/src/api/documentAudit.ts
+++ b/frontend/src/api/documentAudit.ts
@@ -1,0 +1,37 @@
+export type DocumentAuditEvent = {
+  action: string;
+  document_id?: string;
+  project_id?: string;
+  outcome: string;
+  actor?: string;
+  request_id?: string;
+  metadata?: Record<string, unknown>;
+  occurred_at: string;
+};
+
+export type DocumentAuditEventList = {
+  items: DocumentAuditEvent[];
+  total: number;
+};
+
+export type DocumentAuditFilters = {
+  limit?: number;
+  action?: string;
+  outcome?: string;
+  actor?: string;
+  project_id?: string;
+};
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+export const documentAuditApi = {
+  list: async (filters: DocumentAuditFilters = {}): Promise<DocumentAuditEventList> => {
+    const query = new URLSearchParams();
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value !== undefined && value !== "") query.set(key, String(value));
+    });
+    const response = await fetch(`${API_BASE_URL}/documents/audit-events?${query.toString()}`);
+    if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+    return response.json() as Promise<DocumentAuditEventList>;
+  },
+};

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
 
-import { DocumentAuditEventList, documentsApi } from "../api/documents";
+import { documentAuditApi, DocumentAuditEventList } from "../api/documentAudit";
 
 export function DocumentAuditPanel() {
   const [events, setEvents] = useState<DocumentAuditEventList | null>(null);
+  const [action, setAction] = useState("");
+  const [outcome, setOutcome] = useState("");
+  const [actor, setActor] = useState("");
+  const [projectId, setProjectId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -11,7 +15,7 @@ export function DocumentAuditPanel() {
     setIsLoading(true);
     setError(null);
     try {
-      setEvents(await documentsApi.recentAuditEvents(50));
+      setEvents(await documentAuditApi.list({ limit: 50, action, outcome, actor, project_id: projectId }));
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to load audit events");
     } finally {
@@ -24,11 +28,20 @@ export function DocumentAuditPanel() {
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 className="text-base font-semibold text-iron-950">Recent Document Activity</h2>
-          <p className="mt-1 text-sm text-iron-500">Review recent uploads, download-token issuance, downloads, actors, and correlation IDs.</p>
+          <p className="mt-1 text-sm text-iron-500">Filter uploads and downloads by action, outcome, actor, or project.</p>
         </div>
         <button type="button" onClick={loadEvents} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
           {isLoading ? "Loading..." : "Load activity"}
         </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-4">
+        <input value={action} onChange={(event) => setAction(event.target.value)} placeholder="Action" className="rounded-md border border-iron-100 px-3 py-2 text-sm" />
+        <select value={outcome} onChange={(event) => setOutcome(event.target.value)} className="rounded-md border border-iron-100 px-3 py-2 text-sm">
+          <option value="">All outcomes</option><option value="success">Success</option><option value="denied">Denied</option>
+        </select>
+        <input value={actor} onChange={(event) => setActor(event.target.value)} placeholder="Actor" className="rounded-md border border-iron-100 px-3 py-2 text-sm" />
+        <input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="Project UUID" className="rounded-md border border-iron-100 px-3 py-2 text-sm" />
       </div>
 
       {error ? <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
@@ -49,7 +62,7 @@ export function DocumentAuditPanel() {
                   <td className="px-3 py-2 font-mono text-xs text-iron-600">{event.request_id ?? "-"}</td>
                 </tr>
               ))}
-              {events.items.length === 0 ? <tr><td className="px-3 py-3 text-iron-500" colSpan={5}>No recent document activity.</td></tr> : null}
+              {events.items.length === 0 ? <tr><td className="px-3 py-3 text-iron-500" colSpan={5}>No matching document activity.</td></tr> : null}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
Completes the individually gated Iron House OS sequence from Build 131 through Build 140.

## Gate rule followed
No build advanced until backend and frontend CI were green.

## Completed builds
- 131: server-side audit event filtering.
- 132: audit filter tests.
- 133: audit filter API query parameters.
- 134: typed frontend audit client.
- 135: interactive audit filters in Document Operations.
- 136: activity summary counts by action and outcome.
- 137: summary tests.
- 138: filtered CSV export generation.
- 139: CSV export tests.
- 140: audit summary and CSV export endpoints.

## Final validation
CI run `29133457019` passed backend installation, Ruff lint, pytest, frontend installation, lint, tests, and production build.

Branch: `build/build-131-to-140-gated`

Next step: merge this PR into `main`, validate the merged baseline, then begin Build 141.