### PR TITLE
Build 193: supplier quote to estimate integration

### DIFF
--- a/backend/app/api/v1/routes/quotes.py
+++ b/backend/app/api/v1/routes/quotes.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter
 
-from app.schemas.quote_integration import QuoteComparisonRequest, QuoteComparisonResponse
+from app.schemas.quote_integration import (
+    QuoteComparisonRequest,
+    QuoteComparisonResponse,
+    QuoteEstimateImportRequest,
+    QuoteEstimateImportResponse,
+)
 from app.services.quote_comparison import compare_supplier_quotes
+from app.services.quote_estimate import import_quotes_to_estimate
 
 router = APIRouter()
 
@@ -9,3 +15,8 @@ router = APIRouter()
 @router.post("/compare", response_model=QuoteComparisonResponse)
 def compare_quotes(payload: QuoteComparisonRequest) -> QuoteComparisonResponse:
     return compare_supplier_quotes(payload)
+
+
+@router.post("/estimate-import", response_model=QuoteEstimateImportResponse)
+def import_quote_pricing(payload: QuoteEstimateImportRequest) -> QuoteEstimateImportResponse:
+    return import_quotes_to_estimate(payload)

--- a/backend/app/schemas/quote_integration.py
+++ b/backend/app/schemas/quote_integration.py
@@ -27,6 +27,8 @@ class SupplierQuoteCreate(BaseModel):
     rfq_package_id: UUID | None = None
     supplier_id: UUID | None = None
     supplier_name: str = Field(min_length=1)
+    quote_reference: str | None = None
+    revision: int = Field(default=1, ge=1)
     line_item_code: str | None = None
     line_item_description: str | None = None
     scope: str = Field(min_length=1)
@@ -65,3 +67,40 @@ class QuoteComparisonResponse(BaseModel):
     total_lowest: float
     total_selected: float
     delta_from_lowest: float
+
+
+class QuoteEstimateImportRequest(BaseModel):
+    quotes: list[SupplierQuoteCreate] = Field(default_factory=list)
+    include_superseded_revisions: bool = False
+    minimum_mapping_confidence: float = Field(default=0.5, ge=0, le=1)
+
+
+class QuoteEstimateLine(BaseModel):
+    supplier_name: str
+    quote_reference: str | None = None
+    revision: int
+    scope: str
+    scope_type: QuoteScopeType
+    amount: float
+    cost_code: str | None = None
+    cost_code_name: str | None = None
+    mapping_confidence: float = Field(ge=0, le=1)
+    needs_review: bool
+    exclusions: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class QuoteRevisionSummary(BaseModel):
+    supplier_name: str
+    quote_reference: str | None = None
+    current_revision: int
+    superseded_revisions: list[int] = Field(default_factory=list)
+
+
+class QuoteEstimateImportResponse(BaseModel):
+    lines: list[QuoteEstimateLine]
+    revisions: list[QuoteRevisionSummary]
+    mapped_count: int
+    review_count: int
+    total_amount: float
+    warnings: list[str] = Field(default_factory=list)

