### PR TITLE
Validate main after Builds 171–180

### DIFF
--- a/docs/validation-main-after-build-180.md
+++ b/docs/validation-main-after-build-180.md
@@ -1,0 +1,5 @@
+# Main Validation After Builds 171–180
+
+This marker validates the exact `main` baseline after the gated Builds 171–180 block was merged.
+
+Build 181 remains locked until backend and frontend CI are both green for this validation PR.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 171–180. This PR contains only a validation marker and must pass backend and frontend CI before Build 181 begins.