### PR TITLE
Validate main after Build 194

### DIFF
--- a/docs/validation/MAIN_AFTER_BUILD_194.md
+++ b/docs/validation/MAIN_AFTER_BUILD_194.md
@@ -1,0 +1,5 @@
+# Main validation after Build 194
+
+Baseline commit: `9b118b959c6a8cb9ebd17f09121f3db8967a3988`
+
+This marker exists only to trigger backend and frontend CI against the exact merged Build 194 baseline.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Build 194. This PR contains only a validation marker and must pass backend and frontend CI before Build 195 begins.