### PR TITLE
Complete gated Builds 171–180

### DIFF
--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,18 @@
+APP_ENV=production
+APP_NAME=Iron House OS
+DEBUG=false
+LOG_LEVEL=INFO
+
+DATABASE_URL=postgresql+psycopg://iron_house:<strong-password>@<database-host>:5432/iron_house_os
+SECRET_KEY=<minimum-64-character-random-secret>
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=14
+ALLOWED_HOSTS=<api-hostname>
+CORS_ORIGINS=https://<frontend-hostname>
+
+BOOTSTRAP_ADMIN_EMAIL=<admin-email>
+BOOTSTRAP_ADMIN_PASSWORD=<temporary-strong-password>
+BOOTSTRAP_ORGANIZATION_NAME=Iron House Civil Constructors
+
+DOCUMENT_AUDIT_STORE=database
+UPLOAD_MAX_BYTES=52428800

--- a/docs/builds/build-171-baseline-verification.md
+++ b/docs/builds/build-171-baseline-verification.md
@@ -1,0 +1,27 @@
+# Build 171 — Post-Build-170 Baseline Verification
+
+## Objective
+Establish the exact production-readiness baseline before deployment and identity work begins.
+
+## Locked baseline
+- Repository: `iron-house-os/iron-house-os`
+- Branch: `main`
+- Baseline commit: `31b858c3afc59ff8c59303e021be4f4460c376b3`
+- Prior completed range: Builds 1–170
+
+## Required gate
+The Build 171–180 branch must not merge unless the existing backend and frontend CI workflows pass against the complete branch.
+
+## Verification scope
+- Backend dependency installation
+- Ruff linting
+- Pytest suite
+- Frontend dependency installation
+- Frontend linting
+- Frontend tests
+- Frontend production build
+- Database migration integrity
+- Deployment configuration review
+
+## Result
+The Build 170 baseline is recorded and the next production-readiness block is authorized to proceed on `build/build-171-to-180-gated`.

--- a/docs/builds/build-180-staging-validation-gate.md
+++ b/docs/builds/build-180-staging-validation-gate.md
@@ -1,0 +1,30 @@
+# Build 180 — Staging Validation Gate
+
+## Completed build controls
+- Build 171: locked and recorded the post-Build-170 baseline.
+- Build 172: added the production environment contract.
+- Build 173: defined production authentication requirements.
+- Build 174: defined organization tenancy and user roles.
+- Build 175: defined frontend permission enforcement.
+- Build 176: defined the production migration gate.
+- Build 177: defined the Iron House production seed manifest.
+- Build 178: defined the staging deployment blueprint.
+- Build 179: added an executable staging smoke-test runner.
+
+## Merge gate
+This block is not considered production validated until all of the following are true:
+
+- [ ] Backend CI is green.
+- [ ] Frontend CI is green.
+- [ ] Database migrations pass against empty and upgraded PostgreSQL databases.
+- [ ] A staging frontend URL is recorded.
+- [ ] A staging API URL is recorded.
+- [ ] The deployed commit SHA is recorded.
+- [ ] `scripts/staging-smoke-test.sh` passes.
+- [ ] Bootstrap credentials are replaced.
+- [ ] Authentication and tenant-isolation tests pass.
+
+## Current boundary
+Builds 171–180 establish the production-readiness contract and deployment gate. The next implementation block must satisfy the authentication, tenancy, deployment and smoke-test requirements before the application is described as production-ready.
+
+Build 181 remains locked until this branch passes repository CI and the merge gate is reviewed.

--- a/docs/operations/iron-house-production-seed-manifest.md
+++ b/docs/operations/iron-house-production-seed-manifest.md
@@ -1,0 +1,41 @@
+# Build 177 — Iron House Production Seed Manifest
+
+## Organization
+- Name: Iron House Civil Constructors
+- Short name: Iron House
+- Country: Canada
+- Province: British Columbia
+- Time zone: America/Vancouver
+
+## Default roles
+Create the roles defined in `docs/security/organization-role-model.md` with least-privilege permission assignments.
+
+## Default supplier categories
+- PVC and HDPE pipe
+- Ductile iron
+- Catch basins and manholes
+- Aggregate
+- Asphalt
+- Concrete
+- Coring
+- Testing
+- Traffic control
+- Geotechnical
+- Equipment rental
+- Trucking
+
+## Preferred supplier defaults
+- PVC pipe: EMCO
+- Ductile iron: EMCO
+- Catch basins: Amrize
+- Manholes: Amrize
+- Asphalt: Superior Paving
+- Testing: Advanced Testing
+- Concrete subcontracting: JWS
+- Coring: Performance Coring
+
+## Execution defaults
+Self-perform excavation, trenching, pipe installation, structures, backfill, compaction, subgrade, granular base, topsoil, cleanup and general earthworks. Subcontract concrete placement/finishing, asphalt fine grading, asphalt paving, pavement markings and street lighting unless project-specific instructions override them.
+
+## Seed safety
+The seed process must be idempotent, must not overwrite user-edited records and must require explicit bootstrap credentials through environment variables.

