### PR TITLE
Build 201: complete estimate workbook contract

### DIFF
--- a/backend/app/services/estimate_workbooks.py
+++ b/backend/app/services/estimate_workbooks.py
@@ -32,6 +32,7 @@ def build_estimate_workbook(payload: EstimateCreate) -> bytes:
     _build_markups_sheet(workbook, payload, summary)
     _build_risks_sheet(workbook, payload)
     _build_assumptions_sheet(workbook, summary)
+    _build_exclusions_sheet(workbook, summary)
     _build_quote_comparison_sheet(workbook, payload)
 
     stream = BytesIO()
@@ -126,7 +127,8 @@ def _build_line_items_sheet(workbook: Workbook, summary: EstimateSummary) -> Non
 
     total_row = len(summary.line_items) + 5
     sheet.cell(row=total_row, column=11, value="Total Direct Cost")
-    sheet.cell(row=total_row, column=12, value=f"=SUM(L4:L{total_row - 2})")
+    total_formula = f"=SUM(L4:L{total_row - 2})" if summary.line_items else "=0"
+    sheet.cell(row=total_row, column=12, value=total_formula)
     sheet.cell(row=total_row, column=12).number_format = MONEY_FORMAT
     _fill_row(sheet, total_row, 11, 12, SUBTOTAL_FILL)
     sheet.cell(row=total_row, column=11).font = Font(bold=True)
@@ -239,18 +241,28 @@ def _build_risks_sheet(workbook: Workbook, payload: EstimateCreate) -> None:
 
 def _build_assumptions_sheet(workbook: Workbook, summary: EstimateSummary) -> None:
     sheet = workbook.create_sheet("Assumptions")
-    _title(sheet, "Assumptions and Exclusions")
-    sheet.cell(row=3, column=1, value="Assumptions")
-    sheet.cell(row=3, column=2, value="Exclusions")
-    _header_row(sheet, 3, 1, 2)
-    max_rows = max(len(summary.assumptions), len(summary.exclusions), 1)
-    for offset in range(max_rows):
-        row_index = offset + 4
-        sheet.cell(row=row_index, column=1, value=_safe_list_value(summary.assumptions, offset))
-        sheet.cell(row=row_index, column=2, value=_safe_list_value(summary.exclusions, offset))
-    _apply_borders(sheet, 3, 1, max_rows + 3, 2)
-    _set_widths(sheet, {"A": 60, "B": 60})
+    _title(sheet, "Estimate Assumptions")
+    sheet.cell(row=3, column=1, value="Assumption")
+    _header_row(sheet, 3, 1, 1)
+    if not summary.assumptions:
+        sheet.cell(row=4, column=1, value="No assumptions entered.")
+    for row_index, assumption in enumerate(summary.assumptions, start=4):
+        sheet.cell(row=row_index, column=1, value=assumption)
+    _apply_borders(sheet, 3, 1, max(4, len(summary.assumptions) + 3), 1)
+    _set_widths(sheet, {"A": 100})
 
+
+def _build_exclusions_sheet(workbook: Workbook, summary: EstimateSummary) -> None:
+    sheet = workbook.create_sheet("Exclusions")
+    _title(sheet, "Estimate Exclusions")
+    sheet.cell(row=3, column=1, value="Exclusion")
+    _header_row(sheet, 3, 1, 1)
+    if not summary.exclusions:
+        sheet.cell(row=4, column=1, value="No exclusions entered.")
+    for row_index, exclusion in enumerate(summary.exclusions, start=4):
+        sheet.cell(row=row_index, column=1, value=exclusion)
+    _apply_borders(sheet, 3, 1, max(4, len(summary.exclusions) + 3), 1)
+    _set_widths(sheet, {"A": 100})
 
 def _build_quote_comparison_sheet(workbook: Workbook, payload: EstimateCreate) -> None:
     sheet = workbook.create_sheet("Quote Comparison")
@@ -330,12 +342,6 @@ def _set_widths(sheet: Worksheet, widths: dict[str, int]) -> None:
     for row in range(1, sheet.max_row + 1):
         sheet.row_dimensions[row].height = 20
     sheet.freeze_panes = "A4"
-
-
-def _safe_list_value(values: list[str], index: int) -> str:
-    if index < len(values):
-        return values[index]
-    return ""
 
 
 def workbook_filename(project_name: str, project_code: str | None = None) -> str:

--- a/docs/estimate-workbook-generator.md
+++ b/docs/estimate-workbook-generator.md
@@ -14,16 +14,21 @@ Accepts the same estimate payload as `POST /api/v1/estimates/summary` and return
 - Markups
 - Risks
 - Assumptions
+- Exclusions
 - Quote Comparison
 
 ## Notes
 
 The generator lives in `backend/app/services/estimate_workbooks.py`.
 
