### PR TITLE
Validate main after Builds 181–190

### DIFF
--- a/docs/validation-main-after-build-190.md
+++ b/docs/validation-main-after-build-190.md
@@ -1,0 +1,5 @@
+# Main Validation After Builds 181–190
+
+This marker validates the exact `main` baseline after the gated Builds 181–190 block was merged.
+
+Build 191 remains locked until backend and frontend CI are both green for this validation PR.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 181–190. This PR contains only a validation marker and must pass backend and frontend CI before Build 191 begins.