--- a/backend/app/services/quote_estimate.py
+++ b/backend/app/services/quote_estimate.py
@@ -1,0 +1,98 @@
+from collections import defaultdict
+
+from app.schemas.cost_code import CostCodeResolveRequest
+from app.schemas.quote_integration import (
+    QuoteEstimateImportRequest,
+    QuoteEstimateImportResponse,
+    QuoteEstimateLine,
+    QuoteRevisionSummary,
+    SupplierQuoteCreate,
+)
+from app.services.cost_codes import resolve_cost_code
+
+
+def import_quotes_to_estimate(payload: QuoteEstimateImportRequest) -> QuoteEstimateImportResponse:
+    current_quotes, revisions = _select_current_revisions(
+        payload.quotes,
+        payload.include_superseded_revisions,
+    )
+    lines: list[QuoteEstimateLine] = []
+    warnings: list[str] = []
+
+    for quote in current_quotes:
+        resolution = resolve_cost_code(
+            CostCodeResolveRequest(
+                code=quote.line_item_code,
+                description=quote.line_item_description or quote.scope,
+            )
+        )
+        match = resolution.match
+        needs_review = match is None or resolution.confidence < payload.minimum_mapping_confidence
+        if quote.amount == 0:
+            needs_review = True
+            warnings.append(
+                f"{quote.supplier_name}: '{quote.scope}' has a zero amount and requires review."
+            )
+        if quote.exclusions:
+            warnings.append(
+                f"{quote.supplier_name}: '{quote.scope}' includes {len(quote.exclusions)} exclusion(s)."
+            )
+
+        lines.append(
+            QuoteEstimateLine(
+                supplier_name=quote.supplier_name,
+                quote_reference=quote.quote_reference,
+                revision=quote.revision,
+                scope=quote.scope,
+                scope_type=quote.scope_type,
+                amount=quote.amount,
+                cost_code=match.code if match else None,
+                cost_code_name=match.name if match else None,
+                mapping_confidence=resolution.confidence,
+                needs_review=needs_review,
+                exclusions=quote.exclusions,
+                notes=quote.notes,
+            )
+        )
+
+    return QuoteEstimateImportResponse(
+        lines=lines,
+        revisions=revisions,
+        mapped_count=sum(1 for line in lines if line.cost_code and not line.needs_review),
+        review_count=sum(1 for line in lines if line.needs_review),
+        total_amount=round(sum(line.amount for line in lines), 2),
+        warnings=sorted(set(warnings)),
+    )
+
+
+def _select_current_revisions(
+    quotes: list[SupplierQuoteCreate],
+    include_superseded: bool,
+) -> tuple[list[SupplierQuoteCreate], list[QuoteRevisionSummary]]:
+    grouped: dict[tuple[str, str], list[SupplierQuoteCreate]] = defaultdict(list)
+    for quote in quotes:
+        key = (
+            quote.supplier_name.strip().lower(),
+            (quote.quote_reference or quote.scope).strip().lower(),
+        )
+        grouped[key].append(quote)
+
+    selected: list[SupplierQuoteCreate] = []
+    summaries: list[QuoteRevisionSummary] = []
+    for group in grouped.values():
+        ordered = sorted(group, key=lambda quote: quote.revision)
+        current = ordered[-1]
+        superseded = [quote.revision for quote in ordered[:-1]]
+        summaries.append(
+            QuoteRevisionSummary(
+                supplier_name=current.supplier_name,
+                quote_reference=current.quote_reference,
+                current_revision=current.revision,
+                superseded_revisions=superseded,
+            )
+        )
+        selected.extend(ordered if include_superseded else [current])
+
+    selected.sort(key=lambda quote: (quote.supplier_name.lower(), quote.scope.lower(), quote.revision))
+    summaries.sort(key=lambda item: (item.supplier_name.lower(), item.quote_reference or ""))
+    return selected, summaries

