### PR TITLE
Build 202: complete Estimate UI integration

### DIFF
--- a/docs/estimate-ui-integration.md
+++ b/docs/estimate-ui-integration.md
@@ -1,58 +1,38 @@
 # Estimate UI Integration
 
-## Current State
+## Status
 
-The frontend already has an Estimating page wired into the app route at `/estimating`.
+The Estimating page at `/estimating` is connected to the backend estimate engine and workbook export.
 
-Existing capabilities:
+Completed capabilities:
 
-- Loads production rate library from `GET /api/v1/estimates/rate-library`
-- Builds an estimate payload
-- Calculates estimate summary through `POST /api/v1/estimates/summary`
-- Downloads estimate workbook through `POST /api/v1/estimates/workbook`
-- Supports project name and code
-- Supports line item quantity, unit, direct unit cost, and default production activity
-- Supports mobilization, risk allowance, contingency, overhead, profit, bonding, and insurance
-- Displays final bid summary and gross margin
+- Loads production activity defaults from `GET /api/v1/estimates/rate-library`
+- Calculates estimates through `POST /api/v1/estimates/summary`
+- Downloads formatted workbooks through `POST /api/v1/estimates/workbook`
+- Supports project name and code with required-name validation
+- Supports line item quantity, unit, direct unit cost, and production activity defaults
+- Supports line-item disposal material, quantity, unit, disposal cost, haul cost, and facility
+- Supports a selected vendor quote with supplier, scope, amount, selected flag, and notes
+- Supports mobilization, disposal allowance, risk amount, risk probability, contingency, overhead, profit, bonding, and insurance
+- Displays bid totals, gross margin, category breakdown, per-line calculated cost, unit cost, and selected supplier
+- Blocks calculation and workbook export when the project name is empty
 
-## Next UI Improvements
+## Validation
 
-Add the remaining estimate engine fields to the Estimating page:
+The frontend test command runs the real Vitest suite:
 
-1. Disposal inputs
-   - Material
-   - Quantity
-   - Unit
-   - Disposal unit cost
-   - Haul cost
-   - Facility
+```bash
+cd frontend
+npm test
+```
 
-2. Vendor quote inputs
-   - Supplier
-   - Scope
-   - Amount
-   - Selected quote flag
-   - Notes
+`EstimatingPage.test.tsx` verifies:
 
-3. Risk probability
-   - Allow risk amount and probability to calculate expected risk value
+- production defaults load from the API
+- line item, disposal, quote, risk, and markup data reach the summary endpoint
+- the returned bid summary and selected supplier render
+- missing project names block summary and workbook requests
 
-4. Category breakdown display
-   - Labour
-   - Equipment
-   - Material
-   - Disposal
-   - Subcontract
-   - Indirect
-   - Risk
+## Next Queue Boundary
 
-5. Validation and UX
-   - Prevent workbook download when project name is empty
-   - Show selected quote supplier beside line item result
-   - Add clear note when the lowest quote is not selected
-
-## Implementation Notes
-
-Frontend estimate API types should include `DisposalInput` and `EstimateLineItem.disposal` so the UI matches the backend schema.
-
-Backend workbook export is already available at `/api/v1/estimates/workbook`.
+Multiple supplier quotes, qualified-low selection, and non-low selection reasons remain part of the separate supplier quote integration task in issue #1.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "tsc --noEmit",
-    "test": "node -e \"console.log('frontend smoke test ok')\"",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/src/api/estimates.ts
+++ b/frontend/src/api/estimates.ts
@@ -40,6 +40,15 @@ export type MaterialInput = {
   waste_percent: number;
 };
 
