### PR TITLE
Build 192: estimate validation engine

### DIFF
--- a/backend/app/api/v1/routes/estimates.py
+++ b/backend/app/api/v1/routes/estimates.py
@@ -16,8 +16,9 @@ from app.schemas.estimate import (
     EstimateSummary,
     RateLibrary,
 )
+from app.schemas.estimate_validation import EstimateValidationRequest, EstimateValidationResult
 from app.schemas.estimate_workspace import EstimateWorkspaceList, EstimateWorkspaceRead, EstimateWorkspaceSaveRequest
-from app.services import estimate_handoff, estimate_workspace, estimate_workbooks, estimates
+from app.services import estimate_handoff, estimate_validation, estimate_workspace, estimate_workbooks, estimates
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
@@ -31,6 +32,11 @@ def get_rate_library() -> RateLibrary:
 @router.post("/line-item", response_model=EstimateLineItemCost)
 def calculate_line_item(payload: EstimateLineItem) -> EstimateLineItemCost:
     return estimates.calculate_line_item(payload)
+
+
+@router.post("/validate", response_model=EstimateValidationResult)
+def validate_estimate(payload: EstimateValidationRequest) -> EstimateValidationResult:
+    return estimate_validation.validate_estimate(payload)
 
 
 @router.post("/handoff", response_model=EstimateHandoffResponse)

--- a/backend/app/schemas/estimate_validation.py
+++ b/backend/app/schemas/estimate_validation.py
@@ -1,0 +1,33 @@
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from app.schemas.estimate import EstimateCreate
+
+
+class ValidationSeverity(StrEnum):
+    error = "error"
+    warning = "warning"
+    info = "info"
+
+
+class EstimateValidationIssue(BaseModel):
+    severity: ValidationSeverity
+    code: str
+    message: str
+    line_item_index: int | None = None
+    field: str | None = None
+
+
+class EstimateValidationResult(BaseModel):
+    is_valid: bool
+    errors: int
+    warnings: int
+    issues: list[EstimateValidationIssue] = Field(default_factory=list)
+
+
+class EstimateValidationRequest(BaseModel):
+    estimate: EstimateCreate
+    require_cost_codes: bool = True
+    require_priced_items: bool = True
+    minimum_profit_percent: float = Field(default=5, ge=0)

--- a/backend/app/services/estimate_validation.py
+++ b/backend/app/services/estimate_validation.py
@@ -1,0 +1,108 @@
+from app.schemas.cost_code import CostCodeResolveRequest
+from app.schemas.estimate_validation import (
+    EstimateValidationIssue,
+    EstimateValidationRequest,
+    EstimateValidationResult,
+    ValidationSeverity,
+)
+from app.services.cost_codes import resolve_cost_code
+
+
+def validate_estimate(payload: EstimateValidationRequest) -> EstimateValidationResult:
+    issues: list[EstimateValidationIssue] = []
+    estimate = payload.estimate
+
+    if not estimate.line_items:
+        issues.append(_issue(ValidationSeverity.error, "estimate.empty", "Estimate has no line items."))
+
+    for index, item in enumerate(estimate.line_items):
+        resolved = resolve_cost_code(
+            CostCodeResolveRequest(code=item.code, description=item.description)
+        )
+        if payload.require_cost_codes and resolved.match is None:
+            issues.append(
+                _issue(
+                    ValidationSeverity.error,
+                    "line_item.cost_code_missing",
+                    f"No cost code could be resolved for '{item.description}'.",
+                    index,
+                    "code",
+                )
+            )
+        elif item.code is None and resolved.match is not None:
+            issues.append(
+                _issue(
+                    ValidationSeverity.warning,
+                    "line_item.cost_code_suggested",
+                    f"Suggested cost code {resolved.match.code} for '{item.description}'.",
+                    index,
+                    "code",
+                )
+            )
+
+        has_price = any(
+            [
+                item.direct_unit_cost is not None,
+                bool(item.labour),
+                bool(item.equipment),
+                bool(item.materials),
+                bool(item.disposal),
+                item.subcontract is not None,
+                bool(item.vendor_quotes),
+                item.default_activity is not None,
+            ]
+        )
+        if payload.require_priced_items and not has_price:
+            issues.append(
+                _issue(
+                    ValidationSeverity.error,
+                    "line_item.unpriced",
+                    f"'{item.description}' has no pricing basis.",
+                    index,
+                    "direct_unit_cost",
+                )
+            )
+        if item.quantity == 0:
+            issues.append(
+                _issue(
+                    ValidationSeverity.warning,
+                    "line_item.zero_quantity",
+                    f"'{item.description}' has zero quantity.",
+                    index,
+                    "quantity",
+                )
+            )
+
+    if estimate.markup.profit_percent < payload.minimum_profit_percent:
+        issues.append(
+            _issue(
+                ValidationSeverity.warning,
+                "markup.low_profit",
+                f"Profit markup is below {payload.minimum_profit_percent:.1f}%.",
+                field="markup.profit_percent",
+            )
+        )
+    if not estimate.assumptions:
+        issues.append(_issue(ValidationSeverity.warning, "estimate.no_assumptions", "No estimate assumptions recorded."))
+    if not estimate.exclusions:
+        issues.append(_issue(ValidationSeverity.warning, "estimate.no_exclusions", "No estimate exclusions recorded."))
+
+    errors = sum(issue.severity == ValidationSeverity.error for issue in issues)
+    warnings = sum(issue.severity == ValidationSeverity.warning for issue in issues)
+    return EstimateValidationResult(is_valid=errors == 0, errors=errors, warnings=warnings, issues=issues)
+
+
+def _issue(
+    severity: ValidationSeverity,
+    code: str,
+    message: str,
+    line_item_index: int | None = None,
+    field: str | None = None,
+) -> EstimateValidationIssue:
+    return EstimateValidationIssue(
+        severity=severity,
+        code=code,
+        message=message,
+        line_item_index=line_item_index,
+        field=field,
+    )

