### PR TITLE
Complete gated Builds 151–160

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,12 +5,15 @@ from app.api.v1.router import api_router
 from app.core.config import get_settings
 from app.core.errors import register_exception_handlers
 from app.core.logging import configure_logging
+from app.services.document_audit import configure_document_audit_store
+from app.services.document_audit_store import create_document_audit_store_from_environment
 from app.services.system_readiness import get_system_readiness
 
 
 def create_app() -> FastAPI:
     settings = get_settings()
     configure_logging(settings.log_level)
+    configure_document_audit_store(create_document_audit_store_from_environment())
 
     app = FastAPI(
         title=settings.app_name,

--- a/backend/app/services/document_audit.py
+++ b/backend/app/services/document_audit.py
@@ -1,4 +1,4 @@
-from collections import Counter, deque
+from collections import Counter
 import csv
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -8,9 +8,11 @@ import logging
 from typing import Any
 from uuid import UUID
 
+from app.services.document_audit_store import DocumentAuditStore, InMemoryDocumentAuditStore
+
 logger = logging.getLogger("ihos.document_audit")
 MAX_RECENT_EVENTS = 200
-_recent_events: deque[dict[str, Any]] = deque(maxlen=MAX_RECENT_EVENTS)
+_audit_store: DocumentAuditStore = InMemoryDocumentAuditStore(MAX_RECENT_EVENTS)
 
 
 @dataclass(frozen=True)
@@ -35,13 +37,18 @@ def _serialize(value: Any) -> Any:
     return value
 
 
+def configure_document_audit_store(store: DocumentAuditStore) -> None:
+    global _audit_store
+    _audit_store = store
+
+
 def emit_document_audit_event(event: DocumentAuditEvent) -> None:
     payload = {
         key: _serialize(value)
         for key, value in asdict(event).items()
         if value not in (None, {}, [])
     }
-    _recent_events.appendleft(payload)
+    _audit_store.append(payload)
     logger.info("document_audit %s", json.dumps(payload, sort_keys=True))
 
 
@@ -53,21 +60,21 @@ def list_recent_document_audit_events(
     actor: str | None = None,
     project_id: UUID | str | None = None,
 ) -> list[dict[str, Any]]:
-    bounded_limit = max(1, min(limit, MAX_RECENT_EVENTS))
     expected_project_id = str(project_id) if project_id is not None else None
     filtered = (
         event
-        for event in _recent_events
+        for event in _audit_store.recent(MAX_RECENT_EVENTS)
         if (action is None or event.get("action") == action)
         and (outcome is None or event.get("outcome", "success") == outcome)
         and (actor is None or event.get("actor") == actor)
         and (expected_project_id is None or event.get("project_id") == expected_project_id)
     )
+    bounded_limit = max(1, min(limit, MAX_RECENT_EVENTS))
     return list(filtered)[:bounded_limit]
 
 
 def summarize_document_audit_events() -> dict[str, Any]:
-    events = list(_recent_events)
+    events = _audit_store.recent(MAX_RECENT_EVENTS)
     return {
         "total": len(events),
         "by_action": dict(Counter(event.get("action", "unknown") for event in events)),
@@ -97,4 +104,4 @@ def export_document_audit_events_csv(events: list[dict[str, Any]]) -> str:
 
 
 def clear_recent_document_audit_events() -> None:
-    _recent_events.clear()
+    _audit_store.clear()

--- a/backend/app/services/document_audit_access.py
+++ b/backend/app/services/document_audit_access.py
@@ -1,0 +1,43 @@
+from enum import StrEnum
+
+
+class DocumentAuditPermission(StrEnum):
+    READ = "read"
+    EXPORT = "export"
+    ADMINISTER = "administer"
+
+
+_ROLE_PERMISSIONS: dict[str, frozenset[DocumentAuditPermission]] = {
+    "admin": frozenset(DocumentAuditPermission),
+    "operations_manager": frozenset(
+        {DocumentAuditPermission.READ, DocumentAuditPermission.EXPORT}
+    ),
+    "estimator": frozenset({DocumentAuditPermission.READ}),
+    "viewer": frozenset(),
+}
+
+
+def normalize_role(role: str | None) -> str:
+    return (role or "viewer").strip().lower().replace(" ", "_")
+
+
+def document_audit_permissions_for_role(role: str | None) -> frozenset[DocumentAuditPermission]:
+    return _ROLE_PERMISSIONS.get(normalize_role(role), frozenset())
+
+
+def can_access_document_audit(
+    role: str | None,
+    permission: DocumentAuditPermission,
+) -> bool:
+    return permission in document_audit_permissions_for_role(role)
+
+
+def require_document_audit_permission(
+    role: str | None,
+    permission: DocumentAuditPermission,
+) -> None:
+    if not can_access_document_audit(role, permission):
+        normalized_role = normalize_role(role)
+        raise PermissionError(
+            f"Role '{normalized_role}' lacks document audit permission '{permission.value}'"
+        )

--- a/backend/app/services/document_audit_store.py
+++ b/backend/app/services/document_audit_store.py
@@ -1,5 +1,7 @@
 from collections import deque
 from collections.abc import Iterable
+import json
+from pathlib import Path
 from typing import Any, Protocol
 
 
@@ -33,3 +35,35 @@ class InMemoryDocumentAuditStore:
 
     def clear(self) -> None:
         self._events.clear()
+
+
+class JsonlDocumentAuditStore:
+    """Durable append-only JSON Lines store for single-node deployments."""
+
+    def __init__(self, path: str | Path, max_read_events: int = 10_000) -> None:
+        if max_read_events < 1:
+            raise ValueError("max_read_events must be at least 1")
+        self.path = Path(path)
+        self.max_read_events = max_read_events
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def append(self, event: dict[str, Any]) -> None:
+        with self.path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(event, sort_keys=True, separators=(",", ":")))
+            stream.write("\n")
+
+    def recent(self, limit: int) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        bounded_limit = max(1, min(limit, self.max_read_events))
+        lines = self.path.read_text(encoding="utf-8").splitlines()
+        events: list[dict[str, Any]] = []
+        for line in reversed(lines[-self.max_read_events :]):
+            if line.strip():
+                events.append(json.loads(line))
+            if len(events) >= bounded_limit:
+                break
+        return events
+
+    def clear(self) -> None:
+        self.path.write_text("", encoding="utf-8")

--- a/backend/app/services/document_audit_store.py
+++ b/backend/app/services/document_audit_store.py
@@ -1,0 +1,35 @@
+from collections import deque
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+
+class DocumentAuditStore(Protocol):
+    """Append-only storage contract for serialized document audit events."""
+
+    def append(self, event: dict[str, Any]) -> None: ...
+
+    def recent(self, limit: int) -> list[dict[str, Any]]: ...
+
+    def clear(self) -> None: ...
+
+
+class InMemoryDocumentAuditStore:
+    """Bounded process-local audit store used as the safe default."""
+
+    def __init__(self, max_events: int = 200, events: Iterable[dict[str, Any]] | None = None) -> None:
+        if max_events < 1:
+            raise ValueError("max_events must be at least 1")
+        self.max_events = max_events
+        self._events: deque[dict[str, Any]] = deque(maxlen=max_events)
+        for event in events or ():
+            self.append(event)
+
+    def append(self, event: dict[str, Any]) -> None:
+        self._events.appendleft(dict(event))
+
+    def recent(self, limit: int) -> list[dict[str, Any]]:
+        bounded_limit = max(1, min(limit, self.max_events))
+        return [dict(event) for event in list(self._events)[:bounded_limit]]
+
+    def clear(self) -> None:
+        self._events.clear()

--- a/backend/app/services/document_audit_store.py
+++ b/backend/app/services/document_audit_store.py
@@ -1,6 +1,7 @@
 from collections import deque
 from collections.abc import Iterable
 import json
+import os
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -67,3 +68,15 @@ class JsonlDocumentAuditStore:
 
     def clear(self) -> None:
         self.path.write_text("", encoding="utf-8")
+
+
+def create_document_audit_store_from_environment() -> DocumentAuditStore:
+    provider = os.getenv("DOCUMENT_AUDIT_STORE", "memory").strip().lower()
+    if provider == "memory":
+        max_events = int(os.getenv("DOCUMENT_AUDIT_MAX_EVENTS", "200"))
+        return InMemoryDocumentAuditStore(max_events=max_events)
+    if provider == "jsonl":
+        path = os.getenv("DOCUMENT_AUDIT_JSONL_PATH", "data/audit/document-events.jsonl")
+        max_read_events = int(os.getenv("DOCUMENT_AUDIT_MAX_READ_EVENTS", "10000"))
+        return JsonlDocumentAuditStore(path=path, max_read_events=max_read_events)
+    raise ValueError(f"Unsupported document audit store: {provider}")

--- a/backend/tests/test_document_audit_access.py
+++ b/backend/tests/test_document_audit_access.py
@@ -1,0 +1,38 @@
+import pytest
+
+from app.services.document_audit_access import (
+    DocumentAuditPermission,
+    can_access_document_audit,
+    document_audit_permissions_for_role,
+    normalize_role,
+    require_document_audit_permission,
+)
+
+
+def test_role_normalization_and_unknown_roles() -> None:
+    assert normalize_role(" Operations Manager ") == "operations_manager"
+    assert document_audit_permissions_for_role("unknown") == frozenset()
+
+
+def test_admin_has_all_document_audit_permissions() -> None:
+    permissions = document_audit_permissions_for_role("admin")
+
+    assert permissions == frozenset(DocumentAuditPermission)
+
+
+def test_operations_manager_can_read_and_export_but_not_administer() -> None:
+    assert can_access_document_audit("operations_manager", DocumentAuditPermission.READ)
+    assert can_access_document_audit("operations manager", DocumentAuditPermission.EXPORT)
+    assert not can_access_document_audit(
+        "operations_manager", DocumentAuditPermission.ADMINISTER
+    )
+
+
+def test_estimator_is_read_only() -> None:
+    assert can_access_document_audit("estimator", DocumentAuditPermission.READ)
+    assert not can_access_document_audit("estimator", DocumentAuditPermission.EXPORT)
+
+
+def test_permission_requirement_raises_for_denied_role() -> None:
+    with pytest.raises(PermissionError, match="lacks document audit permission"):
+        require_document_audit_permission("viewer", DocumentAuditPermission.READ)

--- a/backend/tests/test_document_audit_store.py
+++ b/backend/tests/test_document_audit_store.py
@@ -1,6 +1,9 @@
+import pytest
+
 from app.services.document_audit_store import (
     InMemoryDocumentAuditStore,
     JsonlDocumentAuditStore,
+    create_document_audit_store_from_environment,
 )
 
 
@@ -50,3 +53,31 @@ def test_jsonl_audit_store_respects_limit_and_clear(tmp_path) -> None:
     assert store.recent(1) == [{"action": "second"}]
     store.clear()
     assert store.recent(10) == []
+
+
+def test_environment_factory_defaults_to_memory(monkeypatch) -> None:
+    monkeypatch.delenv("DOCUMENT_AUDIT_STORE", raising=False)
+    monkeypatch.setenv("DOCUMENT_AUDIT_MAX_EVENTS", "7")
+
+    store = create_document_audit_store_from_environment()
+
+    assert isinstance(store, InMemoryDocumentAuditStore)
+    assert store.max_events == 7
+
+
+def test_environment_factory_selects_jsonl(monkeypatch, tmp_path) -> None:
+    path = tmp_path / "events.jsonl"
+    monkeypatch.setenv("DOCUMENT_AUDIT_STORE", "jsonl")
+    monkeypatch.setenv("DOCUMENT_AUDIT_JSONL_PATH", str(path))
+
+    store = create_document_audit_store_from_environment()
+
+    assert isinstance(store, JsonlDocumentAuditStore)
+    assert store.path == path
+
+
+def test_environment_factory_rejects_unknown_provider(monkeypatch) -> None:
+    monkeypatch.setenv("DOCUMENT_AUDIT_STORE", "unknown")
+
+    with pytest.raises(ValueError, match="Unsupported document audit store"):
+        create_document_audit_store_from_environment()

--- a/backend/tests/test_document_audit_store.py
+++ b/backend/tests/test_document_audit_store.py
@@ -1,4 +1,7 @@
-from app.services.document_audit_store import InMemoryDocumentAuditStore
+from app.services.document_audit_store import (
+    InMemoryDocumentAuditStore,
+    JsonlDocumentAuditStore,
+)
 
 
 def test_in_memory_audit_store_is_bounded_and_newest_first() -> None:
@@ -26,4 +29,24 @@ def test_in_memory_audit_store_clear_removes_events() -> None:
     store = InMemoryDocumentAuditStore(events=[{"action": "upload"}])
     store.clear()
 
+    assert store.recent(10) == []
+
+
+def test_jsonl_audit_store_persists_and_reads_newest_first(tmp_path) -> None:
+    path = tmp_path / "audit" / "events.jsonl"
+    store = JsonlDocumentAuditStore(path)
+    store.append({"action": "first"})
+    store.append({"action": "second"})
+
+    reopened = JsonlDocumentAuditStore(path)
+    assert reopened.recent(10) == [{"action": "second"}, {"action": "first"}]
+
+
+def test_jsonl_audit_store_respects_limit_and_clear(tmp_path) -> None:
+    store = JsonlDocumentAuditStore(tmp_path / "events.jsonl")
+    store.append({"action": "first"})
+    store.append({"action": "second"})
+
+    assert store.recent(1) == [{"action": "second"}]
+    store.clear()
     assert store.recent(10) == []

--- a/backend/tests/test_document_audit_store.py
+++ b/backend/tests/test_document_audit_store.py
@@ -1,0 +1,29 @@
+from app.services.document_audit_store import InMemoryDocumentAuditStore
+
+
+def test_in_memory_audit_store_is_bounded_and_newest_first() -> None:
+    store = InMemoryDocumentAuditStore(max_events=2)
+    store.append({"action": "first"})
+    store.append({"action": "second"})
+    store.append({"action": "third"})
+
+    assert store.recent(10) == [{"action": "third"}, {"action": "second"}]
+
+
+def test_in_memory_audit_store_returns_copies() -> None:
+    store = InMemoryDocumentAuditStore()
+    event = {"action": "upload"}
+    store.append(event)
+    event["action"] = "mutated"
+
+    result = store.recent(1)
+    result[0]["action"] = "changed"
+
+    assert store.recent(1) == [{"action": "upload"}]
+
+
+def test_in_memory_audit_store_clear_removes_events() -> None:
+    store = InMemoryDocumentAuditStore(events=[{"action": "upload"}])
+    store.clear()
+
+    assert store.recent(10) == []


### PR DESCRIPTION
Completes the individually gated Iron House OS sequence from Build 151 through Build 160.

## Gate rule followed
No build advanced until backend and frontend CI were green.

## Completed builds
- 151: document-audit store abstraction and bounded in-memory default.
- 152: audit service routed through the storage abstraction.
- 153: in-memory store regression tests.
- 154: durable append-only JSONL audit store.
- 155: JSONL persistence, ordering, limit, and clear tests.
- 156: environment-driven audit-store factory.
- 157: audit-store factory configuration tests.
- 158: configured audit store activated during application startup.
- 159: role-based document-audit permission primitives.
- 160: role-policy regression tests.

## Final validation
CI run `29148064557` passed backend installation, Ruff lint, pytest, frontend installation, lint, tests, and production build.

Branch: `build/build-151-to-160-gated`

Next step: merge this PR into `main`, validate the merged baseline, then begin Build 161.