### PR TITLE
Validate main after Build 191

### DIFF
--- a/docs/validation-main-after-build-191.md
+++ b/docs/validation-main-after-build-191.md
@@ -1,0 +1,5 @@
+# Main Validation After Build 191
+
+This marker validates the exact merged `main` baseline after Build 191.
+
+Build 192 remains locked until backend and frontend CI are both green for this validation PR.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Build 191. This PR contains only a validation marker and must pass backend and frontend CI before Build 192 begins.