--- a/backend/tests/test_estimate_validation.py
+++ b/backend/tests/test_estimate_validation.py
@@ -1,0 +1,63 @@
+from app.schemas.estimate import EstimateCreate, EstimateLineItem, EstimateMarkup
+from app.schemas.estimate_validation import EstimateValidationRequest
+from app.services.estimate_validation import validate_estimate
+
+
+def test_validation_rejects_empty_estimate() -> None:
+    result = validate_estimate(
+        EstimateValidationRequest(estimate=EstimateCreate(project_name="Empty"))
+    )
+    assert result.is_valid is False
+    assert any(issue.code == "estimate.empty" for issue in result.issues)
+
+
+def test_validation_flags_unpriced_item_and_suggests_cost_code() -> None:
+    estimate = EstimateCreate(
+        project_name="Storm repair",
+        line_items=[EstimateLineItem(description="Install storm pipe", quantity=25)],
+    )
+    result = validate_estimate(EstimateValidationRequest(estimate=estimate))
+    assert result.is_valid is False
+    assert any(issue.code == "line_item.unpriced" for issue in result.issues)
+    assert any(issue.code == "line_item.cost_code_suggested" for issue in result.issues)
+
+
+def test_validation_accepts_priced_coded_item() -> None:
+    estimate = EstimateCreate(
+        project_name="Excavation",
+        line_items=[
+            EstimateLineItem(
+                code="02-200",
+                description="Common excavation",
+                quantity=100,
+                direct_unit_cost=18,
+            )
+        ],
+        markup=EstimateMarkup(profit_percent=10),
+        assumptions=["Normal soil conditions"],
+        exclusions=["Contaminated soil"],
+    )
+    result = validate_estimate(EstimateValidationRequest(estimate=estimate))
+    assert result.is_valid is True
+    assert result.errors == 0
+
+
+def test_validation_warns_on_zero_quantity_and_low_profit() -> None:
+    estimate = EstimateCreate(
+        project_name="Allowance",
+        line_items=[
+            EstimateLineItem(
+                code="01-100",
+                description="Mobilization",
+                quantity=0,
+                direct_unit_cost=1000,
+            )
+        ],
+        markup=EstimateMarkup(profit_percent=2),
+    )
+    result = validate_estimate(
+        EstimateValidationRequest(estimate=estimate, minimum_profit_percent=5)
+    )
+    codes = {issue.code for issue in result.issues}
+    assert "line_item.zero_quantity" in codes
+    assert "markup.low_profit" in codes

--- a/docs/builds/build-192-estimate-validation.md
+++ b/docs/builds/build-192-estimate-validation.md
@@ -1,0 +1,17 @@
+# Build 192 — Estimate Validation Engine
+
+Status: implemented; pending CI validation.
+
+Build 192 adds a deterministic estimate quality gate before pricing review or bid-package generation.
+
+## Implemented controls
+- Reject empty estimates.
+- Require resolvable civil cost codes when configured.
+- Suggest cost codes from line-item descriptions.
+- Reject unpriced line items when configured.
+- Warn on zero quantities.
+- Warn when profit markup is below the configured minimum.
+- Warn when assumptions or exclusions are missing.
+- Return structured error and warning counts through `POST /api/v1/estimates/validate`.
+
+Build 193 remains locked until this branch and the exact merged-main baseline are green.


### PR DESCRIPTION
## Summary
Implements Build 192 as real estimating application code.

## Changes
- Adds structured estimate validation request/result schemas
- Adds cost-code resolution checks and suggested-code warnings
- Rejects empty estimates and unpriced line items when configured
- Warns on zero quantities, low profit, missing assumptions, and missing exclusions
- Adds `POST /api/v1/estimates/validate`
- Adds regression tests and build documentation

## Validation requested
- Backend dependency installation
- Ruff lint
- Pytest, including `test_estimate_validation.py`
- Frontend dependency installation, lint, tests, and production build

Build 193 remains locked until this PR and the exact merged-main baseline are green.