### PR TITLE
Validate main after Builds 131–140

### DIFF
--- a/docs/validation-main-after-build-140.md
+++ b/docs/validation-main-after-build-140.md
@@ -1,0 +1,5 @@
+# Main validation after Build 140
+
+This marker validates the exact merged `main` baseline after Builds 131–140.
+
+Required gate: backend and frontend CI must both pass before Build 141 begins.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 131–140. This PR contains only a validation marker and must pass backend and frontend CI before Build 141 begins.