### PR TITLE
Build 194: quantity takeoff normalization

### DIFF
--- a/backend/app/api/v1/routes/takeoff.py
+++ b/backend/app/api/v1/routes/takeoff.py
@@ -5,10 +5,17 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.schemas.takeoff import QuantityRegisterRequest, QuantityRegisterResponse, TakeoffEngineRequest, TakeoffEngineResponse
+from app.schemas.takeoff import (
+    QuantityRegisterRequest,
+    QuantityRegisterResponse,
+    TakeoffEngineRequest,
+    TakeoffEngineResponse,
+)
+from app.schemas.takeoff_normalization import TakeoffNormalizeRequest, TakeoffNormalizeResponse
 from app.schemas.takeoff_persistence import TakeoffList, TakeoffRead, TakeoffSaveRequest
 from app.services import takeoff_persistence
 from app.services.takeoff import run_takeoff_engine, summarize_quantity_register
+from app.services.takeoff_normalization import normalize_takeoff
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
@@ -22,6 +29,11 @@ def summarize(payload: QuantityRegisterRequest) -> QuantityRegisterResponse:
 @router.post("/engine", response_model=TakeoffEngineResponse)
 def engine(payload: TakeoffEngineRequest) -> TakeoffEngineResponse:
     return run_takeoff_engine(payload)
