### PR TITLE
Build 191: estimate cost-code foundation

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -4,6 +4,7 @@ from app.api.v1.routes import (
     auth,
     bid_package,
     bids,
+    cost_codes,
     documents,
     drawing_intelligence,
     equipment,
@@ -28,6 +29,7 @@ api_router.include_router(rfq_automation.router, prefix="/rfq-automation", tags=
 api_router.include_router(bid_package.router, prefix="/bid-package", tags=["bid-package"])
 api_router.include_router(bids.router, prefix="/bids", tags=["bids"])
 api_router.include_router(estimates.router, prefix="/estimates", tags=["estimates"])
+api_router.include_router(cost_codes.router, prefix="/cost-codes", tags=["cost-codes"])
 api_router.include_router(quotes.router, prefix="/quotes", tags=["quotes"])
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
 api_router.include_router(drawing_intelligence.router, prefix="/drawing-intelligence", tags=["drawing-intelligence"])

--- a/backend/app/api/v1/routes/cost_codes.py
+++ b/backend/app/api/v1/routes/cost_codes.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+from app.schemas.cost_code import CostCodeLibrary, CostCodeResolveRequest, CostCodeResolveResponse
+from app.services import cost_codes
+
+router = APIRouter()
+
+
+@router.get("", response_model=CostCodeLibrary)
+def list_cost_codes() -> CostCodeLibrary:
+    return cost_codes.get_cost_code_library()
+
+
+@router.post("/resolve", response_model=CostCodeResolveResponse)
+def resolve_cost_code(payload: CostCodeResolveRequest) -> CostCodeResolveResponse:
+    return cost_codes.resolve_cost_code(payload)

--- a/backend/app/schemas/cost_code.py
+++ b/backend/app/schemas/cost_code.py
@@ -1,0 +1,52 @@
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.schemas.estimate import EstimateItemType, EstimateUnit
+
+
+class CostCodeGroup(StrEnum):
+    general = "general"
+    earthworks = "earthworks"
+    utilities = "utilities"
+    structures = "structures"
+    concrete = "concrete"
+    asphalt = "asphalt"
+    traffic = "traffic"
+    landscaping = "landscaping"
+    testing = "testing"
+    closeout = "closeout"
+
+
+class CostCode(BaseModel):
+    code: str = Field(min_length=3, max_length=32)
+    name: str = Field(min_length=1, max_length=160)
+    group: CostCodeGroup
+    default_item_type: EstimateItemType
+    default_unit: EstimateUnit
+    description: str | None = None
+    active: bool = True
+    parent_code: str | None = None
+    tags: list[str] = Field(default_factory=list)
+
+
+class CostCodeLibrary(BaseModel):
+    version: str
+    items: list[CostCode]
+
+
+class CostCodeResolveRequest(BaseModel):
+    code: str | None = None
+    description: str | None = None
+
+    @model_validator(mode="after")
+    def require_code_or_description(self) -> "CostCodeResolveRequest":
+        if not self.code and not self.description:
+            raise ValueError("code or description is required")
+        return self
+
+
+class CostCodeResolveResponse(BaseModel):
+    match: CostCode | None
+    confidence: float = Field(ge=0, le=1)
+    alternatives: list[CostCode] = Field(default_factory=list)

--- a/backend/app/services/cost_codes.py
+++ b/backend/app/services/cost_codes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from app.schemas.cost_code import (
+    CostCode,
+    CostCodeGroup,
+    CostCodeLibrary,
+    CostCodeResolveRequest,
+    CostCodeResolveResponse,
+)
+from app.schemas.estimate import EstimateItemType, EstimateUnit
+
+
+LIBRARY_VERSION = "2026.07"
+
+COST_CODES: tuple[CostCode, ...] = (
+    CostCode(code="01-100", name="Mobilization", group=CostCodeGroup.general, default_item_type=EstimateItemType.indirect, default_unit=EstimateUnit.lump_sum, tags=["mobilization", "startup", "demobilization"]),
+    CostCode(code="01-200", name="Site supervision", group=CostCodeGroup.general, default_item_type=EstimateItemType.indirect, default_unit=EstimateUnit.day, tags=["supervision", "foreman", "project management"]),
+    CostCode(code="02-100", name="Clearing and grubbing", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.square_metre, tags=["clearing", "grubbing", "brush"]),
+    CostCode(code="02-200", name="Common excavation", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.cubic_metre, tags=["excavation", "dig", "soil"]),
+    CostCode(code="02-300", name="Trench backfill and compaction", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.cubic_metre, tags=["backfill", "compaction", "trench"]),
+    CostCode(code="02-400", name="Granular base and subbase", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.tonne, tags=["aggregate", "road base", "subbase", "granular"]),
+    CostCode(code="03-100", name="PVC sewer and drain pipe", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.metre, tags=["pvc", "storm", "sanitary", "pipe"]),
+    CostCode(code="03-200", name="Watermain pipe", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.metre, tags=["watermain", "ductile iron", "pvc", "pipe"]),
+    CostCode(code="03-300", name="Manholes", group=CostCodeGroup.structures, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.each, tags=["manhole", "precast", "structure"]),
+    CostCode(code="03-400", name="Catch basins", group=CostCodeGroup.structures, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.each, tags=["catch basin", "cb", "drainage"]),
+    CostCode(code="04-100", name="Concrete curb", group=CostCodeGroup.concrete, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.metre, tags=["curb", "concrete"]),
+    CostCode(code="04-200", name="Concrete sidewalk", group=CostCodeGroup.concrete, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.square_metre, tags=["sidewalk", "concrete", "flatwork"]),
+    CostCode(code="05-100", name="Asphalt paving", group=CostCodeGroup.asphalt, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.tonne, tags=["asphalt", "paving", "blacktop"]),
+    CostCode(code="05-200", name="Asphalt removal and disposal", group=CostCodeGroup.asphalt, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.square_metre, tags=["asphalt removal", "milling", "sawcut"]),
+    CostCode(code="06-100", name="Traffic control", group=CostCodeGroup.traffic, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.day, tags=["traffic", "tcp", "lane closure"]),
+    CostCode(code="06-200", name="Pavement markings", group=CostCodeGroup.traffic, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.lump_sum, tags=["paint", "markings", "thermoplastic"]),
+    CostCode(code="07-100", name="Topsoil and landscape restoration", group=CostCodeGroup.landscaping, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.square_metre, tags=["topsoil", "landscape", "restoration"]),
+    CostCode(code="08-100", name="Material and compaction testing", group=CostCodeGroup.testing, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.lump_sum, tags=["testing", "density", "compaction", "concrete"]),
+    CostCode(code="09-100", name="Coring", group=CostCodeGroup.closeout, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.each, tags=["coring", "core drilling"]),
+    CostCode(code="09-200", name="Cleanup and closeout", group=CostCodeGroup.closeout, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.lump_sum, tags=["cleanup", "closeout", "deficiency"]),
+)
+
+
+def get_cost_code_library() -> CostCodeLibrary:
+    return CostCodeLibrary(version=LIBRARY_VERSION, items=list(COST_CODES))
+
+
+def resolve_cost_code(payload: CostCodeResolveRequest) -> CostCodeResolveResponse:
+    if payload.code:
+        normalized = payload.code.strip().lower()
+        exact = next((item for item in COST_CODES if item.code.lower() == normalized), None)
+        if exact:
+            return CostCodeResolveResponse(match=exact, confidence=1.0)
+
+    query = (payload.description or "").strip().lower()
+    if not query:
+        return CostCodeResolveResponse(match=None, confidence=0.0)
+
+    scored: list[tuple[float, CostCode]] = []
+    query_tokens = set(query.replace("/", " ").replace("-", " ").split())
+    for item in COST_CODES:
+        haystack = " ".join([item.name, item.description or "", *item.tags]).lower()
+        token_hits = sum(1 for token in query_tokens if token in haystack)
+        phrase_hit = 1 if item.name.lower() in query or query in item.name.lower() else 0
+        score = min(1.0, phrase_hit * 0.75 + token_hits / max(len(query_tokens), 1) * 0.7)
+        if score:
+            scored.append((score, item))
+
+    scored.sort(key=lambda candidate: (-candidate[0], candidate[1].code))
+    if not scored:
+        return CostCodeResolveResponse(match=None, confidence=0.0)
+    best_score, best = scored[0]
+    return CostCodeResolveResponse(
+        match=best,
+        confidence=round(best_score, 2),
+        alternatives=[item for _, item in scored[1:4]],
+    )

--- a/backend/tests/test_cost_codes.py
+++ b/backend/tests/test_cost_codes.py
@@ -1,0 +1,47 @@
+import pytest
+
+from app.schemas.cost_code import CostCodeGroup, CostCodeResolveRequest
+from app.schemas.estimate import EstimateItemType, EstimateUnit
+from app.services.cost_codes import get_cost_code_library, resolve_cost_code
+
+
+def test_cost_code_library_contains_core_civil_scopes() -> None:
+    library = get_cost_code_library()
+    by_code = {item.code: item for item in library.items}
+
+    assert library.version == "2026.07"
+    assert by_code["02-200"].name == "Common excavation"
+    assert by_code["03-100"].default_unit == EstimateUnit.metre
+    assert by_code["05-100"].default_item_type == EstimateItemType.subcontract
+    assert by_code["06-100"].group == CostCodeGroup.traffic
+    assert len(library.items) == len(by_code)
+
+
+def test_cost_code_resolver_matches_exact_code() -> None:
+    result = resolve_cost_code(CostCodeResolveRequest(code="03-300"))
+
+    assert result.match is not None
+    assert result.match.name == "Manholes"
+    assert result.confidence == 1.0
+
+
+def test_cost_code_resolver_matches_civil_description() -> None:
+    result = resolve_cost_code(
+        CostCodeResolveRequest(description="Supply and install asphalt paving")
+    )
+
+    assert result.match is not None
+    assert result.match.code == "05-100"
+    assert result.confidence >= 0.7
+
+
+def test_cost_code_resolver_returns_no_match_for_unknown_scope() -> None:
+    result = resolve_cost_code(CostCodeResolveRequest(description="specialty unrelated scope xyz"))
+
+    assert result.match is None
+    assert result.confidence == 0
+
+
+def test_cost_code_resolve_request_requires_search_input() -> None:
+    with pytest.raises(ValueError):
+        CostCodeResolveRequest()

--- a/docs/build-191-estimate-foundation.md
+++ b/docs/build-191-estimate-foundation.md
@@ -1,0 +1,14 @@
+# Build 191 — Estimate Foundation
+
+Build 191 adds a versioned civil-construction cost-code foundation used by the estimating workflow.
+
+## Implemented
+- Typed cost-code groups and records.
+- Versioned Iron House civil cost-code library.
+- Default estimate item type and unit for each code.
+- Deterministic exact-code and description-based resolution.
+- `GET /api/v1/cost-codes` and `POST /api/v1/cost-codes/resolve` endpoints.
+- Regression tests for uniqueness, core scopes, exact resolution, descriptive resolution, and validation.
+
+## Boundary
+This build establishes classification. Estimate persistence, quote import, production calculations, municipality adjustments, qualifications, and package review remain Builds 192–200.


### PR DESCRIPTION
## Summary
Implements Build 191 as real estimating application code.

## Changes
- Adds a typed, versioned civil cost-code catalog
- Adds exact-code and description-based cost-code resolution
- Adds cost-code API endpoints
- Registers the new router
- Adds regression tests and build documentation

## Validation requested
- Backend dependency installation
- Ruff lint
- Pytest, including `test_cost_codes.py`
- Frontend dependency installation, lint, tests, and production build

Build 192 remains locked until this PR and the exact merged-main baseline are green.