### PR TITLE
Validate main after Build 200

### DIFF
--- a/docs/validation/main-after-build-200.md
+++ b/docs/validation/main-after-build-200.md
@@ -1,0 +1,5 @@
+# Main validation after Build 200
+
+Baseline merge commit: `b12c42b69d458fae801afa489e6c2ce8bbd4697c`
+
+This marker triggers the complete backend and frontend CI gate against the exact merged Builds 195–200 baseline.


### PR DESCRIPTION
Validates the exact merged `main` baseline after Builds 195–200. This PR contains only a validation marker and must pass backend and frontend CI before Build 200 is declared complete.