### PR TITLE
Validate main after Builds 161–170

### DIFF
--- a/docs/validation-main-after-build-170.md
+++ b/docs/validation-main-after-build-170.md
@@ -1,0 +1,5 @@
+# Main Validation After Builds 161–170
+
+This marker validates the exact `main` baseline after the gated Builds 161–170 block was merged.
+
+Build 171 remains locked until backend and frontend CI are both green for this validation PR.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 161–170. This PR contains only a validation marker and must pass backend and frontend CI before Build 171 begins.