### PR TITLE
Complete gated Builds 141–150

### DIFF
--- a/docs/build-141-to-150-completion.md
+++ b/docs/build-141-to-150-completion.md
@@ -1,0 +1,24 @@
+# Builds 141–150 Completion Record
+
+## Gate rule
+
+Every build in this block was committed and required a successful backend and frontend GitHub Actions run before the following build began.
+
+## Delivered capabilities
+
+- Typed frontend access to audit-event lists, operational summaries, and filtered CSV exports.
+- Dedicated audit client support for summary and export endpoints.
+- Live activity totals for matching, successful, and denied events.
+- Filtered CSV export from Document Operations.
+- Last-refresh visibility and one-click filter reset.
+- Reusable action-distribution summary component.
+- Integrated action breakdown in the audit operations interface.
+- Operator runbook for investigations, correlation IDs, exports, and retention limitations.
+
+## Current production boundary
+
+The audit buffer remains bounded and process-local. This block makes the current audit stream operationally usable, but production compliance retention requires a persistent append-only data store, access controls, retention policy, and cross-instance aggregation.
+
+## Next unlocked work
+
+After this branch is merged and the resulting `main` tree is validated green, Build 151 may begin. Recommended next focus: persistent audit storage and role-based access to audit data.

--- a/docs/document-audit-operations.md
+++ b/docs/document-audit-operations.md
@@ -1,0 +1,29 @@
+# Document Audit Operations
+
+## Purpose
+
+Document Operations records upload, token issuance, signed download, direct download, and denied signed-download activity. The audit panel provides recent-event filtering, operational totals, action distribution, request correlation IDs, and CSV export.
+
+## Operator workflow
+
+1. Open **Document Operations**.
+2. Use the Action, Outcome, Actor, or Project UUID filters to narrow the investigation.
+3. Select **Load activity** to refresh both the event table and summary counts.
+4. Review request IDs when tracing one transaction across application logs.
+5. Select **Export CSV** to preserve the currently filtered view.
+6. Select **Reset** before beginning a separate investigation.
+
+## Investigation guidance
+
+- Repeated `signed_download` events with outcome `denied` may indicate expired, malformed, or tampered tokens.
+- Use Project UUID filtering when reviewing an RFQ package or tender-specific document flow.
+- Use Actor filtering to identify activity associated with a user, supplier, or automation identity.
+- Compare the summary action distribution with the event table before exporting evidence.
+
+## Current retention boundary
+
+The recent-event buffer is bounded and process-local. It is intended for current operational visibility, not permanent compliance retention. A persistent audit store remains the production path for long-term evidence and cross-instance aggregation.
+
+## Green-gate requirement
+
+Changes to audit capture, filtering, summaries, or exports must pass backend lint/tests and frontend lint/tests/build before merge.

--- a/frontend/src/api/documentAudit.ts
+++ b/frontend/src/api/documentAudit.ts
@@ -22,16 +22,39 @@ export type DocumentAuditFilters = {
   project_id?: string;
 };
 