-It uses the estimate engine to calculate the summary, then writes a formatted workbook for estimator review.
+It uses the estimate engine to calculate the summary, then writes a formatted workbook for estimator review. Assumptions and exclusions are kept on separate sheets so each can be reviewed and issued independently.
+
+The line-item total remains an estimator-readable Excel formula. Empty estimates use an explicit `=0` total instead of a reversed cell range.
 
 Required backend dependency:
 
 `openpyxl==3.1.5`
 
-If the dependency is not already installed, add it to `backend/requirements.txt`.
+The dependency is pinned in `backend/requirements.txt`.
+
+Regression coverage lives in `tests/backend/test_estimate_workbooks.py` and verifies the sheet contract, formula output, quote selection display, empty-state wording, and safe filenames.

--- a/tests/backend/test_estimate_workbooks.py
+++ b/tests/backend/test_estimate_workbooks.py
@@ -1,0 +1,90 @@
+from io import BytesIO
+
+from openpyxl import load_workbook
+
+from app.schemas.estimate import (
+    EstimateCreate,
+    EstimateLineItem,
+    EstimateMarkup,
+    EstimateRiskAllowance,
+    EstimateUnit,
+    VendorQuoteInput,
+)
+from app.services.estimate_workbooks import build_estimate_workbook, workbook_filename
+
+EXPECTED_SHEETS = [
+    "Summary",
+    "Line Items",
+    "Production Rates",
+    "Markups",
+    "Risks",
+    "Assumptions",
+    "Exclusions",
+    "Quote Comparison",
+]
+
+
+def test_workbook_contains_complete_estimator_sheet_contract() -> None:
+    payload = EstimateCreate(
+        project_name="Marine Drive Parking Lot",
+        project_code="WR26-012",
+        line_items=[
+            EstimateLineItem(
+                code="PIPE-001",
+                description="Supply and install PVC storm pipe",
+                quantity=100,
+                unit=EstimateUnit.metre,
+                direct_unit_cost=50,
+                vendor_quotes=[
+                    VendorQuoteInput(
+                        supplier="EMCO",
+                        scope="PVC pipe supply",
+                        amount=4200,
+                        is_selected=True,
+                        notes="Qualified selected quote",
+                    )
+                ],
+            )
+        ],
+        risks=[
+            EstimateRiskAllowance(
+                description="Unknown utilities",
+                amount=10000,
+                probability=0.25,
+            )
+        ],
+        markup=EstimateMarkup(
+            contingency_percent=5,
+            overhead_percent=10,
+            profit_percent=15,
+        ),
+        assumptions=["Normal working hours"],
+        exclusions=["Contaminated soil disposal"],
+    )
+
+    workbook = load_workbook(BytesIO(build_estimate_workbook(payload)), data_only=False)
+
+    assert workbook.sheetnames == EXPECTED_SHEETS
+    assert workbook["Assumptions"]["A4"].value == "Normal working hours"
+    assert workbook["Exclusions"]["A4"].value == "Contaminated soil disposal"
+    assert workbook["Line Items"]["L6"].value == "=SUM(L4:L4)"
+    assert workbook["Quote Comparison"]["B4"].value == "EMCO"
+    assert workbook["Quote Comparison"]["E4"].value == "Yes"
+
+
+def test_workbook_records_empty_assumptions_exclusions_and_line_items() -> None:
+    workbook = load_workbook(
+        BytesIO(build_estimate_workbook(EstimateCreate(project_name="Empty estimate"))),
+        data_only=False,
+    )
+
+    assert workbook["Assumptions"]["A4"].value == "No assumptions entered."
+    assert workbook["Exclusions"]["A4"].value == "No exclusions entered."
+    assert workbook["Line Items"]["L5"].value == "=0"
+
+
+def test_workbook_filename_is_safe_and_bounded() -> None:
+    filename = workbook_filename("Marine Drive / Parking Lot", "WR26-012")
+
+    assert filename == "WR26-012_Marine_Drive___Parking_Lot_Estimate.xlsx"
+    assert len(filename) <= 120


### PR DESCRIPTION
## What changed

- completes the eight-sheet estimate workbook contract required by issue #1
- separates Assumptions and Exclusions into independent estimator-review sheets
- uses an explicit `=0` line-item total for empty estimates
- adds regression tests for sheet order, formulas, quote display, empty states, and safe filenames
- updates the workbook generator documentation

## Why

The workbook generator and export endpoint already existed, but the queue item was not fully complete: exclusions were combined with assumptions, only seven sheets were produced, and no workbook-specific regression test covered the required contract.

## Validation

- Python syntax compilation passed for the modified service and new tests
- 3 workbook regression tests passed in an isolated local module harness using Pydantic 2.13.4 and openpyxl 3.1.5
- repository CI should run Ruff and the complete backend/frontend test gates

Closes the first unfinished requirement in #1.