### PR TITLE
Validate main after Builds 141–150

### DIFF
--- a/docs/validation/main-after-build-150.md
+++ b/docs/validation/main-after-build-150.md
@@ -1,0 +1,5 @@
+# Main Validation After Build 150
+
+- Baseline merge commit: `f00d2a994306209fc491ecec81df4a70baef6824`
+- Scope: Builds 141–150
+- Requirement: backend and frontend CI must both pass before Build 151 begins.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 141–150. This PR contains only a validation marker and must pass backend and frontend CI before Build 151 begins.