+export type DisposalInput = {
+  material: string;
+  quantity: number;
+  unit: EstimateUnit;
+  unit_cost: number;
+  haul_cost: number;
+  facility?: string | null;
+};
+
 export type VendorQuoteInput = {
   supplier: string;
   scope: string;
@@ -59,6 +68,7 @@ export type EstimateLineItem = {
   labour: LabourCrewMember[];
   equipment: EquipmentResource[];
   materials: MaterialInput[];
+  disposal: DisposalInput[];
   vendor_quotes: VendorQuoteInput[];
   direct_unit_cost?: number | null;
   notes?: string | null;

--- a/frontend/src/pages/EstimatingPage.test.tsx
+++ b/frontend/src/pages/EstimatingPage.test.tsx
@@ -1,0 +1,198 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EstimatingPage } from "./EstimatingPage";
+
+const summaryPayloads: Record<string, unknown>[] = [];
+
+const rateLibrary = {
+  production_rates: [
+    {
+      activity: "excavation",
+      description: "Bulk excavation and loading",
+      unit: "m3",
+      production_rate_per_hour: 30,
+      crew: [],
+      equipment: [],
+      notes: "Normal access",
+    },
+  ],
+};
+
+const estimateSummary = {
+  project_name: "Marine Drive Parking Lot",
+  project_code: "WR26-012",
+  direct_cost: 10000,
+  indirect_cost: 1000,
+  risk_cost: 500,
+  subtotal_before_markup: 11500,
+  contingency: 575,
+  bonding: 0,
+  insurance: 0,
+  overhead: 603.75,
+  profit: 1267.88,
+  final_price: 13946.63,
+  gross_margin_percent: 28.3,
+  category_breakdown: {
+    labour: 2500,
+    equipment: 3000,
+    material: 1500,
+    disposal: 500,
+    subcontract: 2500,
+    indirect: 1000,
+    risk: 500,
+  },
+  line_items: [
+    {
+      code: "31-001",
+      description: "Excavation",
+      item_type: "self_perform",
+      quantity: 25,
+      unit: "m3",
+      hours: 0.83,
+      labour_cost: 2500,
+      equipment_cost: 3000,
+      material_cost: 0,
+      disposal_cost: 500,
+      subcontract_cost: 4000,
+      direct_cost: 10000,
+      unit_cost: 400,
+      selected_quote_supplier: "Qualified Hauling",
+      selected_quote_amount: 4000,
+    },
+  ],
+  assumptions: ["Normal working hours"],
+  exclusions: ["Contaminated soil disposal"],
+};
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("EstimatingPage", () => {
+  beforeEach(() => {
+    summaryPayloads.length = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/estimates/rate-library")) return jsonResponse(rateLibrary);
+        if (url.endsWith("/estimates/summary")) {
+          summaryPayloads.push(JSON.parse(String(init?.body)));
+          return jsonResponse(estimateSummary);
+        }
+        throw new Error(`Unexpected request: ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("submits production, disposal, quote, risk, and markup inputs and renders the summary", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <EstimatingPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("option", { name: "Excavation — 30/hr" });
+
+    const quantity = screen.getByLabelText("Line item 1 quantity");
+    await user.clear(quantity);
+    await user.type(quantity, "25");
+    await user.selectOptions(screen.getByLabelText("Line item 1 production activity"), "excavation");
+
+    await user.type(screen.getByLabelText("Line item 1 quote supplier"), "Qualified Hauling");
+    await user.clear(screen.getByLabelText("Line item 1 quoted scope"));
+    await user.type(screen.getByLabelText("Line item 1 quoted scope"), "Haul excavated material");
+    await user.clear(screen.getByLabelText("Line item 1 quote amount"));
+    await user.type(screen.getByLabelText("Line item 1 quote amount"), "4000");
+    await user.type(screen.getByLabelText("Line item 1 quote notes"), "Complete scope");
+
+    await user.type(screen.getByLabelText("Line item 1 disposal material"), "Native soil");
+    await user.clear(screen.getByLabelText("Line item 1 disposal quantity"));
+    await user.type(screen.getByLabelText("Line item 1 disposal quantity"), "20");
+    await user.clear(screen.getByLabelText("Line item 1 disposal unit cost"));
+    await user.type(screen.getByLabelText("Line item 1 disposal unit cost"), "18");
+    await user.clear(screen.getByLabelText("Line item 1 disposal haul cost"));
+    await user.type(screen.getByLabelText("Line item 1 disposal haul cost"), "7");
+    await user.type(screen.getByLabelText("Line item 1 disposal facility"), "Valley Transfer");
+
+    await user.click(screen.getByRole("button", { name: /Calculate/i }));
+
+    expect(await screen.findByText("$13,947")).toBeInTheDocument();
+    expect(screen.getByText("Selected supplier: Qualified Hauling")).toBeInTheDocument();
+
+    await waitFor(() => expect(summaryPayloads).toHaveLength(1));
+    const submitted = summaryPayloads[0];
+    expect(submitted.line_items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          quantity: 25,
+          default_activity: "excavation",
+          disposal: [
+            expect.objectContaining({
+              material: "Native soil",
+              quantity: 20,
+              unit_cost: 18,
+              haul_cost: 7,
+              facility: "Valley Transfer",
+            }),
+          ],
+          vendor_quotes: [
+            expect.objectContaining({
+              supplier: "Qualified Hauling",
+              amount: 4000,
+              notes: "Complete scope",
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(submitted.markup).toEqual(
+      expect.objectContaining({
+        contingency_percent: 10,
+        overhead_percent: 5,
+        profit_percent: 10,
+      }),
+    );
+    expect(submitted.risks).toEqual([
+      expect.objectContaining({ amount: 500, probability: 1 }),
+    ]);
+  });
+
+  it("blocks calculation and workbook export until a project name is entered", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <EstimatingPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("option", { name: "Excavation — 30/hr" });
+    fireEvent.change(screen.getByLabelText("Project name"), { target: { value: "" } });
+
+    await user.click(screen.getByRole("button", { name: /Calculate/i }));
+    expect(
+      await screen.findByText("Project name is required before calculating or exporting an estimate."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Workbook/i }));
+
+    const fetchMock = vi.mocked(fetch);
+    expect(
+      fetchMock.mock.calls.some(([input]) => String(input).endsWith("/estimates/summary")),
+    ).toBe(false);
+    expect(
+      fetchMock.mock.calls.some(([input]) => String(input).endsWith("/estimates/workbook")),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/pages/EstimatingPage.tsx
+++ b/frontend/src/pages/EstimatingPage.tsx
@@ -4,8 +4,10 @@ import { useLocation } from "react-router-dom";
 
 import {
   DefaultProductionActivity,
+  DisposalInput,
   EstimateCreate,
   EstimateLineItem,
+  EstimateLineItemCost,
   EstimateSummary,
   EstimateUnit,
   ProductionRate,
@@ -25,6 +27,7 @@ const defaultLineItem: EstimateLineItem = {
   labour: [],
   equipment: [],
   materials: [],
+  disposal: [],
   vendor_quotes: [],
   direct_unit_cost: null,
 };
@@ -116,12 +119,19 @@ export function EstimatingPage() {
     void loadRates();
   }, []);
 
+  function hasValidProjectName() {
+    if (projectName.trim()) return true;
+    setError("Project name is required before calculating or exporting an estimate.");
+    return false;
+  }
+
   async function calculateEstimate(event?: FormEvent) {
     event?.preventDefault();
+    if (!hasValidProjectName()) return;
     setIsCalculating(true);
     setError(null);
     try {
-      setSummary(await estimatesApi.summary(payload));
+      setSummary(await estimatesApi.summary({ ...payload, project_name: projectName.trim() }));
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to calculate estimate");
     } finally {
@@ -157,6 +167,7 @@ export function EstimatingPage() {
 
   async function downloadWorkbook() {
     setError(null);
+    if (!hasValidProjectName()) return;
     try {
       const response = await fetch(estimatesApi.workbookUrl(), {
         method: "POST",
@@ -203,7 +214,7 @@ export function EstimatingPage() {
           <div className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
             <h2 className="text-lg font-semibold text-iron-950">Project</h2>
             <div className="mt-4 grid gap-4 md:grid-cols-2">
-              <Input label="Project name" value={projectName} onChange={setProjectName} />
+              <Input label="Project name" value={projectName} onChange={setProjectName} required />
               <Input label="Project code" value={projectCode} onChange={setProjectCode} />
             </div>
           </div>
@@ -224,6 +235,7 @@ export function EstimatingPage() {
                   key={`${item.code}-${index}`}
                   item={item}
                   index={index}
+                  result={summary?.line_items[index]}
                   rates={rateLibrary}
                   onUpdate={updateLineItem}
                   onQuoteUpdate={updateQuote}
@@ -259,6 +271,7 @@ export function EstimatingPage() {
 function LineItemCard({
   item,
   index,
+  result,
   rates,
   onUpdate,
   onQuoteUpdate,
@@ -266,44 +279,84 @@ function LineItemCard({
 }: {
   item: EstimateLineItem;
   index: number;
+  result?: EstimateLineItemCost;
   rates: ProductionRate[];
   onUpdate: (index: number, patch: Partial<EstimateLineItem>) => void;
   onQuoteUpdate: (index: number, quote: VendorQuoteInput) => void;
   onRemove: (index: number) => void;
 }) {
   const quote = item.vendor_quotes[0] ?? { supplier: "", scope: item.description, amount: 0, is_selected: true, notes: "" };
+  const disposal: DisposalInput = item.disposal[0] ?? {
+    material: "",
+    quantity: 0,
+    unit: "t",
+    unit_cost: 0,
+    haul_cost: 0,
+    facility: "",
+  };
+
+  function updateDisposal(next: DisposalInput) {
+    const hasValue = Boolean(next.material || next.facility || next.quantity || next.unit_cost || next.haul_cost);
+    onUpdate(index, { disposal: hasValue ? [next] : [] });
+  }
+
   return (
     <div className="rounded-lg border border-iron-100 p-4">
       <div className="grid gap-3 md:grid-cols-[120px_1fr_120px_120px]">
-        <input value={item.code ?? ""} onChange={(event) => onUpdate(index, { code: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Code" />
-        <input value={item.description} onChange={(event) => onUpdate(index, { description: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Description" />
-        <input type="number" value={item.quantity} onChange={(event) => onUpdate(index, { quantity: Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Qty" />
-        <select value={item.unit} onChange={(event) => onUpdate(index, { unit: event.target.value as EstimateUnit })} className="rounded-md border border-iron-100 px-3 py-2 text-sm">
+        <input aria-label={`Line item ${index + 1} code`} value={item.code ?? ""} onChange={(event) => onUpdate(index, { code: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Code" />
+        <input aria-label={`Line item ${index + 1} description`} value={item.description} onChange={(event) => onUpdate(index, { description: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Description" />
+        <input aria-label={`Line item ${index + 1} quantity`} type="number" value={item.quantity} onChange={(event) => onUpdate(index, { quantity: Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Qty" />
+        <select aria-label={`Line item ${index + 1} unit`} value={item.unit} onChange={(event) => onUpdate(index, { unit: event.target.value as EstimateUnit })} className="rounded-md border border-iron-100 px-3 py-2 text-sm">
           {(["LS", "EA", "m", "m2", "m3", "t", "hr", "day"] as EstimateUnit[]).map((unit) => (
             <option key={unit} value={unit}>{unit}</option>
           ))}
         </select>
       </div>
       <div className="mt-3 grid gap-3 md:grid-cols-[1fr_160px_120px]">
-        <select value={item.default_activity ?? ""} onChange={(event) => onUpdate(index, { default_activity: event.target.value ? (event.target.value as DefaultProductionActivity) : null })} className="rounded-md border border-iron-100 px-3 py-2 text-sm">
+        <select aria-label={`Line item ${index + 1} production activity`} value={item.default_activity ?? ""} onChange={(event) => onUpdate(index, { default_activity: event.target.value ? (event.target.value as DefaultProductionActivity) : null })} className="rounded-md border border-iron-100 px-3 py-2 text-sm">
           <option value="">No activity default</option>
           {rates.map((rate) => (
             <option key={rate.activity} value={rate.activity}>{activityLabels[rate.activity]} — {rate.production_rate_per_hour}/hr</option>
           ))}
         </select>
-        <input type="number" value={item.direct_unit_cost ?? ""} onChange={(event) => onUpdate(index, { direct_unit_cost: event.target.value === "" ? null : Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Direct $/unit" />
+        <input aria-label={`Line item ${index + 1} direct unit cost`} type="number" value={item.direct_unit_cost ?? ""} onChange={(event) => onUpdate(index, { direct_unit_cost: event.target.value === "" ? null : Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Direct $/unit" />
         <button type="button" onClick={() => onRemove(index)} className="inline-flex items-center justify-center gap-2 rounded-md border border-iron-100 px-3 py-2 text-sm text-red-700">
           <Trash2 className="h-4 w-4" /> Remove
         </button>
       </div>
       <div className="mt-3 grid gap-3 rounded-md bg-iron-50 p-3 md:grid-cols-[1fr_1fr_140px_120px]">
-        <input value={quote.supplier} onChange={(event) => onQuoteUpdate(index, { ...quote, supplier: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Vendor quote supplier" />
-        <input value={quote.scope} onChange={(event) => onQuoteUpdate(index, { ...quote, scope: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quoted scope" />
-        <input type="number" value={quote.amount} onChange={(event) => onQuoteUpdate(index, { ...quote, amount: Number(event.target.value), is_selected: true })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quote total" />
+        <input aria-label={`Line item ${index + 1} quote supplier`} value={quote.supplier} onChange={(event) => onQuoteUpdate(index, { ...quote, supplier: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Vendor quote supplier" />
+        <input aria-label={`Line item ${index + 1} quoted scope`} value={quote.scope} onChange={(event) => onQuoteUpdate(index, { ...quote, scope: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quoted scope" />
+        <input aria-label={`Line item ${index + 1} quote amount`} type="number" value={quote.amount} onChange={(event) => onQuoteUpdate(index, { ...quote, amount: Number(event.target.value), is_selected: true })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quote total" />
         <label className="flex items-center gap-2 text-sm text-iron-700">
           <input type="checkbox" checked={quote.is_selected} onChange={(event) => onQuoteUpdate(index, { ...quote, is_selected: event.target.checked })} /> Selected
         </label>
+        <input
+          aria-label={`Line item ${index + 1} quote notes`}
+          value={quote.notes ?? ""}
+          onChange={(event) => onQuoteUpdate(index, { ...quote, notes: event.target.value })}
+          className="rounded-md border border-iron-100 px-3 py-2 text-sm md:col-span-4"
+          placeholder="Quote notes or selection reason"
+        />
       </div>
+
+      <div className="mt-3 grid gap-3 rounded-md border border-iron-100 bg-white p-3 md:grid-cols-6">
+        <input aria-label={`Line item ${index + 1} disposal material`} value={disposal.material} onChange={(event) => updateDisposal({ ...disposal, material: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Disposal material" />
+        <input aria-label={`Line item ${index + 1} disposal quantity`} type="number" value={disposal.quantity} onChange={(event) => updateDisposal({ ...disposal, quantity: Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Qty" />
+        <select aria-label={`Line item ${index + 1} disposal unit`} value={disposal.unit} onChange={(event) => updateDisposal({ ...disposal, unit: event.target.value as EstimateUnit })} className="rounded-md border border-iron-100 px-3 py-2 text-sm">
+          {(["t", "m3", "EA", "LS"] as EstimateUnit[]).map((unit) => <option key={unit} value={unit}>{unit}</option>)}
+        </select>
+        <input aria-label={`Line item ${index + 1} disposal unit cost`} type="number" value={disposal.unit_cost} onChange={(event) => updateDisposal({ ...disposal, unit_cost: Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Disposal $/unit" />
+        <input aria-label={`Line item ${index + 1} disposal haul cost`} type="number" value={disposal.haul_cost} onChange={(event) => updateDisposal({ ...disposal, haul_cost: Number(event.target.value) })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Haul $/unit" />
+        <input aria-label={`Line item ${index + 1} disposal facility`} value={disposal.facility ?? ""} onChange={(event) => updateDisposal({ ...disposal, facility: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Facility" />
+      </div>
+
+      {result ? (
+        <div data-testid={`line-item-result-${index}`} className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-md bg-iron-950 px-3 py-2 text-sm text-white">
+          <span>Calculated: {moneyFormatter.format(result.direct_cost)} · {moneyFormatter.format(result.unit_cost)}/{result.unit}</span>
+          <span>{result.selected_quote_supplier ? `Selected supplier: ${result.selected_quote_supplier}` : "No supplier quote selected"}</span>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -347,11 +400,21 @@ function SummaryPanel({ summary, isBusy }: { summary: EstimateSummary | null; is
   );
 }
 
-function Input({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) {
+function Input({
+  label,
+  value,
+  onChange,
+  required = false,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+}) {
   return (
     <label className="space-y-1 text-sm font-medium text-iron-700">
       {label}
-      <input value={value} onChange={(event) => onChange(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" />
+      <input required={required} value={value} onChange={(event) => onChange(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" />
     </label>
   );
 }

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -50,8 +50,8 @@ describe("ProjectWorkspacePage", () => {
     renderWorkspace("/projects");
 
     expect(await screen.findByText(project.name)).toBeInTheDocument();
-    expect(screen.getByText("RFQ Progress")).toBeInTheDocument();
-    expect(screen.getByText("Document Count")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Ready" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Docs" })).toBeInTheDocument();
     expect(await screen.findByText("80%")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
   });


### PR DESCRIPTION
## What changed

- aligns the frontend line-item contract with backend disposal inputs
- adds disposal material, quantity, unit, disposal cost, haul cost, and facility controls
- captures vendor quote notes and selection context
- displays per-line calculated cost, unit cost, and selected supplier after calculation
- blocks estimate calculation and workbook export when the project name is empty
- replaces the placeholder frontend test command with the real Vitest suite
- adds Estimate UI integration tests and updates the integration documentation

## Why

The Estimating page and API calls already existed, but issue #1's UI item was not fully closed. The frontend contract omitted line-item disposal, calculated line-item results were not surfaced, invalid project names could reach export, and CI only ran a fake smoke test.

## Validation

- `npm run lint` passed
- `npm test` passed: 2 Estimate UI integration tests
- `npm run build` passed in an isolated production harness
- repository CI should run the complete backend and frontend gates

## Queue boundary

Multiple quote comparison and qualified/non-low selection remain in the next supplier quote integration task from issue #1.