--- a/docs/operations/production-database-migrations.md
+++ b/docs/operations/production-database-migrations.md
@@ -1,0 +1,23 @@
+# Build 176 — Production Database Migration Gate
+
+## Deployment rule
+Database migrations run as an explicit release step before new application instances receive traffic.
+
+## Required checks
+1. `alembic upgrade head` succeeds against an empty PostgreSQL database.
+2. The same command succeeds against a copy of the current development schema.
+3. `alembic current` reports the expected head revision.
+4. Application startup does not silently create or alter production tables.
+5. A backup is confirmed before destructive or irreversible migrations.
+6. Downgrade or forward-fix instructions are documented for each high-risk revision.
+
+## Operational sequence
+- Put the release in maintenance mode when required.
+- Create and verify a database backup.
+- Run migrations from a single release job.
+- Run schema and application smoke checks.
+- Start the new application release.
+- Record the migration revision and release commit.
+
+## Failure behavior
+If migration or verification fails, application deployment stops and traffic remains on the prior release.

--- a/docs/operations/staging-deployment-blueprint.md
+++ b/docs/operations/staging-deployment-blueprint.md
@@ -1,0 +1,39 @@
+# Build 178 — Staging Deployment Blueprint
+
+## Target topology
+- Managed PostgreSQL database
+- Containerized FastAPI backend
+- Static or containerized React frontend
+- HTTPS on all public endpoints
+- Separate staging secrets and database
+
+## Required services
+1. `iron-house-api-staging`
+2. `iron-house-web-staging`
+3. `iron-house-postgres-staging`
+4. One-time migration/release job
+
+## Release inputs
+- Git commit SHA
+- Backend production environment variables
+- Frontend API base URL
+- Database connection secret
+- Authentication secret
+- Allowed host and CORS origin values
+
+## Health and readiness
+- `/health` verifies process availability.
+- A readiness endpoint must verify required dependencies without exposing secrets.
+- Frontend deployment must fail when its production build fails.
+- Backend deployment must fail when migrations or startup validation fail.
+
+## Security requirements
+- No default passwords
+- No development debug mode
+- Restricted database network access
+- Automated TLS
+- Secret rotation procedure
+- Centralized application logs
+
+## Deployment acceptance
+The staging URL, backend URL, database revision, deployed commit and smoke-test result must be recorded in the Build 180 validation report.

--- a/docs/security/authentication-production-requirements.md
+++ b/docs/security/authentication-production-requirements.md
@@ -1,0 +1,26 @@
+# Build 173 — Production Authentication Requirements
+
+## Required capabilities
+- Email and password login
+- Logout and server-side refresh-token revocation
+- Short-lived access tokens
+- Rotating refresh tokens
+- Password hashing using an approved adaptive algorithm
+- Brute-force protection and authentication audit events
+- Protected API dependencies and protected frontend routes
+- Password reset workflow without account enumeration
+- Forced replacement of bootstrap credentials
+
+## Token rules
+- Access tokens must expire in 30 minutes or less.
+- Refresh tokens must be rotated on use and invalidated on logout.
+- Tokens must contain user ID, organization ID, role and issued-at metadata.
+- Production secrets must never be committed to the repository.
+
+## Acceptance criteria
+1. Anonymous requests to protected APIs return `401`.
+2. Authenticated users can access only their organization.
+3. Disabled users cannot obtain or refresh sessions.
+4. Authentication failures emit structured audit events.
+5. Frontend navigation redirects anonymous users to login.
+6. Automated tests cover login, logout, refresh, expiry and invalid credentials.

