### PR TITLE
Validate main after Build 192

### DIFF
--- a/docs/validation/main-after-build-192.md
+++ b/docs/validation/main-after-build-192.md
@@ -1,0 +1,3 @@
+# Main validation after Build 192
+
+This marker validates the exact merged `main` baseline after Build 192. Backend and frontend CI must pass before Build 193 begins.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Build 192. This PR contains only a validation marker and must pass backend and frontend CI before Build 193 begins.