### PR TITLE
Complete gated Builds 161–170

### DIFF
--- a/backend/app/api/v1/routes/documents.py
+++ b/backend/app/api/v1/routes/documents.py
@@ -26,11 +26,18 @@ from app.services.document_audit import (
     list_recent_document_audit_events,
     summarize_document_audit_events,
 )
+from app.services.document_audit_access import DocumentAuditPermission
+from app.services.document_audit_auth import (
+    DocumentAuditPrincipal,
+    authorize_document_audit,
+    get_document_audit_principal,
+)
 from app.services.request_context import get_request_audit_context
 from app.services.signed_download import DEFAULT_TTL_SECONDS, create_download_token, verify_download_token
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
+AuditPrincipal = Annotated[DocumentAuditPrincipal, Depends(get_document_audit_principal)]
 OptionalQuery = Annotated[str | None, Query()]
 OptionalUUIDQuery = Annotated[UUID | None, Query()]
 
@@ -95,12 +102,14 @@ def list_documents(
 
 @router.get("/audit-events")
 def document_audit_events(
+    principal: AuditPrincipal,
     limit: int = Query(default=50, ge=1, le=200),
     action: str | None = Query(default=None),
     outcome: str | None = Query(default=None),
     actor: str | None = Query(default=None),
     project_id: UUID | None = Query(default=None),
 ) -> dict[str, Any]:
+    authorize_document_audit(principal, DocumentAuditPermission.READ)
     items = list_recent_document_audit_events(
         limit,
         action=action,
@@ -112,18 +121,21 @@ def document_audit_events(
 
 
 @router.get("/audit-events/summary")
-def document_audit_summary() -> dict[str, Any]:
+def document_audit_summary(principal: AuditPrincipal) -> dict[str, Any]:
+    authorize_document_audit(principal, DocumentAuditPermission.READ)
     return summarize_document_audit_events()
 
 
 @router.get("/audit-events/export.csv")
 def document_audit_export(
+    principal: AuditPrincipal,
     limit: int = Query(default=200, ge=1, le=200),
     action: str | None = Query(default=None),
     outcome: str | None = Query(default=None),
     actor: str | None = Query(default=None),
     project_id: UUID | None = Query(default=None),
 ) -> Response:
+    authorize_document_audit(principal, DocumentAuditPermission.EXPORT)
     events = list_recent_document_audit_events(
         limit,
         action=action,

--- a/backend/app/services/document_audit_auth.py
+++ b/backend/app/services/document_audit_auth.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+from fastapi import Header, HTTPException, status
+
+from app.services.document_audit_access import (
+    DocumentAuditPermission,
+    normalize_role,
+    require_document_audit_permission,
+)
+
+
+@dataclass(frozen=True)
+class DocumentAuditPrincipal:
+    role: str
+
+
+def get_document_audit_principal(
+    x_ihos_role: str | None = Header(default=None, alias="X-IHOS-Role"),
+) -> DocumentAuditPrincipal:
+    return DocumentAuditPrincipal(role=normalize_role(x_ihos_role))
+
+
+def authorize_document_audit(
+    principal: DocumentAuditPrincipal,
+    permission: DocumentAuditPermission,
+) -> None:
+    try:
+        require_document_audit_permission(principal.role, permission)
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc

--- a/backend/app/services/document_audit_auth.py
+++ b/backend/app/services/document_audit_auth.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from fastapi import Header, HTTPException, status
 
+from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
 from app.services.document_audit_access import (
     DocumentAuditPermission,
     normalize_role,
@@ -27,6 +28,14 @@ def authorize_document_audit(
     try:
         require_document_audit_permission(principal.role, permission)
     except PermissionError as exc:
+        emit_document_audit_event(
+            DocumentAuditEvent(
+                action="audit_access",
+                outcome="denied",
+                actor=principal.role,
+                metadata={"permission": permission.value},
+            )
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(exc),

--- a/backend/app/services/document_audit_auth.py
+++ b/backend/app/services/document_audit_auth.py
@@ -5,6 +5,7 @@ from fastapi import Header, HTTPException, status
 from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
 from app.services.document_audit_access import (
     DocumentAuditPermission,
+    document_audit_permissions_for_role,
     normalize_role,
     require_document_audit_permission,
 )
@@ -19,6 +20,16 @@ def get_document_audit_principal(
     x_ihos_role: str | None = Header(default=None, alias="X-IHOS-Role"),
 ) -> DocumentAuditPrincipal:
     return DocumentAuditPrincipal(role=normalize_role(x_ihos_role))
+
+
+def describe_document_audit_access(
+    principal: DocumentAuditPrincipal,
+) -> dict[str, str | list[str]]:
+    permissions = sorted(
+        permission.value
+        for permission in document_audit_permissions_for_role(principal.role)
+    )
+    return {"role": normalize_role(principal.role), "permissions": permissions}
 
 
 def authorize_document_audit(

--- a/backend/tests/test_document_audit_auth.py
+++ b/backend/tests/test_document_audit_auth.py
@@ -9,6 +9,7 @@ from app.services.document_audit_access import DocumentAuditPermission
 from app.services.document_audit_auth import (
     DocumentAuditPrincipal,
     authorize_document_audit,
+    describe_document_audit_access,
     get_document_audit_principal,
 )
 
@@ -20,6 +21,25 @@ def setup_function() -> None:
 def test_principal_normalizes_header_role() -> None:
     principal = get_document_audit_principal(" Operations Manager ")
     assert principal == DocumentAuditPrincipal(role="operations_manager")
+
+
+def test_permission_snapshots_are_normalized_and_sorted() -> None:
+    assert describe_document_audit_access(DocumentAuditPrincipal(role="Admin")) == {
+        "role": "admin",
+        "permissions": ["administer", "export", "read"],
+    }
+    assert describe_document_audit_access(DocumentAuditPrincipal(role="operations manager")) == {
+        "role": "operations_manager",
+        "permissions": ["export", "read"],
+    }
+    assert describe_document_audit_access(DocumentAuditPrincipal(role="estimator")) == {
+        "role": "estimator",
+        "permissions": ["read"],
+    }
+    assert describe_document_audit_access(DocumentAuditPrincipal(role="viewer")) == {
+        "role": "viewer",
+        "permissions": [],
+    }
 
 
 def test_authorize_allows_role_permission_without_denial_event() -> None:

--- a/backend/tests/test_document_audit_auth.py
+++ b/backend/tests/test_document_audit_auth.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import HTTPException
+
+from app.services.document_audit_access import DocumentAuditPermission
+from app.services.document_audit_auth import (
+    DocumentAuditPrincipal,
+    authorize_document_audit,
+    get_document_audit_principal,
+)
+
+
+def test_principal_normalizes_header_role() -> None:
+    principal = get_document_audit_principal(" Operations Manager ")
+    assert principal == DocumentAuditPrincipal(role="operations_manager")
+
+
+def test_authorize_allows_role_permission() -> None:
+    authorize_document_audit(
+        DocumentAuditPrincipal(role="operations_manager"),
+        DocumentAuditPermission.EXPORT,
+    )
+
+
+def test_authorize_rejects_missing_permission() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        authorize_document_audit(
+            DocumentAuditPrincipal(role="viewer"),
+            DocumentAuditPermission.READ,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "lacks document audit permission 'read'" in str(exc_info.value.detail)

--- a/backend/tests/test_document_audit_auth.py
+++ b/backend/tests/test_document_audit_auth.py
@@ -1,6 +1,10 @@
 import pytest
 from fastapi import HTTPException
 
+from app.services.document_audit import (
+    clear_recent_document_audit_events,
+    list_recent_document_audit_events,
+)
 from app.services.document_audit_access import DocumentAuditPermission
 from app.services.document_audit_auth import (
     DocumentAuditPrincipal,
@@ -9,19 +13,24 @@ from app.services.document_audit_auth import (
 )
 
 
+def setup_function() -> None:
+    clear_recent_document_audit_events()
+
+
 def test_principal_normalizes_header_role() -> None:
     principal = get_document_audit_principal(" Operations Manager ")
     assert principal == DocumentAuditPrincipal(role="operations_manager")
 
 
-def test_authorize_allows_role_permission() -> None:
+def test_authorize_allows_role_permission_without_denial_event() -> None:
     authorize_document_audit(
         DocumentAuditPrincipal(role="operations_manager"),
         DocumentAuditPermission.EXPORT,
     )
+    assert list_recent_document_audit_events() == []
 
 
-def test_authorize_rejects_missing_permission() -> None:
+def test_authorize_rejects_and_audits_missing_permission() -> None:
     with pytest.raises(HTTPException) as exc_info:
         authorize_document_audit(
             DocumentAuditPrincipal(role="viewer"),
@@ -30,3 +39,12 @@ def test_authorize_rejects_missing_permission() -> None:
 
     assert exc_info.value.status_code == 403
     assert "lacks document audit permission 'read'" in str(exc_info.value.detail)
+    assert list_recent_document_audit_events() == [
+        {
+            "action": "audit_access",
+            "outcome": "denied",
+            "actor": "viewer",
+            "metadata": {"permission": "read"},
+            "occurred_at": list_recent_document_audit_events()[0]["occurred_at"],
+        }
+    ]

--- a/backend/tests/test_document_audit_routes_access.py
+++ b/backend/tests/test_document_audit_routes_access.py
@@ -1,0 +1,74 @@
+import pytest
+from fastapi import HTTPException
+
+from app.api.v1.routes.documents import (
+    document_audit_events,
+    document_audit_export,
+    document_audit_summary,
+)
+from app.services.document_audit import (
+    DocumentAuditEvent,
+    clear_recent_document_audit_events,
+    emit_document_audit_event,
+)
+from app.services.document_audit_auth import DocumentAuditPrincipal
+
+
+def setup_function() -> None:
+    clear_recent_document_audit_events()
+
+
+def test_viewer_cannot_read_audit_events() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        document_audit_events(
+            DocumentAuditPrincipal(role="viewer"),
+            limit=50,
+            action=None,
+            outcome=None,
+            actor=None,
+            project_id=None,
+        )
+    assert exc_info.value.status_code == 403
+
+
+def test_estimator_can_read_but_cannot_export() -> None:
+    principal = DocumentAuditPrincipal(role="estimator")
+    emit_document_audit_event(DocumentAuditEvent(action="upload"))
+
+    result = document_audit_events(
+        principal,
+        limit=50,
+        action=None,
+        outcome=None,
+        actor=None,
+        project_id=None,
+    )
+    assert result["total"] == 1
+
+    with pytest.raises(HTTPException) as exc_info:
+        document_audit_export(
+            principal,
+            limit=200,
+            action=None,
+            outcome=None,
+            actor=None,
+            project_id=None,
+        )
+    assert exc_info.value.status_code == 403
+
+
+def test_operations_manager_can_export_and_admin_can_summarize() -> None:
+    emit_document_audit_event(DocumentAuditEvent(action="upload"))
+
+    response = document_audit_export(
+        DocumentAuditPrincipal(role="operations_manager"),
+        limit=200,
+        action=None,
+        outcome=None,
+        actor=None,
+        project_id=None,
+    )
+    assert response.media_type == "text/csv"
+
+    summary = document_audit_summary(DocumentAuditPrincipal(role="admin"))
+    assert summary["total"] == 1

--- a/docs/build-161-to-170-completion.md
+++ b/docs/build-161-to-170-completion.md
@@ -1,0 +1,25 @@
+# Builds 161–170 Completion Record
+
+## Gate rule
+
+Every build in this block was committed independently and required successful backend and frontend GitHub Actions checks before the next build began.
+
+## Delivered capabilities
+
+- Trusted document-audit principal derived from the `X-IHOS-Role` integration header.
+- Central authorization dependency for audit read, export, and administrative permissions.
+- Role enforcement on audit-event list, summary, and CSV export endpoints.
+- Endpoint-level tests covering viewer, estimator, operations-manager, and administrator behaviour.
+- Structured `audit_access` denial events with requested permission metadata.
+- Regression tests proving denied access is recorded and successful access does not create false denial records.
+- Normalized role-permission snapshots for consistent API and frontend capability handling.
+- Regression coverage for permission snapshots across all supported roles.
+- Operations runbook covering role trust boundaries, deployment configuration, denial investigation, and export handling.
+
+## Current production boundary
+
+The `X-IHOS-Role` header must be supplied by a trusted authentication gateway or verified application session. It is not safe as a public client-controlled identity mechanism. The JSONL audit store is appropriate for protected single-node deployment, but multi-instance production still requires centralized append-only storage, durable retention policy, authenticated user identity, and organization/project scope enforcement.
+
+## Next unlocked work
+
+After this branch is merged and the resulting `main` tree is validated green, Build 171 may begin. Recommended next focus: authenticated identity claims, organization/project scope authorization, and a permission-discovery endpoint consumed by the frontend.

--- a/docs/document-audit-access-control.md
+++ b/docs/document-audit-access-control.md
@@ -1,0 +1,50 @@
+# Document Audit Access Control
+
+## Purpose
+
+Document audit data can expose filenames, project identifiers, user identifiers, request correlation IDs, and operational activity. Access is therefore controlled separately from ordinary document browsing.
+
+## Request role header
+
+Audit endpoints read the caller role from the `X-IHOS-Role` request header. Role values are normalized to lowercase snake case. A missing or unknown role is treated as `viewer` and receives no audit permissions.
+
+This header is an integration boundary, not a complete identity system. Production deployments must set it from a trusted authentication gateway or verified application session. It must not be accepted directly from an untrusted public client.
+
+## Role matrix
+
+| Role | Read events | Export CSV | Administer audit data |
+|---|---:|---:|---:|
+| `admin` | Yes | Yes | Yes |
+| `operations_manager` | Yes | Yes | No |
+| `estimator` | Yes | No | No |
+| `viewer` | No | No | No |
+
+## Protected endpoints
+
+- `GET /api/v1/documents/audit-events` requires `read`.
+- `GET /api/v1/documents/audit-events/summary` requires `read`.
+- `GET /api/v1/documents/audit-events/export.csv` requires `export`.
+
+## Denied access events
+
+A denied permission check emits a structured document-audit event:
+
+- action: `audit_access`
+- outcome: `denied`
+- actor: normalized role
+- metadata: requested permission
+
+Operators should filter the audit stream by `action=audit_access` and `outcome=denied` when investigating repeated unauthorized attempts.
+
+## Deployment requirements
+
+1. Terminate authentication before requests reach the API.
+2. Derive the IHOS role from a verified user or service identity.
+3. Remove any inbound public `X-IHOS-Role` header and replace it with the trusted role.
+4. Use the JSONL audit store only for single-node deployments with protected persistent storage.
+5. Move to a centralized append-only audit service before multi-instance production deployment.
+6. Restrict audit CSV exports because they can aggregate sensitive operational metadata.
+
+## Verification
+
+Backend tests cover role normalization, permission snapshots, successful authorization, denied authorization, denial-event emission, and endpoint-level role enforcement.


### PR DESCRIPTION
Completes the individually gated Iron House OS sequence from Build 161 through Build 170.

## Gate rule followed
No build advanced until backend and frontend CI were green.

## Completed builds
- 161: document-audit principal and authorization dependency.
- 162: authorization dependency regression tests.
- 163: role enforcement on audit list, summary, and CSV export endpoints.
- 164: endpoint-level role enforcement tests.
- 165: structured denial-event emission for unauthorized audit access.
- 166: denial-event regression tests.
- 167: normalized role-permission snapshots.
- 168: permission-snapshot regression tests.
- 169: audit access-control operations runbook.
- 170: completion record and next production boundary.

## Final validation
CI run `29148703884` passed backend installation, Ruff lint, pytest, frontend installation, lint, tests, and production build.

Branch: `build/build-161-to-170-gated`

Next step: merge this PR into `main`, validate the merged baseline, then begin Build 171.