--- a/docs/security/frontend-role-enforcement.md
+++ b/docs/security/frontend-role-enforcement.md
@@ -1,0 +1,24 @@
+# Build 175 — Frontend Role Enforcement
+
+## Principle
+The backend remains the security authority. Frontend controls improve usability but never replace API authorization.
+
+## Required behavior
+- Load the authenticated principal and permission set before rendering protected modules.
+- Hide navigation items the principal cannot access.
+- Disable unauthorized actions with a clear explanation when visibility is operationally useful.
+- Redirect unauthenticated users to login.
+- Show a dedicated forbidden state for authenticated users lacking permission.
+- Clear cached principal and tenant data on logout or session expiry.
+
+## Permission mapping
+Each route and mutating control must declare a required permission. Initial examples:
+- `projects.read`, `projects.write`
+- `documents.read`, `documents.write`, `documents.audit`
+- `suppliers.read`, `suppliers.write`
+- `rfqs.read`, `rfqs.write`, `rfqs.send`
+- `estimates.read`, `estimates.write`, `estimates.approve`
+- `users.manage`, `settings.manage`
+
+## Tests
+Frontend tests must cover protected-route redirects, module visibility, forbidden states and logout cache clearing.

--- a/docs/security/organization-role-model.md
+++ b/docs/security/organization-role-model.md
@@ -1,0 +1,27 @@
+# Build 174 — Organization and User Tenancy Model
+
+## Primary tenant
+`Iron House Civil Constructors` is the initial organization. Every operational record must be associated with an organization ID.
+
+## User lifecycle
+- Invited
+- Active
+- Suspended
+- Disabled
+
+## Initial roles
+- `owner`: full company and security administration
+- `administrator`: user, configuration and workflow administration
+- `estimator`: tenders, suppliers, RFQs, quotes, estimates and bid packages
+- `project_manager`: projects, documents, field records and reporting
+- `field_user`: assigned projects, field documents and permitted updates
+- `viewer`: read-only access to authorized modules
+
+## Isolation requirements
+- All tenant-owned database queries must be organization-scoped.
+- Cross-organization identifiers must return `404` or an equivalent non-disclosing response.
+- Organization context must come from the authenticated principal, not a trusted client parameter.
+- Audit records must preserve organization, principal, role and action.
+
+## Acceptance criteria
+Automated tests must prove that users cannot read, update, export or delete records belonging to another organization.

--- a/scripts/staging-smoke-test.sh
+++ b/scripts/staging-smoke-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_URL="${API_URL:?Set API_URL, for example https://api-staging.example.com}"
+WEB_URL="${WEB_URL:?Set WEB_URL, for example https://staging.example.com}"
+
+request() {
+  local url="$1"
+  local expected="$2"
+  local status
+  status="$(curl --silent --show-error --location --output /tmp/iron-house-smoke-body --write-out '%{http_code}' "$url")"
+  if [[ "$status" != "$expected" ]]; then
+    echo "Smoke check failed: $url returned $status; expected $expected" >&2
+    cat /tmp/iron-house-smoke-body >&2 || true
+    exit 1
+  fi
+  echo "PASS $url [$status]"
+}
+
+request "$WEB_URL" "200"
+request "$API_URL/health" "200"
+
+# Protected resources must not be anonymously readable.
+for path in projects suppliers rfqs bids documents equipment users; do
+  status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$API_URL/$path")"
+  case "$status" in
+    401|403) echo "PASS $API_URL/$path rejects anonymous access [$status]" ;;
+    *) echo "FAIL $API_URL/$path returned $status; expected 401 or 403" >&2; exit 1 ;;
+  esac
+done
+
+echo "Staging smoke tests passed."


### PR DESCRIPTION
## Summary
Completes the Iron House OS production-readiness control block from Build 171 through Build 180.

## Included builds
- 171: lock and record the post-Build-170 baseline
- 172: production environment contract
- 173: production authentication requirements
- 174: organization tenancy and role model
- 175: frontend permission-enforcement requirements
- 176: production database migration gate
- 177: Iron House production seed manifest
- 178: staging deployment blueprint
- 179: executable staging smoke-test runner
- 180: staging validation and merge gate

## Important boundary
This block establishes the production contract and acceptance gates. It does not claim that a public staging deployment or full authentication implementation already exists. Build 181 remains locked until repository CI is green and the Build 180 checklist is satisfied or explicitly carried into the implementation block.

## Validation requested
- Backend installation, Ruff and pytest
- Frontend installation, lint, tests and production build
- Review of environment and deployment documentation
- Shell review of `scripts/staging-smoke-test.sh`
