### PR TITLE
Validate main after Builds 151–160

### DIFF
--- a/docs/validation-main-after-build-160.md
+++ b/docs/validation-main-after-build-160.md
@@ -1,0 +1,5 @@
+# Main Validation After Build 160
+
+This marker validates the exact merged `main` baseline after individually gated Builds 151–160.
+
+No Build 161 work may begin until the backend and frontend CI jobs for this validation commit are both green.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 151–160. This PR contains only a validation marker and must pass backend and frontend CI before Build 161 begins.