+export type DocumentAuditSummary = {
+  total: number;
+  by_action: Record<string, number>;
+  by_outcome: Record<string, number>;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
+function buildQuery(filters: DocumentAuditFilters = {}): string {
+  const query = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") query.set(key, String(value));
+  });
+  return query.toString();
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`);
+  if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+  return response.json() as Promise<T>;
+}
+
 export const documentAuditApi = {
-  list: async (filters: DocumentAuditFilters = {}): Promise<DocumentAuditEventList> => {
-    const query = new URLSearchParams();
-    Object.entries(filters).forEach(([key, value]) => {
-      if (value !== undefined && value !== "") query.set(key, String(value));
-    });
-    const response = await fetch(`${API_BASE_URL}/documents/audit-events?${query.toString()}`);
-    if (!response.ok) throw new Error(`Request failed with ${response.status}`);
-    return response.json() as Promise<DocumentAuditEventList>;
+  list: (filters: DocumentAuditFilters = {}) => {
+    const query = buildQuery(filters);
+    return getJson<DocumentAuditEventList>(`/documents/audit-events${query ? `?${query}` : ""}`);
+  },
+  summary: (filters: DocumentAuditFilters = {}) => {
+    const query = buildQuery(filters);
+    return getJson<DocumentAuditSummary>(`/documents/audit-events/summary${query ? `?${query}` : ""}`);
+  },
+  csvUrl: (filters: DocumentAuditFilters = {}) => {
+    const query = buildQuery(filters);
+    return `${API_BASE_URL}/documents/audit-events/export.csv${query ? `?${query}` : ""}`;
   },
 };

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -118,6 +118,20 @@ export type DocumentAuditEventList = {
   total: number;
 };
 
+export type DocumentAuditFilters = {
+  limit?: number;
+  action?: string;
+  outcome?: string;
+  actor?: string;
+  project_id?: string;
+};
+
+export type DocumentAuditSummary = {
+  total: number;
+  by_action: Record<string, number>;
+  by_outcome: Record<string, number>;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -143,6 +157,14 @@ async function uploadRequest<T>(path: string, formData: FormData): Promise<T> {
   });
   if (!response.ok) throw new Error(`Request failed with ${response.status}`);
   return response.json() as Promise<T>;
+}
+
+function auditQuery(filters: DocumentAuditFilters = {}): string {
+  const query = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") query.set(key, String(value));
+  });
+  return query.toString();
 }
 
 export const documentCategories: DocumentCategory[] = [
@@ -204,8 +226,18 @@ export const documentsApi = {
     request<SignedDownloadTokenResponse>(`/documents/${id}/download-token`),
   signedDownloadUrl: (token: string) =>
     `${API_BASE_URL}/documents/signed-download?token=${encodeURIComponent(token)}`,
-  recentAuditEvents: (limit = 50) =>
-    request<DocumentAuditEventList>(`/documents/audit-events?limit=${limit}`),
+  recentAuditEvents: (filters: DocumentAuditFilters = {}) => {
+    const query = auditQuery({ limit: 50, ...filters });
+    return request<DocumentAuditEventList>(`/documents/audit-events?${query}`);
+  },
+  auditSummary: (filters: DocumentAuditFilters = {}) => {
+    const query = auditQuery(filters);
+    return request<DocumentAuditSummary>(`/documents/audit-events/summary${query ? `?${query}` : ""}`);
+  },
+  auditCsvUrl: (filters: DocumentAuditFilters = {}) => {
+    const query = auditQuery(filters);
+    return `${API_BASE_URL}/documents/audit-events/export.csv${query ? `?${query}` : ""}`;
+  },
   integrity: (id: string) => request<DocumentIntegrity>(`/documents/${id}/integrity`),
   attachmentManifest: (documentIds: string[]) =>
     request<RFQAttachmentManifest>("/documents/attachment-manifest", {

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -22,6 +22,17 @@ export function DocumentAuditPanel() {
     return { limit: 50, action, outcome, actor, project_id: projectId };
   }
 
+  function resetFilters() {
+    setAction("");
+    setOutcome("");
+    setActor("");
+    setProjectId("");
+    setEvents(null);
+    setSummary(null);
+    setLastUpdated(null);
+    setError(null);
+  }
+
   async function loadEvents() {
     setIsLoading(true);
     setError(null);
@@ -49,7 +60,8 @@ export function DocumentAuditPanel() {
           <p className="mt-1 text-sm text-iron-500">Filter uploads and downloads by action, outcome, actor, or project.</p>
           {lastUpdated ? <p className="mt-1 text-xs text-iron-400">Last refreshed {lastUpdated.toLocaleString()}</p> : null}
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={resetFilters} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-600">Reset</button>
           <a href={documentAuditApi.csvUrl(filters())} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">Export CSV</a>
           <button type="button" onClick={loadEvents} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
             {isLoading ? "Loading..." : "Load activity"}

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -14,6 +14,7 @@ export function DocumentAuditPanel() {
   const [outcome, setOutcome] = useState("");
   const [actor, setActor] = useState("");
   const [projectId, setProjectId] = useState("");
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -32,6 +33,7 @@ export function DocumentAuditPanel() {
       ]);
       setEvents(nextEvents);
       setSummary(nextSummary);
+      setLastUpdated(new Date());
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to load audit events");
     } finally {
@@ -45,6 +47,7 @@ export function DocumentAuditPanel() {
         <div>
           <h2 className="text-base font-semibold text-iron-950">Recent Document Activity</h2>
           <p className="mt-1 text-sm text-iron-500">Filter uploads and downloads by action, outcome, actor, or project.</p>
+          {lastUpdated ? <p className="mt-1 text-xs text-iron-400">Last refreshed {lastUpdated.toLocaleString()}</p> : null}
         </div>
         <div className="flex gap-2">
           <a href={documentAuditApi.csvUrl(filters())} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">Export CSV</a>

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -4,12 +4,13 @@ import {
   documentAuditApi,
   DocumentAuditEventList,
   DocumentAuditFilters,
-  DocumentAuditSummary,
+  DocumentAuditSummary as Summary,
 } from "../api/documentAudit";
+import { DocumentAuditSummary } from "./DocumentAuditSummary";
 
 export function DocumentAuditPanel() {
   const [events, setEvents] = useState<DocumentAuditEventList | null>(null);
-  const [summary, setSummary] = useState<DocumentAuditSummary | null>(null);
+  const [summary, setSummary] = useState<Summary | null>(null);
   const [action, setAction] = useState("");
   const [outcome, setOutcome] = useState("");
   const [actor, setActor] = useState("");
@@ -79,14 +80,7 @@ export function DocumentAuditPanel() {
       </div>
 
       {error ? <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
-
-      {summary ? (
-        <div className="mt-4 grid gap-3 md:grid-cols-3">
-          <div className="rounded-md border border-iron-100 p-3"><div className="text-xs uppercase text-iron-500">Matching events</div><div className="mt-1 text-2xl font-semibold text-iron-950">{summary.total}</div></div>
-          <div className="rounded-md border border-iron-100 p-3"><div className="text-xs uppercase text-iron-500">Successful</div><div className="mt-1 text-2xl font-semibold text-iron-950">{summary.by_outcome.success ?? 0}</div></div>
-          <div className="rounded-md border border-iron-100 p-3"><div className="text-xs uppercase text-iron-500">Denied</div><div className="mt-1 text-2xl font-semibold text-iron-950">{summary.by_outcome.denied ?? 0}</div></div>
-        </div>
-      ) : null}
+      {summary ? <DocumentAuditSummary summary={summary} /> : null}
 
       {events ? (
         <div className="mt-4 overflow-hidden rounded-md border border-iron-100">

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -46,9 +46,12 @@ export function DocumentAuditPanel() {
           <h2 className="text-base font-semibold text-iron-950">Recent Document Activity</h2>
           <p className="mt-1 text-sm text-iron-500">Filter uploads and downloads by action, outcome, actor, or project.</p>
         </div>
-        <button type="button" onClick={loadEvents} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
-          {isLoading ? "Loading..." : "Load activity"}
-        </button>
+        <div className="flex gap-2">
+          <a href={documentAuditApi.csvUrl(filters())} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">Export CSV</a>
+          <button type="button" onClick={loadEvents} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
+            {isLoading ? "Loading..." : "Load activity"}
+          </button>
+        </div>
       </div>
 
       <div className="mt-4 grid gap-3 md:grid-cols-4">

--- a/frontend/src/components/DocumentAuditPanel.tsx
+++ b/frontend/src/components/DocumentAuditPanel.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
 
-import { documentAuditApi, DocumentAuditEventList } from "../api/documentAudit";
+import {
+  documentAuditApi,
+  DocumentAuditEventList,
+  DocumentAuditFilters,
+  DocumentAuditSummary,
+} from "../api/documentAudit";
 
 export function DocumentAuditPanel() {
   const [events, setEvents] = useState<DocumentAuditEventList | null>(null);
+  const [summary, setSummary] = useState<DocumentAuditSummary | null>(null);
   const [action, setAction] = useState("");
   const [outcome, setOutcome] = useState("");
   const [actor, setActor] = useState("");
@@ -11,11 +17,21 @@ export function DocumentAuditPanel() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
+  function filters(): DocumentAuditFilters {
+    return { limit: 50, action, outcome, actor, project_id: projectId };
+  }
+
   async function loadEvents() {
     setIsLoading(true);
     setError(null);
     try {
-      setEvents(await documentAuditApi.list({ limit: 50, action, outcome, actor, project_id: projectId }));
+      const currentFilters = filters();
+      const [nextEvents, nextSummary] = await Promise.all([
+        documentAuditApi.list(currentFilters),
+        documentAuditApi.summary(currentFilters),
+      ]);
+      setEvents(nextEvents);
+      setSummary(nextSummary);
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to load audit events");
     } finally {
@@ -45,6 +61,14 @@ export function DocumentAuditPanel() {
       </div>
 
       {error ? <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
+
+      {summary ? (
+        <div className="mt-4 grid gap-3 md:grid-cols-3">
+          <div className="rounded-md border border-iron-100 p-3"><div className="text-xs uppercase text-iron-500">Matching events</div><div className="mt-1 text-2xl font-semibold text-iron-950">{summary.total}</div></div>
+          <div className="rounded-md border border-iron-100 p-3"><div className="text-xs uppercase text-iron-500">Successful</div><div className="mt-1 text-2xl font-semibold text-iron-950">{summary.by_outcome.success ?? 0}</div></div>
+          <div className="rounded-md border border-iron-100 p-3"><div className="text-xs uppercase text-iron-500">Denied</div><div className="mt-1 text-2xl font-semibold text-iron-950">{summary.by_outcome.denied ?? 0}</div></div>
+        </div>
+      ) : null}
 
       {events ? (
         <div className="mt-4 overflow-hidden rounded-md border border-iron-100">

--- a/frontend/src/components/DocumentAuditSummary.tsx
+++ b/frontend/src/components/DocumentAuditSummary.tsx
@@ -1,0 +1,42 @@
+import { DocumentAuditSummary as Summary } from "../api/documentAudit";
+
+type Props = {
+  summary: Summary;
+};
+
+export function DocumentAuditSummary({ summary }: Props) {
+  const actions = Object.entries(summary.by_action).sort((left, right) => right[1] - left[1]);
+
+  return (
+    <div className="mt-4 space-y-3">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-md border border-iron-100 p-3">
+          <div className="text-xs uppercase text-iron-500">Matching events</div>
+          <div className="mt-1 text-2xl font-semibold text-iron-950">{summary.total}</div>
+        </div>
+        <div className="rounded-md border border-iron-100 p-3">
+          <div className="text-xs uppercase text-iron-500">Successful</div>
+          <div className="mt-1 text-2xl font-semibold text-iron-950">{summary.by_outcome.success ?? 0}</div>
+        </div>
+        <div className="rounded-md border border-iron-100 p-3">
+          <div className="text-xs uppercase text-iron-500">Denied</div>
+          <div className="mt-1 text-2xl font-semibold text-iron-950">{summary.by_outcome.denied ?? 0}</div>
+        </div>
+      </div>
+
+      {actions.length > 0 ? (
+        <div className="rounded-md border border-iron-100 p-3">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-iron-500">Activity by action</h3>
+          <div className="mt-2 grid gap-2 md:grid-cols-2">
+            {actions.map(([action, count]) => (
+              <div key={action} className="flex items-center justify-between rounded border border-iron-100 px-3 py-2 text-sm">
+                <span className="font-medium text-iron-800">{action}</span>
+                <span className="font-mono text-iron-600">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Completes the individually gated Iron House OS sequence from Build 141 through Build 150.

## Gate rule followed
No build advanced until backend and frontend CI were green.

## Completed builds
- 141: typed frontend summary and CSV export support.
- 142: dedicated audit client summary and export support.
- 143: live audit summary cards.
- 144: filtered CSV export action.
- 145: last-refresh visibility.
- 146: one-click audit filter reset.
- 147: reusable action-distribution summary component.
- 148: integrated action breakdown in Document Operations.
- 149: document audit operations runbook.
- 150: completion record and production-boundary documentation.

## Final validation
CI run `29146829593` passed backend installation, Ruff lint, pytest, frontend installation, lint, tests, and production build.

Branch: `build/build-141-to-150-gated`

Next step: merge this PR into `main`, validate the merged baseline, then begin Build 151.