### PR TITLE
Builds 195-200: estimating acceptance gate

### DIFF
--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.v1.routes import (
     auth,
     bid_package,
+    bid_readiness,
     bids,
     cost_codes,
     documents,
@@ -27,6 +28,7 @@ api_router.include_router(suppliers.router, prefix="/suppliers", tags=["supplier
 api_router.include_router(rfqs.router, prefix="/rfqs", tags=["rfqs"])
 api_router.include_router(rfq_automation.router, prefix="/rfq-automation", tags=["rfq-automation"])
 api_router.include_router(bid_package.router, prefix="/bid-package", tags=["bid-package"])
+api_router.include_router(bid_readiness.router, prefix="/bid-readiness", tags=["bid-readiness"])
 api_router.include_router(bids.router, prefix="/bids", tags=["bids"])
 api_router.include_router(estimates.router, prefix="/estimates", tags=["estimates"])
 api_router.include_router(cost_codes.router, prefix="/cost-codes", tags=["cost-codes"])

--- a/backend/app/api/v1/routes/bid_readiness.py
+++ b/backend/app/api/v1/routes/bid_readiness.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+from app.schemas.bid_readiness import BidReadinessRequest, BidReadinessResponse
+from app.services.bid_readiness import evaluate_bid_readiness
+
+router = APIRouter()
+
+
+@router.post("/evaluate", response_model=BidReadinessResponse)
+def evaluate(payload: BidReadinessRequest) -> BidReadinessResponse:
+    return evaluate_bid_readiness(payload)

--- a/backend/app/schemas/bid_readiness.py
+++ b/backend/app/schemas/bid_readiness.py
@@ -1,0 +1,74 @@
+from pydantic import BaseModel, Field
+
+
+class MunicipalityAdjustment(BaseModel):
+    municipality: str
+    label: str
+    percentage: float = Field(default=0, ge=0)
+    fixed_cost: float = Field(default=0, ge=0)
+    requirement: str | None = None
+
+
+class RFQReadinessInput(BaseModel):
+    required_categories: list[str] = Field(default_factory=list)
+    covered_categories: list[str] = Field(default_factory=list)
+    required_documents: list[str] = Field(default_factory=list)
+    attached_documents: list[str] = Field(default_factory=list)
+
+
+class QuoteCandidate(BaseModel):
+    supplier: str
+    amount: float = Field(ge=0)
+    scope_complete: bool = True
+    exclusions_count: int = Field(default=0, ge=0)
+    confidence: float = Field(default=1, ge=0, le=1)
+
+
+class EquipmentCandidate(BaseModel):
+    name: str
+    hourly_rate: float = Field(ge=0)
+    estimated_hours: float = Field(ge=0)
+    mobilization: float = Field(default=0, ge=0)
+    fuel_surcharge: float = Field(default=0, ge=0)
+
+
+class RiskItem(BaseModel):
+    label: str
+    probability: float = Field(ge=0, le=1)
+    impact: float = Field(ge=0)
+    included_in_price: bool = False
+
+
+class BidReadinessRequest(BaseModel):
+    project_name: str
+    direct_cost: float = Field(ge=0)
+    markup_percentage: float = Field(default=30, ge=0)
+    municipality_adjustments: list[MunicipalityAdjustment] = Field(default_factory=list)
+    rfq: RFQReadinessInput = Field(default_factory=RFQReadinessInput)
+    quotes: list[QuoteCandidate] = Field(default_factory=list)
+    equipment: list[EquipmentCandidate] = Field(default_factory=list)
+    risks: list[RiskItem] = Field(default_factory=list)
+    assumptions: list[str] = Field(default_factory=list)
+    exclusions: list[str] = Field(default_factory=list)
+
+
+class RankedOption(BaseModel):
+    name: str
+    total_cost: float
+    score: float | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class BidReadinessResponse(BaseModel):
+    municipality_cost: float
+    adjusted_cost: float
+    contingency: float
+    recommended_quote: RankedOption | None
+    recommended_equipment: RankedOption | None
+    rfq_ready: bool
+    missing_rfq_categories: list[str]
+    missing_rfq_documents: list[str]
+    tender_price: float
+    package_ready: bool
+    blockers: list[str]
+    warnings: list[str]

--- a/backend/app/services/bid_readiness.py
+++ b/backend/app/services/bid_readiness.py
@@ -1,0 +1,85 @@
+from app.schemas.bid_readiness import BidReadinessRequest, BidReadinessResponse, RankedOption
+
+
+def evaluate_bid_readiness(payload: BidReadinessRequest) -> BidReadinessResponse:
+    municipality_cost = round(
+        sum(payload.direct_cost * item.percentage / 100 + item.fixed_cost for item in payload.municipality_adjustments),
+        2,
+    )
+    adjusted_cost = round(payload.direct_cost + municipality_cost, 2)
+
+    missing_categories = sorted(set(payload.rfq.required_categories) - set(payload.rfq.covered_categories))
+    missing_documents = sorted(set(payload.rfq.required_documents) - set(payload.rfq.attached_documents))
+    rfq_ready = not missing_categories and not missing_documents
+
+    recommended_quote = _recommend_quote(payload)
+    recommended_equipment = _recommend_equipment(payload)
+    contingency = round(
+        sum(item.probability * item.impact for item in payload.risks if not item.included_in_price),
+        2,
+    )
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if payload.direct_cost <= 0:
+        blockers.append("Direct cost must be greater than zero.")
+    if missing_categories:
+        blockers.append("RFQ coverage is incomplete.")
+    if missing_documents:
+        blockers.append("Required RFQ documents are missing.")
+    if payload.quotes and recommended_quote is None:
+        blockers.append("No supplier quote is suitable for award.")
+    if not payload.assumptions:
+        warnings.append("Bid assumptions have not been recorded.")
+    if not payload.exclusions:
+        warnings.append("Bid exclusions have not been recorded.")
+    for adjustment in payload.municipality_adjustments:
+        if adjustment.requirement and adjustment.percentage == 0 and adjustment.fixed_cost == 0:
+            warnings.append(f"Municipal requirement needs pricing review: {adjustment.requirement}")
+
+    tender_price = round((adjusted_cost + contingency) * (1 + payload.markup_percentage / 100), 2)
+    package_ready = not blockers and bool(payload.assumptions) and bool(payload.exclusions)
+    return BidReadinessResponse(
+        municipality_cost=municipality_cost,
+        adjusted_cost=adjusted_cost,
+        contingency=contingency,
+        recommended_quote=recommended_quote,
+        recommended_equipment=recommended_equipment,
+        rfq_ready=rfq_ready,
+        missing_rfq_categories=missing_categories,
+        missing_rfq_documents=missing_documents,
+        tender_price=tender_price,
+        package_ready=package_ready,
+        blockers=blockers,
+        warnings=warnings,
+    )
+
+
+def _recommend_quote(payload: BidReadinessRequest) -> RankedOption | None:
+    ranked: list[RankedOption] = []
+    for quote in payload.quotes:
+        if not quote.scope_complete or quote.amount <= 0:
+            continue
+        penalty = quote.exclusions_count * 5 + (1 - quote.confidence) * 20
+        score = round(100 - penalty, 2)
+        warnings = []
+        if quote.exclusions_count:
+            warnings.append(f"{quote.exclusions_count} exclusions require review.")
+        ranked.append(RankedOption(name=quote.supplier, total_cost=quote.amount, score=score, warnings=warnings))
+    if not ranked:
+        return None
+    return sorted(ranked, key=lambda item: (-float(item.score or 0), item.total_cost, item.name))[0]
+
+
+def _recommend_equipment(payload: BidReadinessRequest) -> RankedOption | None:
+    options = [
+        RankedOption(
+            name=item.name,
+            total_cost=round(item.hourly_rate * item.estimated_hours + item.mobilization + item.fuel_surcharge, 2),
+        )
+        for item in payload.equipment
+        if item.estimated_hours > 0
+    ]
+    if not options:
+        return None
+    return sorted(options, key=lambda item: (item.total_cost, item.name))[0]

--- a/backend/tests/test_bid_readiness.py
+++ b/backend/tests/test_bid_readiness.py
@@ -1,0 +1,93 @@
+from app.schemas.bid_readiness import (
+    BidReadinessRequest,
+    EquipmentCandidate,
+    MunicipalityAdjustment,
+    QuoteCandidate,
+    RFQReadinessInput,
+    RiskItem,
+)
+from app.services.bid_readiness import evaluate_bid_readiness
+
+
+def test_bid_readiness_builds_complete_tender_gate() -> None:
+    result = evaluate_bid_readiness(
+        BidReadinessRequest(
+            project_name="Marine Drive",
+            direct_cost=100000,
+            markup_percentage=30,
+            municipality_adjustments=[
+                MunicipalityAdjustment(
+                    municipality="Surrey",
+                    label="Supplementary standards",
+                    percentage=2,
+                    fixed_cost=1500,
+                    requirement="Additional testing and restoration controls",
+                )
+            ],
+            rfq=RFQReadinessInput(
+                required_categories=["pipe", "asphalt"],
+                covered_categories=["pipe", "asphalt"],
+                required_documents=["drawings", "specifications"],
+                attached_documents=["drawings", "specifications"],
+            ),
+            quotes=[
+                QuoteCandidate(supplier="EMCO", amount=18000, scope_complete=True, confidence=0.98),
+                QuoteCandidate(supplier="Alternate", amount=17000, scope_complete=True, exclusions_count=4),
+            ],
+            equipment=[
+                EquipmentCandidate(name="Rental A", hourly_rate=160, estimated_hours=80, mobilization=1200),
+                EquipmentCandidate(name="Rental B", hourly_rate=150, estimated_hours=80, mobilization=2500),
+            ],
+            risks=[RiskItem(label="Unknown subgrade", probability=0.25, impact=20000)],
+            assumptions=["Normal working hours"],
+            exclusions=["Contaminated soil disposal"],
+        )
+    )
+
+    assert result.municipality_cost == 3500
+    assert result.adjusted_cost == 103500
+    assert result.contingency == 5000
+    assert result.recommended_quote is not None
+    assert result.recommended_quote.name == "EMCO"
+    assert result.recommended_equipment is not None
+    assert result.recommended_equipment.name == "Rental A"
+    assert result.rfq_ready is True
+    assert result.package_ready is True
+    assert result.tender_price == 141050
+
+
+def test_bid_readiness_blocks_incomplete_rfq_package() -> None:
+    result = evaluate_bid_readiness(
+        BidReadinessRequest(
+            project_name="Storage Shed",
+            direct_cost=50000,
+            rfq=RFQReadinessInput(
+                required_categories=["concrete", "testing"],
+                covered_categories=["concrete"],
+                required_documents=["drawings"],
+                attached_documents=[],
+            ),
+        )
+    )
+
+    assert result.rfq_ready is False
+    assert result.missing_rfq_categories == ["testing"]
+    assert result.missing_rfq_documents == ["drawings"]
+    assert result.package_ready is False
+    assert "RFQ coverage is incomplete." in result.blockers
+    assert "Required RFQ documents are missing." in result.blockers
+
+
+def test_bid_readiness_skips_incomplete_supplier_quotes() -> None:
+    result = evaluate_bid_readiness(
+        BidReadinessRequest(
+            project_name="Bike Path",
+            direct_cost=25000,
+            quotes=[QuoteCandidate(supplier="Incomplete", amount=10000, scope_complete=False)],
+            assumptions=["Traffic windows confirmed"],
+            exclusions=["Night work"],
+        )
+    )
+
+    assert result.recommended_quote is None
+    assert "No supplier quote is suitable for award." in result.blockers

--- a/docs/builds/195-200-estimating-gate.md
+++ b/docs/builds/195-200-estimating-gate.md
@@ -1,0 +1,37 @@
+# Builds 195–200 — Estimating Acceptance Gate
+
+This block closes the first complete estimating workflow.
+
+## Build 195 — Municipality adjustments
+
+Applies percentage and fixed-cost adjustments for supplementary standards, testing, restoration, permits, traffic, and other municipality-driven requirements.
+
+## Build 196 — RFQ readiness
+
+Checks required supplier categories and required package documents before an RFQ package is considered complete.
+
+## Build 197 — Quote recommendation
+
+Ranks complete supplier quotes using scope completeness, exclusions, confidence, and price. Incomplete quotes are not recommended.
+
+## Build 198 — Equipment optimization
+
+Compares equipment options using hourly cost, estimated hours, mobilization, and fuel surcharges.
+
+## Build 199 — Risk and contingency
+
+Calculates expected-value contingency from probability and cost impact while avoiding risks already included in price.
+
+## Build 200 — Bid package acceptance
+
+Produces an adjusted cost, contingency, tender price, blockers, warnings, and final package-ready decision through:
+
+`POST /api/v1/bid-readiness/evaluate`
+
+## Boundary
+
+Municipality requirements must be supplied from reviewed project standards. This build does not claim that every BC municipality standard is automatically current or complete. Supplier pricing and takeoff quantities must pass their existing Build 193 and Build 194 gates before final bid review.
+
+## Validation
+
+Backend installation, Ruff, pytest, frontend installation, lint, tests, and production build must pass. The exact merged `main` baseline must then pass a separate validation PR.


### PR DESCRIPTION
## Summary
Implements Builds 195–200 as real estimating application code.

## Delivered
- Municipality-driven percentage and fixed-cost adjustments
- RFQ category and document readiness checks
- Supplier quote recommendation with completeness, exclusions, confidence, and price
- Equipment option optimization using hours, rates, mobilization, and fuel
- Expected-value risk contingency
- Final tender price, blockers, warnings, and package-ready acceptance decision
- `POST /api/v1/bid-readiness/evaluate`
- Regression tests and build documentation

## Boundary
Municipality requirements must come from reviewed current project standards. This build does not claim a fully autonomous or universally current BC standards database.

## Validation requested
- Backend dependency installation
- Ruff lint
- Pytest, including `test_bid_readiness.py`
- Frontend dependency installation, lint, tests, and production build
- Separate exact-main validation after merge