+
+
+@router.post("/normalize", response_model=TakeoffNormalizeResponse)
+def normalize(payload: TakeoffNormalizeRequest) -> TakeoffNormalizeResponse:
+    return normalize_takeoff(payload)
 
 
 @router.post("/save", response_model=TakeoffRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/schemas/takeoff_normalization.py
+++ b/backend/app/schemas/takeoff_normalization.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel, Field
+
+from app.schemas.takeoff import EstimateReadyItem, QuantityItem
+
+
+class TakeoffNormalizeRequest(BaseModel):
+    project_name: str | None = None
+    project_id: str | None = None
+    items: list[QuantityItem] = Field(default_factory=list)
+    minimum_confidence: float = Field(default=0.7, ge=0, le=1)
+    combine_duplicates: bool = True
+    require_drawing_reference: bool = True
+
+
+class TakeoffDuplicateGroup(BaseModel):
+    key: str
+    item_count: int
+    combined_quantity: float
+    unit: str
+    drawing_references: list[str] = Field(default_factory=list)
+
+
+class TakeoffNormalizeResponse(BaseModel):
+    normalized_items: list[QuantityItem]
+    estimate_handoff_items: list[EstimateReadyItem]
+    duplicate_groups: list[TakeoffDuplicateGroup]
+    rejected_items: list[QuantityItem]
+    warnings: list[str]
+    input_count: int
+    normalized_count: int
+    estimate_ready_count: int

--- a/backend/app/services/takeoff_normalization.py
+++ b/backend/app/services/takeoff_normalization.py
@@ -1,0 +1,102 @@
+from collections import defaultdict
+
+from app.schemas.takeoff import EstimateReadyItem, QuantityItem
+from app.schemas.takeoff_normalization import (
+    TakeoffDuplicateGroup,
+    TakeoffNormalizeRequest,
+    TakeoffNormalizeResponse,
+)
+
+
+def normalize_takeoff(payload: TakeoffNormalizeRequest) -> TakeoffNormalizeResponse:
+    grouped: dict[str, list[QuantityItem]] = defaultdict(list)
+    rejected: list[QuantityItem] = []
+    warnings: list[str] = []
+
+    for item in payload.items:
+        reason = _rejection_reason(item, payload)
+        if reason:
+            rejected.append(item)
+            warnings.append(f"{item.description}: {reason}")
+            continue
+        grouped[_dedupe_key(item)].append(item)
+
+    normalized: list[QuantityItem] = []
+    duplicate_groups: list[TakeoffDuplicateGroup] = []
+    for key, items in sorted(grouped.items()):
+        if payload.combine_duplicates and len(items) > 1:
+            combined = _combine_items(items)
+            normalized.append(combined)
+            duplicate_groups.append(
+                TakeoffDuplicateGroup(
+                    key=key,
+                    item_count=len(items),
+                    combined_quantity=combined.quantity,
+                    unit=combined.unit,
+                    drawing_references=sorted(
+                        {item.drawing_reference for item in items if item.drawing_reference}
+                    ),
+                )
+            )
+            warnings.append(f"Combined {len(items)} duplicate takeoff items for {combined.description}.")
+        else:
+            normalized.extend(items)
+
+    handoff = [_to_handoff(item) for item in normalized if item.estimate_ready]
+    return TakeoffNormalizeResponse(
+        normalized_items=normalized,
+        estimate_handoff_items=handoff,
+        duplicate_groups=duplicate_groups,
+        rejected_items=rejected,
+        warnings=warnings,
+        input_count=len(payload.items),
+        normalized_count=len(normalized),
+        estimate_ready_count=len(handoff),
+    )
+
+
+def _rejection_reason(item: QuantityItem, payload: TakeoffNormalizeRequest) -> str | None:
+    if item.quantity <= 0:
+        return "quantity must be greater than zero"
+    if item.confidence < payload.minimum_confidence:
+        return f"confidence {item.confidence:.2f} is below {payload.minimum_confidence:.2f}"
+    if payload.require_drawing_reference and not item.drawing_reference:
+        return "drawing reference is required"
+    return None
+
+
+def _dedupe_key(item: QuantityItem) -> str:
+    code_or_description = (item.code or item.description).strip().lower()
+    return "|".join([code_or_description, item.category, item.unit, item.revision or ""])
+
+
+def _combine_items(items: list[QuantityItem]) -> QuantityItem:
+    first = items[0]
+    references = sorted({item.drawing_reference for item in items if item.drawing_reference})
+    notes = [item.notes for item in items if item.notes]
+    return first.model_copy(
+        update={
+            "quantity": round(sum(item.quantity for item in items), 3),
+            "confidence": round(min(item.confidence for item in items), 3),
+            "estimate_ready": all(item.estimate_ready for item in items),
+            "drawing_reference": ", ".join(references) or None,
+            "notes": "; ".join(notes) or first.notes,
+        }
+    )
+
+
+def _to_handoff(item: QuantityItem) -> EstimateReadyItem:
+    return EstimateReadyItem(
+        code=item.code,
+        description=item.description,
+        category=item.category,
+        quantity=item.quantity,
+        unit=item.unit,
+        source=item.source,
+        confidence=item.confidence,
+        drawing_reference=item.drawing_reference,
+        notes=item.notes,
+        takeoff_method=item.takeoff_method,
+        scale=item.scale,
+        revision=item.revision,
+    )

--- a/backend/tests/test_takeoff_normalization.py
+++ b/backend/tests/test_takeoff_normalization.py
@@ -1,0 +1,100 @@
+from app.schemas.takeoff import QuantityItem
+from app.schemas.takeoff_normalization import TakeoffNormalizeRequest
+from app.services.takeoff_normalization import normalize_takeoff
+
+
+def test_normalize_combines_duplicate_drawing_quantities() -> None:
+    payload = TakeoffNormalizeRequest(
+        items=[
+            QuantityItem(
+                code="03-100",
+                description="PVC storm pipe",
+                category="pipe",
+                quantity=42,
+                unit="m",
+                confidence=0.95,
+                drawing_reference="C-201",
+                revision="2",
+            ),
+            QuantityItem(
+                code="03-100",
+                description="PVC storm pipe",
+                category="pipe",
+                quantity=18,
+                unit="m",
+                confidence=0.9,
+                drawing_reference="C-202",
+                revision="2",
+            ),
+        ]
+    )
+
+    result = normalize_takeoff(payload)
+
+    assert result.input_count == 2
+    assert result.normalized_count == 1
+    assert result.normalized_items[0].quantity == 60
+    assert result.normalized_items[0].drawing_reference == "C-201, C-202"
+    assert result.duplicate_groups[0].item_count == 2
+    assert result.estimate_ready_count == 1
+
+
+def test_normalize_rejects_low_confidence_and_missing_reference() -> None:
+    payload = TakeoffNormalizeRequest(
+        minimum_confidence=0.8,
+        items=[
+            QuantityItem(
+                description="Unverified excavation",
+                category="earthworks",
+                quantity=100,
+                unit="m3",
+                confidence=0.6,
+            ),
+            QuantityItem(
+                description="Sidewalk area",
+                category="concrete",
+                quantity=55,
+                unit="m2",
+                confidence=0.95,
+            ),
+        ],
+    )
+
+    result = normalize_takeoff(payload)
+
+    assert result.normalized_count == 0
+    assert len(result.rejected_items) == 2
+    assert any("below 0.80" in warning for warning in result.warnings)
+    assert any("drawing reference is required" in warning for warning in result.warnings)
+
+
+def test_normalize_preserves_revision_boundaries() -> None:
+    payload = TakeoffNormalizeRequest(
+        items=[
+            QuantityItem(
+                code="05-100",
+                description="Asphalt paving",
+                category="asphalt",
+                quantity=20,
+                unit="t",
+                confidence=1,
+                drawing_reference="C-401",
+                revision="1",
+            ),
+            QuantityItem(
+                code="05-100",
+                description="Asphalt paving",
+                category="asphalt",
+                quantity=25,
+                unit="t",
+                confidence=1,
+                drawing_reference="C-401",
+                revision="2",
+            ),
+        ]
+    )
+
+    result = normalize_takeoff(payload)
+
+    assert result.normalized_count == 2
+    assert result.duplicate_groups == []

--- a/docs/builds/BUILD_194.md
+++ b/docs/builds/BUILD_194.md
@@ -1,0 +1,23 @@
+# Build 194 — Quantity Takeoff Normalization
+
+Build 194 adds a deterministic normalization gate between drawing takeoff and estimating.
+
+## Delivered
+
+- Duplicate detection by cost code/description, category, unit, and revision
+- Optional duplicate quantity consolidation
+- Drawing-reference requirements
+- Configurable minimum-confidence threshold
+- Zero-quantity rejection
+- Revision boundaries that prevent obsolete/current quantities from being combined
+- Estimate-ready handoff items
+- Audit warnings and rejected-item reporting
+- `POST /api/v1/takeoff/normalize`
+
+## Boundary
+
+This build normalizes structured takeoff data. Direct PDF geometry recognition and autonomous drawing measurement remain separate drawing-processing work.
+
+## Validation gate
+
+Backend install, Ruff, pytest, frontend install, lint, tests, and production build must pass before merge. The exact merged `main` baseline must then pass separately before Build 195 begins.


### PR DESCRIPTION
## Summary
Implements Build 194 as real takeoff-to-estimating application code.

## Changes
- Adds structured takeoff normalization schemas
- Detects and optionally combines duplicate quantities
- Enforces minimum-confidence and drawing-reference gates
- Rejects zero-quantity items
- Preserves drawing revision boundaries
- Produces estimate-ready handoff items
- Adds `POST /api/v1/takeoff/normalize`
- Adds regression tests and build documentation

## Boundary
This build normalizes structured takeoff data. Direct PDF geometry recognition and autonomous drawing measurement remain separate drawing-processing work.

## Validation requested
- Backend dependency installation
- Ruff lint
- Pytest, including `test_takeoff_normalization.py`
- Frontend dependency installation, lint, tests, and production build

Build 195 remains locked until this PR and the exact merged-main baseline are green.