--- a/backend/tests/test_quote_estimate.py
+++ b/backend/tests/test_quote_estimate.py
@@ -1,0 +1,96 @@
+from app.schemas.quote_integration import (
+    QuoteEstimateImportRequest,
+    QuoteScopeType,
+    SupplierQuoteCreate,
+)
+from app.services.quote_estimate import import_quotes_to_estimate
+
+
+def test_quote_import_maps_scope_to_cost_code() -> None:
+    result = import_quotes_to_estimate(
+        QuoteEstimateImportRequest(
+            quotes=[
+                SupplierQuoteCreate(
+                    supplier_name="EMCO",
+                    quote_reference="Q-100",
+                    scope="PVC storm pipe supply",
+                    scope_type=QuoteScopeType.material,
+                    amount=12500,
+                )
+            ]
+        )
+    )
+
+    assert result.mapped_count == 1
+    assert result.review_count == 0
+    assert result.lines[0].cost_code == "03-100"
+    assert result.total_amount == 12500
+
+
+def test_quote_import_keeps_latest_revision_only_by_default() -> None:
+    result = import_quotes_to_estimate(
+        QuoteEstimateImportRequest(
+            quotes=[
+                SupplierQuoteCreate(
+                    supplier_name="Superior Paving",
+                    quote_reference="SP-22",
+                    revision=1,
+                    scope="Asphalt paving",
+                    scope_type=QuoteScopeType.subcontract,
+                    amount=40000,
+                ),
+                SupplierQuoteCreate(
+                    supplier_name="Superior Paving",
+                    quote_reference="SP-22",
+                    revision=2,
+                    scope="Asphalt paving",
+                    scope_type=QuoteScopeType.subcontract,
+                    amount=38500,
+                ),
+            ]
+        )
+    )
+
+    assert len(result.lines) == 1
+    assert result.lines[0].revision == 2
+    assert result.total_amount == 38500
+    assert result.revisions[0].superseded_revisions == [1]
+
+
+def test_quote_import_flags_unmapped_and_zero_pricing() -> None:
+    result = import_quotes_to_estimate(
+        QuoteEstimateImportRequest(
+            quotes=[
+                SupplierQuoteCreate(
+                    supplier_name="Unknown Supplier",
+                    scope="Special proprietary item xyz",
+                    amount=0,
+                )
+            ]
+        )
+    )
+
+    assert result.review_count == 1
+    assert result.lines[0].needs_review is True
+    assert result.lines[0].cost_code is None
+    assert any("zero amount" in warning for warning in result.warnings)
+
+
+def test_quote_import_preserves_exclusion_warning() -> None:
+    result = import_quotes_to_estimate(
+        QuoteEstimateImportRequest(
+            quotes=[
+                SupplierQuoteCreate(
+                    supplier_name="JWS",
+                    scope="Concrete sidewalk",
+                    scope_type=QuoteScopeType.subcontract,
+                    amount=21000,
+                    exclusions=["Winter heat", "Traffic control"],
+                )
+            ]
+        )
+    )
+
+    assert result.lines[0].cost_code == "04-200"
+    assert result.lines[0].exclusions == ["Winter heat", "Traffic control"]
+    assert any("2 exclusion" in warning for warning in result.warnings)

--- a/docs/builds/193-supplier-quote-estimate-integration.md
+++ b/docs/builds/193-supplier-quote-estimate-integration.md
@@ -1,0 +1,15 @@
+# Build 193 — Supplier Quote to Estimate Integration
+
+Status: implemented; awaiting CI and merged-main validation.
+
+## Delivered
+- Imports supplier quote pricing into estimate-ready line records.
+- Maps quote scope to the Build 191 cost-code catalog.
+- Supports explicit line-item codes and description-based resolution.
+- Retains quote revision summaries and uses the latest revision by default.
+- Flags unmapped or low-confidence items for estimator review.
+- Preserves exclusions and warns on zero pricing.
+- Exposes `POST /api/v1/quotes/estimate-import`.
+
+## Boundary
+This build normalizes quote data already supplied to the API. Automated parsing of arbitrary PDF quotations and mailbox ingestion remain separate connector and document-processing tasks.


### PR DESCRIPTION
## Summary
Implements Build 193 as real supplier-quote-to-estimate application code.

## Changes
- Adds quote references and revision numbers to supplier quote payloads
- Adds quote-to-estimate import request and response schemas
- Uses the Build 191 cost-code resolver for scope mapping
- Keeps the latest quote revision by default and reports superseded revisions
- Flags unmapped, low-confidence, zero-priced, and exclusion-bearing quote lines
- Adds `POST /api/v1/quotes/estimate-import`
- Adds regression tests and build documentation

## Boundary
This build normalizes structured quote data supplied to the API. Automated mailbox ingestion and arbitrary PDF quote parsing remain separate connector/document-processing work.

## Validation requested
- Backend dependency installation
- Ruff lint
- Pytest, including `test_quote_estimate.py`
- Frontend dependency installation, lint, tests, and production build

Build 194 remains locked until this PR and the exact merged-main baseline are green.