### PR TITLE
Build 203: integrate supplier quote selection with estimates

### DIFF
--- a/backend/app/api/v1/routes/quotes.py
+++ b/backend/app/api/v1/routes/quotes.py
@@ -5,9 +5,12 @@ from app.schemas.quote_integration import (
     QuoteComparisonResponse,
     QuoteEstimateImportRequest,
     QuoteEstimateImportResponse,
+    QuoteEstimateSelectionRequest,
+    QuoteEstimateSelectionResponse,
 )
 from app.services.quote_comparison import compare_supplier_quotes
 from app.services.quote_estimate import import_quotes_to_estimate
+from app.services.quote_selection import select_quotes_for_estimate
 
 router = APIRouter()
 
@@ -15,6 +18,13 @@ router = APIRouter()
 @router.post("/compare", response_model=QuoteComparisonResponse)
 def compare_quotes(payload: QuoteComparisonRequest) -> QuoteComparisonResponse:
     return compare_supplier_quotes(payload)
+
+
+@router.post("/estimate-selection", response_model=QuoteEstimateSelectionResponse)
+def select_quote_pricing(
+    payload: QuoteEstimateSelectionRequest,
+) -> QuoteEstimateSelectionResponse:
+    return select_quotes_for_estimate(payload)
 
 
 @router.post("/estimate-import", response_model=QuoteEstimateImportResponse)

--- a/backend/app/schemas/estimate.py
+++ b/backend/app/schemas/estimate.py
@@ -96,7 +96,10 @@ class VendorQuoteInput(BaseModel):
     supplier: str = Field(min_length=1)
     scope: str = Field(min_length=1)
     amount: float = Field(default=0, ge=0)
+    is_qualified: bool = True
+    qualification_notes: list[str] = Field(default_factory=list)
     is_selected: bool = False
+    selection_reason: str | None = None
     notes: str | None = None
 
 

--- a/backend/app/schemas/quote_integration.py
+++ b/backend/app/schemas/quote_integration.py
@@ -3,6 +3,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from app.schemas.estimate import EstimateLineItem
+
 
 class QuoteStatus(StrEnum):
     requested = "requested"
@@ -35,6 +37,8 @@ class SupplierQuoteCreate(BaseModel):
     scope_type: QuoteScopeType = QuoteScopeType.material
     status: QuoteStatus = QuoteStatus.received
     amount: float = Field(default=0, ge=0)
+    is_qualified: bool = True
+    qualification_notes: list[str] = Field(default_factory=list)
     is_selected: bool = False
     selection_reason: str | None = None
     exclusions: list[str] = Field(default_factory=list)
@@ -49,6 +53,7 @@ class QuoteComparisonLine(BaseModel):
     line_item_code: str | None = None
     line_item_description: str
     scope: str
+    scope_type: QuoteScopeType
     lowest_supplier: str | None = None
     lowest_amount: float | None = None
     selected_supplier: str | None = None
@@ -56,6 +61,9 @@ class QuoteComparisonLine(BaseModel):
     selected_is_lowest: bool = True
     selection_reason: str | None = None
     quote_count: int
+    qualified_quote_count: int
+    ready_for_estimate: bool
+    blockers: list[str] = Field(default_factory=list)
 
 
 class QuoteComparisonRequest(BaseModel):
@@ -67,6 +75,36 @@ class QuoteComparisonResponse(BaseModel):
     total_lowest: float
     total_selected: float
     delta_from_lowest: float
+    ready_for_estimate: bool
+    blockers: list[str] = Field(default_factory=list)
+
+
+class QuoteSelectionDecision(BaseModel):
+    line_item_code: str | None = None
+    line_item_description: str
+    scope: str
+    scope_type: QuoteScopeType
+    lowest_qualified_supplier: str | None = None
+    lowest_qualified_amount: float | None = None
+    selected_supplier: str | None = None
+    selected_amount: float | None = None
+    selected_is_lowest: bool = True
+    selection_reason: str | None = None
+    quote_count: int
+    qualified_quote_count: int
+    ready_for_estimate: bool
+    blockers: list[str] = Field(default_factory=list)
+
+
+class QuoteEstimateSelectionRequest(BaseModel):
+    quotes: list[SupplierQuoteCreate] = Field(default_factory=list)
+
+
+class QuoteEstimateSelectionResponse(BaseModel):
+    decisions: list[QuoteSelectionDecision]
+    line_items: list[EstimateLineItem]
+    ready_for_estimate: bool
+    blockers: list[str] = Field(default_factory=list)
 
 
 class QuoteEstimateImportRequest(BaseModel):

--- a/backend/app/services/estimate_workbooks.py
+++ b/backend/app/services/estimate_workbooks.py
@@ -267,7 +267,17 @@ def _build_exclusions_sheet(workbook: Workbook, summary: EstimateSummary) -> Non
 def _build_quote_comparison_sheet(workbook: Workbook, payload: EstimateCreate) -> None:
     sheet = workbook.create_sheet("Quote Comparison")
     _title(sheet, "Supplier and Subcontractor Quote Comparison")
-    headers = ["Line Item", "Supplier", "Scope", "Amount", "Selected", "Notes"]
+    headers = [
+        "Line Item",
+        "Supplier",
+        "Scope",
+        "Amount",
+        "Qualified",
+        "Selected",
+        "Selection Reason",
+        "Qualification Notes",
+        "Notes",
+    ]
     _write_headers(sheet, headers, row=3)
     row_index = 4
     for item in payload.line_items:
@@ -280,18 +290,36 @@ def _build_quote_comparison_sheet(workbook: Workbook, payload: EstimateCreate) -
                     quote.supplier,
                     quote.scope,
                     quote.amount,
+                    "Yes" if quote.is_qualified else "No",
                     "Yes" if quote.is_selected else "No",
+                    quote.selection_reason or "",
+                    "; ".join(quote.qualification_notes),
                     quote.notes or "",
                 ],
             )
             sheet.cell(row=row_index, column=4).number_format = MONEY_FORMAT
             if quote.is_selected:
                 _fill_row(sheet, row_index, 1, len(headers), SUBTOTAL_FILL)
+            elif not quote.is_qualified:
+                _fill_row(sheet, row_index, 1, len(headers), WARNING_FILL)
             row_index += 1
     if row_index == 4:
         sheet.cell(row=4, column=1, value="No vendor quotes entered.")
     _apply_borders(sheet, 3, 1, max(4, row_index - 1), len(headers))
-    _set_widths(sheet, {"A": 34, "B": 26, "C": 34, "D": 16, "E": 12, "F": 42})
+    _set_widths(
+        sheet,
+        {
+            "A": 34,
+            "B": 26,
+            "C": 34,
+            "D": 16,
+            "E": 12,
+            "F": 12,
+            "G": 42,
+            "H": 42,
+            "I": 42,
+        },
+    )
 
 
 def _title(sheet: Worksheet, title: str) -> None:

--- a/backend/app/services/estimates.py
+++ b/backend/app/services/estimates.py
@@ -4,6 +4,7 @@ from app.schemas.estimate import (
     DefaultProductionActivity,
     EquipmentResource,
     EstimateCategoryBreakdown,
+    EstimateItemType,
     EstimateCreate,
     EstimateLineItem,
     EstimateLineItemCost,
@@ -287,8 +288,13 @@ def calculate_line_item(item: EstimateLineItem) -> EstimateLineItemCost:
         for disposal in item.disposal
     )
     selected_quote = _selected_vendor_quote(item)
-    subcontract_cost = selected_quote.amount if selected_quote else 0
-    if not selected_quote and item.subcontract:
+    subcontract_cost = 0
+    if selected_quote:
+        if item.item_type == EstimateItemType.material:
+            material_cost += selected_quote.amount
+        else:
+            subcontract_cost = selected_quote.amount
+    elif item.subcontract:
         subcontract_cost = item.subcontract.quoted_amount
     explicit_direct_cost = (
         item.direct_unit_cost * item.quantity if item.direct_unit_cost is not None else 0

--- a/backend/app/services/estimates.py
+++ b/backend/app/services/estimates.py
@@ -345,12 +345,29 @@ def _calculate_hours(item: EstimateLineItem) -> float:
 
 
 def _selected_vendor_quote(item: EstimateLineItem):
-    selected_quotes = [quote for quote in item.vendor_quotes if quote.is_selected]
-    if selected_quotes:
-        return min(selected_quotes, key=lambda quote: quote.amount)
-    if item.vendor_quotes:
-        return min(item.vendor_quotes, key=lambda quote: quote.amount)
-    return None
+    qualified_quotes = [
+        quote
+        for quote in item.vendor_quotes
+        if quote.is_qualified and quote.amount > 0
+    ]
+    if not qualified_quotes:
+        return None
+
+    lowest_quote = min(
+        qualified_quotes,
+        key=lambda quote: (quote.amount, quote.supplier.casefold()),
+    )
+    selected_quotes = [quote for quote in qualified_quotes if quote.is_selected]
+    if len(selected_quotes) != 1:
+        return lowest_quote
+
+    selected_quote = selected_quotes[0]
+    has_selection_reason = bool(
+        selected_quote.selection_reason and selected_quote.selection_reason.strip()
+    )
+    if selected_quote.amount > lowest_quote.amount and not has_selection_reason:
+        return lowest_quote
+    return selected_quote
 
 
 def _expected_risk_amount(amount: float, probability: float | None) -> float:

--- a/backend/app/services/quote_comparison.py
+++ b/backend/app/services/quote_comparison.py
@@ -1,51 +1,42 @@
-from __future__ import annotations
-
-from collections import defaultdict
-
 from app.schemas.quote_integration import (
     QuoteComparisonLine,
     QuoteComparisonRequest,
     QuoteComparisonResponse,
-    SupplierQuoteCreate,
+    QuoteEstimateSelectionRequest,
 )
+from app.services.quote_selection import select_quotes_for_estimate
 
 
 def compare_supplier_quotes(payload: QuoteComparisonRequest) -> QuoteComparisonResponse:
-    grouped_quotes: dict[tuple[str | None, str, str], list[SupplierQuoteCreate]] = defaultdict(list)
-    for quote in payload.quotes:
-        key = (quote.line_item_code, quote.line_item_description or quote.scope, quote.scope)
-        grouped_quotes[key].append(quote)
-
-    lines: list[QuoteComparisonLine] = []
-    total_lowest = 0.0
-    total_selected = 0.0
-
-    for (line_item_code, line_item_description, scope), quotes in grouped_quotes.items():
-        lowest_quote = min(quotes, key=lambda quote: quote.amount)
-        selected_quotes = [quote for quote in quotes if quote.is_selected]
-        selected_quote = min(selected_quotes, key=lambda quote: quote.amount) if selected_quotes else lowest_quote
-        selected_is_lowest = selected_quote.amount == lowest_quote.amount
-
-        total_lowest += lowest_quote.amount
-        total_selected += selected_quote.amount
-        lines.append(
-            QuoteComparisonLine(
-                line_item_code=line_item_code,
-                line_item_description=line_item_description,
-                scope=scope,
-                lowest_supplier=lowest_quote.supplier_name,
-                lowest_amount=round(lowest_quote.amount, 2),
-                selected_supplier=selected_quote.supplier_name,
-                selected_amount=round(selected_quote.amount, 2),
-                selected_is_lowest=selected_is_lowest,
-                selection_reason=selected_quote.selection_reason,
-                quote_count=len(quotes),
-            )
+    selection = select_quotes_for_estimate(
+        QuoteEstimateSelectionRequest(quotes=payload.quotes)
+    )
+    lines = [
+        QuoteComparisonLine(
+            line_item_code=decision.line_item_code,
+            line_item_description=decision.line_item_description,
+            scope=decision.scope,
+            scope_type=decision.scope_type,
+            lowest_supplier=decision.lowest_qualified_supplier,
+            lowest_amount=decision.lowest_qualified_amount,
+            selected_supplier=decision.selected_supplier,
+            selected_amount=decision.selected_amount,
+            selected_is_lowest=decision.selected_is_lowest,
+            selection_reason=decision.selection_reason,
+            quote_count=decision.quote_count,
+            qualified_quote_count=decision.qualified_quote_count,
+            ready_for_estimate=decision.ready_for_estimate,
+            blockers=decision.blockers,
         )
-
+        for decision in selection.decisions
+    ]
+    total_lowest = sum(line.lowest_amount or 0 for line in lines)
+    total_selected = sum(line.selected_amount or 0 for line in lines)
     return QuoteComparisonResponse(
         lines=lines,
         total_lowest=round(total_lowest, 2),
         total_selected=round(total_selected, 2),
         delta_from_lowest=round(total_selected - total_lowest, 2),
+        ready_for_estimate=selection.ready_for_estimate,
+        blockers=selection.blockers,
     )

--- a/backend/app/services/quote_selection.py
+++ b/backend/app/services/quote_selection.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from app.schemas.estimate import (
+    EstimateItemType,
+    EstimateLineItem,
+    EstimateUnit,
+    VendorQuoteInput,
+)
+from app.schemas.quote_integration import (
+    QuoteEstimateSelectionRequest,
+    QuoteEstimateSelectionResponse,
+    QuoteScopeType,
+    QuoteSelectionDecision,
+    QuoteStatus,
+    SupplierQuoteCreate,
+)
+
+
+def select_quotes_for_estimate(
+    payload: QuoteEstimateSelectionRequest,
+) -> QuoteEstimateSelectionResponse:
+    quotes = _select_current_revisions(payload.quotes)
+    grouped: dict[tuple[str, str], list[SupplierQuoteCreate]] = defaultdict(list)
+    for quote in quotes:
+        grouped[_line_item_key(quote)].append(quote)
+
+    if not grouped:
+        blocker = "Add at least one supplier quote before sending pricing to the estimate."
+        return QuoteEstimateSelectionResponse(
+            decisions=[],
+            line_items=[],
+            ready_for_estimate=False,
+            blockers=[blocker],
+        )
+
+    decisions: list[QuoteSelectionDecision] = []
+    line_items: list[EstimateLineItem] = []
+    blockers: list[str] = []
+
+    for key in sorted(grouped):
+        decision, line_item = _evaluate_group(grouped[key])
+        decisions.append(decision)
+        blockers.extend(decision.blockers)
+        if line_item is not None:
+            line_items.append(line_item)
+
+    return QuoteEstimateSelectionResponse(
+        decisions=decisions,
+        line_items=line_items,
+        ready_for_estimate=not blockers and len(line_items) == len(decisions),
+        blockers=blockers,
+    )
+
+
+def _evaluate_group(
+    quotes: list[SupplierQuoteCreate],
+) -> tuple[QuoteSelectionDecision, EstimateLineItem | None]:
+    first = quotes[0]
+    label = first.line_item_code or first.line_item_description or first.scope
+    eligible = [quote for quote in quotes if _is_eligible(quote)]
+    eligible.sort(key=lambda quote: (quote.amount, quote.supplier_name.casefold()))
+    lowest = eligible[0] if eligible else None
+
+    manually_selected = [
+        quote
+        for quote in quotes
+        if quote.is_selected or quote.status == QuoteStatus.selected
+    ]
+    blockers: list[str] = []
+    selected: SupplierQuoteCreate | None = None
+
+    if not eligible:
+        blockers.append(
+            f"{label}: no received, positive, qualified supplier quote is available."
+        )
+
+    if len(manually_selected) > 1:
+        suppliers = ", ".join(quote.supplier_name for quote in manually_selected)
+        blockers.append(
+            f"{label}: select exactly one supplier; multiple quotes are selected ({suppliers})."
+        )
+    elif len(manually_selected) == 1:
+        candidate = manually_selected[0]
+        if not _is_eligible(candidate):
+            reasons = _ineligible_reasons(candidate)
+            blockers.append(
+                f"{label}: selected quote from {candidate.supplier_name} is not eligible "
+                f"({'; '.join(reasons)})."
+            )
+        else:
+            selected = candidate
+    else:
+        selected = lowest
+
+    selected_is_lowest = (
+        selected is None
+        or lowest is None
+        or selected.amount == lowest.amount
+    )
+    selection_reason = (
+        selected.selection_reason.strip()
+        if selected and selected.selection_reason and selected.selection_reason.strip()
+        else None
+    )
+    if selected and not selected_is_lowest and not selection_reason:
+        blockers.append(
+            f"{label}: explain why {selected.supplier_name} is selected over the "
+            f"lowest qualified quote from {lowest.supplier_name}."
+        )
+
+    ready = selected is not None and not blockers
+    source = selected or lowest or first
+    decision = QuoteSelectionDecision(
+        line_item_code=source.line_item_code,
+        line_item_description=source.line_item_description or source.scope,
+        scope=source.scope,
+        scope_type=source.scope_type,
+        lowest_qualified_supplier=lowest.supplier_name if lowest else None,
+        lowest_qualified_amount=round(lowest.amount, 2) if lowest else None,
+        selected_supplier=selected.supplier_name if selected else None,
+        selected_amount=round(selected.amount, 2) if selected else None,
+        selected_is_lowest=selected_is_lowest,
+        selection_reason=selection_reason,
+        quote_count=len(quotes),
+        qualified_quote_count=len(eligible),
+        ready_for_estimate=ready,
+        blockers=blockers,
+    )
+    if not ready or selected is None:
+        return decision, None
+
+    ordered_quotes = sorted(
+        eligible,
+        key=lambda quote: (
+            quote is not selected,
+            quote.amount,
+            quote.supplier_name.casefold(),
+        ),
+    )
+    vendor_quotes = [
+        VendorQuoteInput(
+            supplier=quote.supplier_name,
+            scope=quote.scope,
+            amount=quote.amount,
+            is_qualified=quote.is_qualified,
+            qualification_notes=quote.qualification_notes,
+            is_selected=quote is selected,
+            selection_reason=(
+                quote.selection_reason.strip()
+                if quote.selection_reason and quote.selection_reason.strip()
+                else None
+            ),
+            notes=quote.notes,
+        )
+        for quote in ordered_quotes
+    ]
+    line_item = EstimateLineItem(
+        code=selected.line_item_code,
+        description=selected.line_item_description or selected.scope,
+        item_type=(
+            EstimateItemType.material
+            if selected.scope_type == QuoteScopeType.material
+            else EstimateItemType.subcontract
+        ),
+        quantity=1,
+        unit=EstimateUnit.lump_sum,
+        vendor_quotes=vendor_quotes,
+        notes=(
+            f"Supplier selection: {selection_reason}"
+            if selection_reason
+            else "Lowest qualified supplier quote selected."
+        ),
+    )
+    return decision, line_item
+
+
+def _line_item_key(quote: SupplierQuoteCreate) -> tuple[str, str]:
+    code = (quote.line_item_code or "").strip().casefold()
+    if code:
+        return ("code", code)
+    description = (quote.line_item_description or quote.scope).strip().casefold()
+    return ("description", description)
+
+
+def _revision_key(quote: SupplierQuoteCreate) -> tuple[str, str, str, str]:
+    line_key = _line_item_key(quote)
+    return (
+        quote.supplier_name.strip().casefold(),
+        (quote.quote_reference or "").strip().casefold(),
+        f"{line_key[0]}:{line_key[1]}",
+        quote.scope.strip().casefold(),
+    )
+
+
+def _select_current_revisions(
+    quotes: list[SupplierQuoteCreate],
+) -> list[SupplierQuoteCreate]:
+    current: dict[tuple[str, str, str, str], SupplierQuoteCreate] = {}
+    for quote in quotes:
+        key = _revision_key(quote)
+        existing = current.get(key)
+        if existing is None or quote.revision >= existing.revision:
+            current[key] = quote
+    return list(current.values())
+
+
+def _is_eligible(quote: SupplierQuoteCreate) -> bool:
+    return (
+        quote.is_qualified
+        and quote.status in {QuoteStatus.received, QuoteStatus.selected}
+        and quote.amount > 0
+    )
+
+
+def _ineligible_reasons(quote: SupplierQuoteCreate) -> list[str]:
+    reasons: list[str] = []
+    if not quote.is_qualified:
+        reasons.append("not qualified")
+    if quote.status not in {QuoteStatus.received, QuoteStatus.selected}:
+        reasons.append(f"status is {quote.status.value}")
+    if quote.amount <= 0:
+        reasons.append("amount must be greater than zero")
+    return reasons

--- a/docs/supplier-quote-integration.md
+++ b/docs/supplier-quote-integration.md
@@ -1,76 +1,34 @@
-# Supplier Quote Integration
+# Supplier Quote Integration (Build 203)
 
-## Purpose
+Build 203 connects supplier quote comparison to estimate line items and workbook export.
 
-Supplier quote integration connects RFQ responses to estimate line items so Iron House can compare pricing, select qualified suppliers, and preserve the reasoning when the lowest quote is not selected.
+## Selection policy
 
-## Backend Additions
+A quote is eligible to price an estimate only when it:
 
-New schemas:
+- is marked qualified;
+- has status `received` or `selected`; and
+- has an amount greater than zero.
 
-- `SupplierQuoteCreate`
-- `SupplierQuoteRead`
-- `QuoteComparisonRequest`
-- `QuoteComparisonResponse`
-- `QuoteComparisonLine`
+For each estimate line item, Iron House OS:
 
-New service:
+1. ignores superseded revisions of the same supplier quote line;
+2. automatically selects the lowest qualified quote when no supplier is manually selected;
+3. accepts exactly one manually selected qualified quote;
+4. requires a selection reason when the manual choice is above the lowest qualified amount; and
+5. blocks estimate handoff when the selection is ambiguous or incomplete.
 
-- `backend/app/services/quote_comparison.py`
+Unqualified, bounced, declined, rejected, requested, and zero-value quotes remain visible as source records but cannot set estimate pricing.
 
-New endpoint:
+## API and UI flow
 
-- `POST /api/v1/quotes/compare`
+- `POST /api/v1/quotes/compare` applies the shared policy and returns qualified counts, blockers, and readiness.
+- `POST /api/v1/quotes/estimate-selection` returns selection decisions plus ready-to-use `EstimateLineItem` records.
+- Quote Comparison exposes status, qualification, notes, manual selection, and selection reason.
+- **Use selected quotes in estimate** sends ready line items to the Estimating page and retains qualified alternatives.
+- Estimate calculation ignores unqualified quotes and falls back to the lowest qualified quote if a non-low choice has no reason.
+- The workbook Quote Comparison sheet records qualification, selection, selection reason, qualification notes, and quote notes.
 
-## Selection Rule
+## Queue boundary
 
-The comparison service groups quotes by line item and scope.
-
-Default behavior:
-
-1. Select the lowest quote if no quote is manually marked selected.
-2. Respect the manually selected quote when `is_selected` is true.
-3. Preserve `selection_reason` when the selected quote is not the lowest.
-4. Report the delta between lowest-total and selected-total.
-
-## Quote Fields
-
-Each quote can track:
-
-- RFQ ID
-- RFQ package ID
-- Supplier ID
-- Supplier name
-- Estimate line item code
-- Estimate line item description
-- Scope
-- Scope type
-- Status
-- Amount
-- Selected flag
-- Selection reason
-- Exclusions
-- Notes
-
-## Next Database Migration
-
-The existing `quotes` table is basic. A future Alembic migration should add:
-
-- `rfq_package_id UUID REFERENCES rfq_packages(id)`
-- `line_item_code VARCHAR(80)`
-- `line_item_description VARCHAR(255)`
-- `scope VARCHAR(255)`
-- `scope_type VARCHAR(80)`
-- `is_selected BOOLEAN NOT NULL DEFAULT FALSE`
-- `selection_reason TEXT`
-- `exclusions_json JSONB NOT NULL DEFAULT '[]'`
-- `metadata_json JSONB NOT NULL DEFAULT '{}'`
-
-## Estimating Integration
-
-Estimate line items already support `vendor_quotes` as input. The estimate engine uses:
-
-- manually selected quote when present
-- otherwise lowest quote
-
-This allows supplier responses to update estimate pricing without rewriting the estimate structure.
+This build consumes manually entered supplier quote records. Automated RFQ package creation, quote collection, and mailbox/Drive ingestion remain separate follow-on work.

--- a/frontend/src/api/estimates.ts
+++ b/frontend/src/api/estimates.ts
@@ -53,7 +53,10 @@ export type VendorQuoteInput = {
   supplier: string;
   scope: string;
   amount: number;
+  is_qualified?: boolean;
+  qualification_notes?: string[];
   is_selected: boolean;
+  selection_reason?: string | null;
   notes?: string | null;
 };
 

--- a/frontend/src/api/quotes.ts
+++ b/frontend/src/api/quotes.ts
@@ -1,3 +1,5 @@
+import type { EstimateLineItem } from "./estimates";
+
 export type QuoteScopeType = "material" | "subcontract" | "trucking" | "disposal" | "equipment" | "other";
 
 export type QuoteStatus = "requested" | "received" | "declined" | "bounced" | "selected" | "rejected";
@@ -7,12 +9,16 @@ export type SupplierQuoteCreate = {
   rfq_package_id?: string | null;
   supplier_id?: string | null;
   supplier_name: string;
+  quote_reference?: string | null;
+  revision?: number;
   line_item_code?: string | null;
   line_item_description?: string | null;
   scope: string;
   scope_type: QuoteScopeType;
   status: QuoteStatus;
   amount: number;
+  is_qualified: boolean;
+  qualification_notes: string[];
   is_selected: boolean;
   selection_reason?: string | null;
   exclusions: string[];
@@ -23,6 +29,7 @@ export type QuoteComparisonLine = {
   line_item_code?: string | null;
   line_item_description: string;
   scope: string;
+  scope_type: QuoteScopeType;
   lowest_supplier?: string | null;
   lowest_amount?: number | null;
   selected_supplier?: string | null;
@@ -30,6 +37,9 @@ export type QuoteComparisonLine = {
   selected_is_lowest: boolean;
   selection_reason?: string | null;
   quote_count: number;
+  qualified_quote_count: number;
+  ready_for_estimate: boolean;
+  blockers: string[];
 };
 
 export type QuoteComparisonResponse = {
@@ -37,6 +47,32 @@ export type QuoteComparisonResponse = {
   total_lowest: number;
   total_selected: number;
   delta_from_lowest: number;
+  ready_for_estimate: boolean;
+  blockers: string[];
+};
+
+export type QuoteSelectionDecision = {
+  line_item_code?: string | null;
+  line_item_description: string;
+  scope: string;
+  scope_type: QuoteScopeType;
+  lowest_qualified_supplier?: string | null;
+  lowest_qualified_amount?: number | null;
+  selected_supplier?: string | null;
+  selected_amount?: number | null;
+  selected_is_lowest: boolean;
+  selection_reason?: string | null;
+  quote_count: number;
+  qualified_quote_count: number;
+  ready_for_estimate: boolean;
+  blockers: string[];
+};
+
+export type QuoteEstimateSelectionResponse = {
+  decisions: QuoteSelectionDecision[];
+  line_items: EstimateLineItem[];
+  ready_for_estimate: boolean;
+  blockers: string[];
 };
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -60,6 +96,11 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 export const quotesApi = {
   compare: (quotes: SupplierQuoteCreate[]) =>
     request<QuoteComparisonResponse>("/quotes/compare", {
+      method: "POST",
+      body: JSON.stringify({ quotes }),
+    }),
+  estimateSelection: (quotes: SupplierQuoteCreate[]) =>
+    request<QuoteEstimateSelectionResponse>("/quotes/estimate-selection", {
       method: "POST",
       body: JSON.stringify({ quotes }),
     }),

--- a/frontend/src/pages/EstimatingPage.test.tsx
+++ b/frontend/src/pages/EstimatingPage.test.tsx
@@ -235,7 +235,9 @@ describe("EstimatingPage", () => {
     await user.click(screen.getByRole("button", { name: /Calculate/i }));
 
     await waitFor(() => expect(summaryPayloads).toHaveLength(1));
-    const submitted = summaryPayloads[0];
+    const submitted = summaryPayloads[0] as {
+      line_items: Array<{ vendor_quotes: unknown[] }>;
+    };
     expect(submitted.line_items[0].vendor_quotes).toEqual([
       expect.objectContaining({
         supplier: "Preferred Supplier",

--- a/frontend/src/pages/EstimatingPage.test.tsx
+++ b/frontend/src/pages/EstimatingPage.test.tsx
@@ -169,6 +169,86 @@ describe("EstimatingPage", () => {
     ]);
   });
 
+  it("loads qualified supplier selections from quote comparison state", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/estimating",
+            state: {
+              quoteLineItems: [
+                {
+                  code: "PIPE-001",
+                  description: "PVC storm pipe supply",
+                  item_type: "material",
+                  quantity: 1,
+                  unit: "LS",
+                  labour: [],
+                  equipment: [],
+                  materials: [],
+                  disposal: [],
+                  vendor_quotes: [
+                    {
+                      supplier: "Preferred Supplier",
+                      scope: "Supply PVC storm pipe",
+                      amount: 11250,
+                      is_qualified: true,
+                      qualification_notes: [],
+                      is_selected: true,
+                      selection_reason: "Complete scope and confirmed delivery",
+                      notes: "Confirmed delivery",
+                    },
+                    {
+                      supplier: "Lowest Supplier",
+                      scope: "Supply PVC storm pipe",
+                      amount: 10000,
+                      is_qualified: true,
+                      qualification_notes: [],
+                      is_selected: false,
+                      selection_reason: null,
+                      notes: null,
+                    },
+                  ],
+                  direct_unit_cost: null,
+                  notes: "Supplier selection: Complete scope and confirmed delivery",
+                },
+              ],
+            },
+          },
+        ]}
+      >
+        <EstimatingPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("Loaded 1 estimate line item from qualified supplier selections."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Line item 1 quote supplier")).toHaveValue("Preferred Supplier");
+    expect(screen.getByLabelText("Line item 1 quote amount")).toHaveValue(11250);
+    expect(screen.getByLabelText("Line item 1 selection reason")).toHaveValue(
+      "Complete scope and confirmed delivery",
+    );
+    expect(screen.getByText("1 qualified alternative quote retained for workbook comparison.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Calculate/i }));
+
+    await waitFor(() => expect(summaryPayloads).toHaveLength(1));
+    const submitted = summaryPayloads[0];
+    expect(submitted.line_items[0].vendor_quotes).toEqual([
+      expect.objectContaining({
+        supplier: "Preferred Supplier",
+        is_selected: true,
+        selection_reason: "Complete scope and confirmed delivery",
+      }),
+      expect.objectContaining({
+        supplier: "Lowest Supplier",
+        is_selected: false,
+      }),
+    ]);
+  });
+
   it("blocks calculation and workbook export until a project name is entered", async () => {
     const user = userEvent.setup();
     render(

--- a/frontend/src/pages/EstimatingPage.tsx
+++ b/frontend/src/pages/EstimatingPage.tsx
@@ -53,12 +53,20 @@ const moneyFormatter = new Intl.NumberFormat("en-CA", {
   maximumFractionDigits: 0,
 });
 
+type EstimatingLocationState = {
+  quoteLineItems?: EstimateLineItem[];
+};
+
 export function EstimatingPage() {
   const location = useLocation();
   const projectContext = readProjectContext(location.search);
+  const locationState = location.state as EstimatingLocationState | null;
+  const importedQuoteLineItems = locationState?.quoteLineItems ?? [];
   const [projectName, setProjectName] = useState(projectContext.projectName ?? "Marine Drive Parking Lot");
   const [projectCode, setProjectCode] = useState(projectContext.projectId ?? "WR26-012");
-  const [lineItems, setLineItems] = useState<EstimateLineItem[]>([defaultLineItem]);
+  const [lineItems, setLineItems] = useState<EstimateLineItem[]>(
+    () => importedQuoteLineItems.length ? importedQuoteLineItems : [defaultLineItem],
+  );
   const [contingency, setContingency] = useState(10);
   const [overhead, setOverhead] = useState(5);
   const [profit, setProfit] = useState(10);
@@ -144,7 +152,12 @@ export function EstimatingPage() {
   }
 
   function updateQuote(index: number, quote: VendorQuoteInput) {
-    updateLineItem(index, { vendor_quotes: quote.supplier || quote.scope || quote.amount ? [quote] : [] });
+    setLineItems((items) => items.map((item, currentIndex) => {
+      if (currentIndex !== index) return item;
+      const alternatives = item.vendor_quotes.slice(1);
+      const hasValue = Boolean(quote.supplier || quote.scope || quote.amount);
+      return { ...item, vendor_quotes: hasValue ? [quote, ...alternatives] : alternatives };
+    }));
   }
 
   function addLineItem() {
@@ -207,6 +220,11 @@ export function EstimatingPage() {
       </div>
 
       <ProjectScopeNotice name={projectContext.projectName} />
+      {importedQuoteLineItems.length ? (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800">
+          Loaded {importedQuoteLineItems.length} estimate line item{importedQuoteLineItems.length === 1 ? "" : "s"} from qualified supplier selections.
+        </div>
+      ) : null}
       {error ? <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div> : null}
 
       <form onSubmit={(event) => void calculateEstimate(event)} className="grid gap-6 xl:grid-cols-[1fr_380px]">
@@ -285,7 +303,16 @@ function LineItemCard({
   onQuoteUpdate: (index: number, quote: VendorQuoteInput) => void;
   onRemove: (index: number) => void;
 }) {
-  const quote = item.vendor_quotes[0] ?? { supplier: "", scope: item.description, amount: 0, is_selected: true, notes: "" };
+  const quote = item.vendor_quotes[0] ?? {
+    supplier: "",
+    scope: item.description,
+    amount: 0,
+    is_qualified: true,
+    qualification_notes: [],
+    is_selected: true,
+    selection_reason: "",
+    notes: "",
+  };
   const disposal: DisposalInput = item.disposal[0] ?? {
     material: "",
     quantity: 0,
@@ -324,20 +351,35 @@ function LineItemCard({
           <Trash2 className="h-4 w-4" /> Remove
         </button>
       </div>
-      <div className="mt-3 grid gap-3 rounded-md bg-iron-50 p-3 md:grid-cols-[1fr_1fr_140px_120px]">
+      <div className="mt-3 grid gap-3 rounded-md bg-iron-50 p-3 md:grid-cols-[1fr_1fr_140px_120px_120px]">
         <input aria-label={`Line item ${index + 1} quote supplier`} value={quote.supplier} onChange={(event) => onQuoteUpdate(index, { ...quote, supplier: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Vendor quote supplier" />
         <input aria-label={`Line item ${index + 1} quoted scope`} value={quote.scope} onChange={(event) => onQuoteUpdate(index, { ...quote, scope: event.target.value })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quoted scope" />
         <input aria-label={`Line item ${index + 1} quote amount`} type="number" value={quote.amount} onChange={(event) => onQuoteUpdate(index, { ...quote, amount: Number(event.target.value), is_selected: true })} className="rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quote total" />
         <label className="flex items-center gap-2 text-sm text-iron-700">
           <input type="checkbox" checked={quote.is_selected} onChange={(event) => onQuoteUpdate(index, { ...quote, is_selected: event.target.checked })} /> Selected
         </label>
+        <label className="flex items-center gap-2 text-sm text-iron-700">
+          <input type="checkbox" checked={quote.is_qualified !== false} onChange={(event) => onQuoteUpdate(index, { ...quote, is_qualified: event.target.checked })} /> Qualified
+        </label>
         <input
           aria-label={`Line item ${index + 1} quote notes`}
           value={quote.notes ?? ""}
           onChange={(event) => onQuoteUpdate(index, { ...quote, notes: event.target.value })}
-          className="rounded-md border border-iron-100 px-3 py-2 text-sm md:col-span-4"
-          placeholder="Quote notes or selection reason"
+          className="rounded-md border border-iron-100 px-3 py-2 text-sm md:col-span-5"
+          placeholder="Quote notes"
         />
+        <input
+          aria-label={`Line item ${index + 1} selection reason`}
+          value={quote.selection_reason ?? ""}
+          onChange={(event) => onQuoteUpdate(index, { ...quote, selection_reason: event.target.value })}
+          className="rounded-md border border-iron-100 px-3 py-2 text-sm md:col-span-5"
+          placeholder="Reason when selecting a non-low quote"
+        />
+        {item.vendor_quotes.length > 1 ? (
+          <p className="text-xs text-iron-500 md:col-span-5">
+            {item.vendor_quotes.length - 1} qualified alternative quote{item.vendor_quotes.length === 2 ? "" : "s"} retained for workbook comparison.
+          </p>
+        ) : null}
       </div>
 
       <div className="mt-3 grid gap-3 rounded-md border border-iron-100 bg-white p-3 md:grid-cols-6">

--- a/frontend/src/pages/QuoteComparisonPage.test.tsx
+++ b/frontend/src/pages/QuoteComparisonPage.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QuoteComparisonPage } from "./QuoteComparisonPage";
+
+const requestBodies: Record<string, unknown>[] = [];
+
+const comparisonResponse = {
+  lines: [
+    {
+      line_item_code: "PIPE-001",
+      line_item_description: "PVC storm pipe supply",
+      scope: "Supply PVC storm pipe",
+      scope_type: "material",
+      lowest_supplier: "Lowest Supplier",
+      lowest_amount: 10000,
+      selected_supplier: "Preferred Supplier",
+      selected_amount: 11250,
+      selected_is_lowest: false,
+      selection_reason: "Complete scope and confirmed delivery",
+      quote_count: 2,
+      qualified_quote_count: 2,
+      ready_for_estimate: true,
+      blockers: [],
+    },
+  ],
+  total_lowest: 10000,
+  total_selected: 11250,
+  delta_from_lowest: 1250,
+  ready_for_estimate: true,
+  blockers: [],
+};
+
+const selectionResponse = {
+  decisions: [
+    {
+      line_item_code: "PIPE-001",
+      line_item_description: "PVC storm pipe supply",
+      scope: "Supply PVC storm pipe",
+      scope_type: "material",
+      lowest_qualified_supplier: "Lowest Supplier",
+      lowest_qualified_amount: 10000,
+      selected_supplier: "Preferred Supplier",
+      selected_amount: 11250,
+      selected_is_lowest: false,
+      selection_reason: "Complete scope and confirmed delivery",
+      quote_count: 2,
+      qualified_quote_count: 2,
+      ready_for_estimate: true,
+      blockers: [],
+    },
+  ],
+  line_items: [
+    {
+      code: "PIPE-001",
+      description: "PVC storm pipe supply",
+      item_type: "material",
+      quantity: 1,
+      unit: "LS",
+      labour: [],
+      equipment: [],
+      materials: [],
+      disposal: [],
+      vendor_quotes: [
+        {
+          supplier: "Preferred Supplier",
+          scope: "Supply PVC storm pipe",
+          amount: 11250,
+          is_qualified: true,
+          qualification_notes: [],
+          is_selected: true,
+          selection_reason: "Complete scope and confirmed delivery",
+          notes: "Confirmed delivery",
+        },
+        {
+          supplier: "Lowest Supplier",
+          scope: "Supply PVC storm pipe",
+          amount: 10000,
+          is_qualified: true,
+          qualification_notes: [],
+          is_selected: false,
+          selection_reason: null,
+          notes: null,
+        },
+      ],
+      direct_unit_cost: null,
+      notes: "Supplier selection: Complete scope and confirmed delivery",
+    },
+  ],
+  ready_for_estimate: true,
+  blockers: [],
+};
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function EstimateHandoffProbe() {
+  const location = useLocation();
+  const state = location.state as typeof selectionResponse | { quoteLineItems: typeof selectionResponse.line_items };
+  const lineItems = "quoteLineItems" in state ? state.quoteLineItems : [];
+  return <div>{location.pathname}: {lineItems[0]?.vendor_quotes[0]?.supplier}</div>;
+}
+
+describe("QuoteComparisonPage", () => {
+  beforeEach(() => {
+    requestBodies.length = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requestBodies.push(JSON.parse(String(init?.body)));
+        const url = String(input);
+        if (url.endsWith("/quotes/compare")) return jsonResponse(comparisonResponse);
+        if (url.endsWith("/quotes/estimate-selection")) return jsonResponse(selectionResponse);
+        throw new Error(`Unexpected request: ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("qualifies a documented non-low supplier and hands it to Estimating", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/quotes?projectId=WR26-012&projectName=Marine%20Drive"]}>
+        <Routes>
+          <Route path="/quotes" element={<QuoteComparisonPage />} />
+          <Route path="/estimating" element={<EstimateHandoffProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const suppliers = screen.getAllByLabelText("Supplier");
+    const codes = screen.getAllByLabelText("Line Item Code");
+    const descriptions = screen.getAllByLabelText("Line Item");
+    const scopes = screen.getAllByLabelText("Scope");
+    const amounts = screen.getAllByLabelText("Amount");
+    const reasons = screen.getAllByLabelText("Selection Reason");
+
+    await user.type(suppliers[0], "Lowest Supplier");
+    await user.type(suppliers[1], "Preferred Supplier");
+    await user.type(codes[0], "PIPE-001");
+    await user.type(codes[1], "PIPE-001");
+    await user.type(descriptions[0], "PVC storm pipe supply");
+    await user.type(descriptions[1], "PVC storm pipe supply");
+    await user.type(scopes[0], "Supply PVC storm pipe");
+    await user.type(scopes[1], "Supply PVC storm pipe");
+    await user.clear(amounts[0]);
+    await user.type(amounts[0], "10000");
+    await user.clear(amounts[1]);
+    await user.type(amounts[1], "11250");
+    await user.click(screen.getAllByLabelText("Selected quote")[1]);
+    await user.type(reasons[1], "Complete scope and confirmed delivery");
+
+    await user.click(screen.getByRole("button", { name: "Compare and qualify quotes" }));
+
+    expect(await screen.findByText("Ready for estimate: every line has one qualified supplier selection.")).toBeInTheDocument();
+    expect(screen.getByText("Not lowest")).toBeInTheDocument();
+    expect(screen.getByText("Complete scope and confirmed delivery")).toBeInTheDocument();
+
+    await waitFor(() => expect(requestBodies).toHaveLength(2));
+    expect(requestBodies[0]).toEqual(
+      expect.objectContaining({
+        quotes: expect.arrayContaining([
+          expect.objectContaining({
+            supplier_name: "Preferred Supplier",
+            is_qualified: true,
+            is_selected: true,
+            selection_reason: "Complete scope and confirmed delivery",
+          }),
+        ]),
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Use selected quotes in estimate" }));
+    expect(await screen.findByText("/estimating: Preferred Supplier")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/QuoteComparisonPage.tsx
+++ b/frontend/src/pages/QuoteComparisonPage.tsx
@@ -1,8 +1,13 @@
-import { Plus, Trash2 } from "lucide-react";
+import { ArrowRight, Plus, Trash2 } from "lucide-react";
 import { FormEvent, useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
-import { QuoteComparisonResponse, quotesApi, SupplierQuoteCreate } from "../api/quotes";
+import {
+  QuoteComparisonResponse,
+  QuoteEstimateSelectionResponse,
+  quotesApi,
+  SupplierQuoteCreate,
+} from "../api/quotes";
 import { ProjectScopeNotice } from "../components/ProjectScopeNotice";
 import { readProjectContext } from "../utils/projectContext";
 
@@ -21,6 +26,8 @@ function blankQuote(): SupplierQuoteCreate {
     scope_type: "material",
     status: "received",
     amount: 0,
+    is_qualified: true,
+    qualification_notes: [],
     is_selected: false,
     selection_reason: "",
     exclusions: [],
@@ -30,14 +37,16 @@ function blankQuote(): SupplierQuoteCreate {
 
 export function QuoteComparisonPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const projectContext = readProjectContext(location.search);
   const [quotes, setQuotes] = useState<SupplierQuoteCreate[]>([blankQuote(), blankQuote()]);
   const [result, setResult] = useState<QuoteComparisonResponse | null>(null);
+  const [selection, setSelection] = useState<QuoteEstimateSelectionResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const validQuoteCount = useMemo(
-    () => quotes.filter((quote) => quote.supplier_name && quote.scope && quote.amount >= 0).length,
+    () => quotes.filter((quote) => quote.supplier_name && quote.scope && quote.amount > 0).length,
     [quotes],
   );
 
@@ -45,6 +54,8 @@ export function QuoteComparisonPage() {
     event.preventDefault();
     setIsLoading(true);
     setError(null);
+    setResult(null);
+    setSelection(null);
     try {
       const cleanQuotes = quotes
         .filter((quote) => quote.supplier_name.trim() && quote.scope.trim())
@@ -55,10 +66,16 @@ export function QuoteComparisonPage() {
           line_item_description: quote.line_item_description?.trim() || quote.scope.trim(),
           scope: quote.scope.trim(),
           amount: Number(quote.amount) || 0,
+          qualification_notes: quote.qualification_notes.map((note) => note.trim()).filter(Boolean),
           selection_reason: quote.selection_reason?.trim() || null,
           notes: quote.notes?.trim() || null,
         }));
-      setResult(await quotesApi.compare(cleanQuotes));
+      const [comparisonResult, selectionResult] = await Promise.all([
+        quotesApi.compare(cleanQuotes),
+        quotesApi.estimateSelection(cleanQuotes),
+      ]);
+      setResult(comparisonResult);
+      setSelection(selectionResult);
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to compare quotes");
     } finally {
@@ -74,12 +91,20 @@ export function QuoteComparisonPage() {
     setQuotes((current) => current.filter((_, quoteIndex) => quoteIndex !== index));
   }
 
+  function useSelectedQuotes() {
+    if (!selection?.ready_for_estimate) return;
+    navigate(
+      { pathname: "/estimating", search: location.search },
+      { state: { quoteLineItems: selection.line_items } },
+    );
+  }
+
   return (
     <section className="space-y-6">
       <div className="border-b border-iron-100 pb-6">
         <h1 className="text-3xl font-semibold text-iron-950">Quote Comparison</h1>
         <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-500">
-          Manual supplier quote comparison for MVP. Enter quotes by line item and scope, mark the selected supplier if needed, and review the delta from lowest price.
+          Qualify supplier quotes by estimate line, compare received pricing, and document any non-low selection before sending it to Estimating.
         </p>
       </div>
 
@@ -87,7 +112,7 @@ export function QuoteComparisonPage() {
 
       <form className="space-y-4" onSubmit={submit}>
         <div className="flex items-center justify-between gap-3">
-          <div className="text-sm text-iron-500">Valid quotes ready: {validQuoteCount}</div>
+          <div className="text-sm text-iron-500">Complete positive quotes: {validQuoteCount}</div>
           <button
             type="button"
             onClick={() => setQuotes((current) => [...current, blankQuote()])}
@@ -125,8 +150,28 @@ export function QuoteComparisonPage() {
                     <option value="other">Other</option>
                   </select>
                 </label>
+                <label className="grid gap-1 text-sm">
+                  <span className="font-medium text-iron-700">Status</span>
+                  <select value={quote.status} onChange={(event) => updateQuote(index, { status: event.target.value as SupplierQuoteCreate["status"] })} className="rounded-md border border-iron-100 px-3 py-2">
+                    <option value="received">Received</option>
+                    <option value="requested">Requested</option>
+                    <option value="declined">Declined</option>
+                    <option value="bounced">Bounced</option>
+                    <option value="rejected">Rejected</option>
+                  </select>
+                </label>
                 <Input label="Amount" type="number" value={String(quote.amount)} onChange={(value) => updateQuote(index, { amount: Number(value) })} />
                 <Input label="Selection Reason" value={quote.selection_reason ?? ""} onChange={(value) => updateQuote(index, { selection_reason: value })} />
+                <Input
+                  label="Qualification Notes"
+                  value={quote.qualification_notes.join("; ")}
+                  onChange={(value) => updateQuote(index, { qualification_notes: value ? [value] : [] })}
+                />
+                <Input label="Quote Notes" value={quote.notes ?? ""} onChange={(value) => updateQuote(index, { notes: value })} />
+                <label className="flex items-end gap-2 pb-2 text-sm font-medium text-iron-700">
+                  <input type="checkbox" checked={quote.is_qualified} onChange={(event) => updateQuote(index, { is_qualified: event.target.checked })} className="h-4 w-4" />
+                  Qualified quote
+                </label>
                 <label className="flex items-end gap-2 pb-2 text-sm font-medium text-iron-700">
                   <input type="checkbox" checked={quote.is_selected} onChange={(event) => updateQuote(index, { is_selected: event.target.checked })} className="h-4 w-4" />
                   Selected quote
@@ -139,15 +184,40 @@ export function QuoteComparisonPage() {
         {error ? <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
 
         <button type="submit" className="rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white" disabled={isLoading}>
-          {isLoading ? "Comparing..." : "Compare quotes"}
+          {isLoading ? "Comparing..." : "Compare and qualify quotes"}
         </button>
       </form>
 
-      {result ? (
+      {result && selection ? (
         <div className="space-y-4 rounded-md border border-iron-100 bg-white p-5">
-          <h2 className="text-lg font-semibold text-iron-950">Comparison Summary</h2>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <h2 className="text-lg font-semibold text-iron-950">Comparison Summary</h2>
+            <button
+              type="button"
+              onClick={useSelectedQuotes}
+              disabled={!selection.ready_for_estimate}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:bg-iron-300"
+            >
+              Use selected quotes in estimate
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </div>
+
+          {selection.ready_for_estimate ? (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+              Ready for estimate: every line has one qualified supplier selection.
+            </div>
+          ) : (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+              <div className="font-semibold">Resolve before estimate handoff</div>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                {selection.blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
+              </ul>
+            </div>
+          )}
+
           <div className="grid gap-3 md:grid-cols-3">
-            <SummaryCard label="Lowest Total" value={moneyFormatter.format(result.total_lowest)} />
+            <SummaryCard label="Lowest Qualified Total" value={moneyFormatter.format(result.total_lowest)} />
             <SummaryCard label="Selected Total" value={moneyFormatter.format(result.total_selected)} />
             <SummaryCard label="Delta" value={moneyFormatter.format(result.delta_from_lowest)} />
           </div>
@@ -158,6 +228,7 @@ export function QuoteComparisonPage() {
                 <tr>
                   <th className="px-3 py-2">Line Item</th>
                   <th className="px-3 py-2">Scope</th>
+                  <th className="px-3 py-2">Qualified</th>
                   <th className="px-3 py-2">Lowest</th>
                   <th className="px-3 py-2">Selected</th>
                   <th className="px-3 py-2">Reason</th>
@@ -168,9 +239,10 @@ export function QuoteComparisonPage() {
                   <tr key={`${line.line_item_code ?? "line"}-${line.scope}-${index}`} className="border-t border-iron-100">
                     <td className="px-3 py-2 font-medium text-iron-950">{line.line_item_description}</td>
                     <td className="px-3 py-2 text-iron-600">{line.scope}</td>
-                    <td className="px-3 py-2 text-iron-600">{line.lowest_supplier} - {moneyFormatter.format(line.lowest_amount ?? 0)}</td>
+                    <td className="px-3 py-2 text-iron-600">{line.qualified_quote_count} / {line.quote_count}</td>
+                    <td className="px-3 py-2 text-iron-600">{line.lowest_supplier ? `${line.lowest_supplier} - ${moneyFormatter.format(line.lowest_amount ?? 0)}` : "—"}</td>
                     <td className="px-3 py-2 text-iron-600">
-                      {line.selected_supplier} - {moneyFormatter.format(line.selected_amount ?? 0)}
+                      {line.selected_supplier ? `${line.selected_supplier} - ${moneyFormatter.format(line.selected_amount ?? 0)}` : "—"}
                       {!line.selected_is_lowest ? <span className="ml-2 rounded bg-amber-100 px-2 py-1 text-xs text-amber-700">Not lowest</span> : null}
                     </td>
                     <td className="px-3 py-2 text-iron-600">{line.selection_reason ?? "—"}</td>

--- a/tests/backend/test_estimate_workbooks.py
+++ b/tests/backend/test_estimate_workbooks.py
@@ -41,6 +41,8 @@ def test_workbook_contains_complete_estimator_sheet_contract() -> None:
                         scope="PVC pipe supply",
                         amount=4200,
                         is_selected=True,
+                        selection_reason="Complete scope and confirmed delivery",
+                        qualification_notes=["Scope reviewed"],
                         notes="Qualified selected quote",
                     )
                 ],
@@ -70,6 +72,9 @@ def test_workbook_contains_complete_estimator_sheet_contract() -> None:
     assert workbook["Line Items"]["L6"].value == "=SUM(L4:L4)"
     assert workbook["Quote Comparison"]["B4"].value == "EMCO"
     assert workbook["Quote Comparison"]["E4"].value == "Yes"
+    assert workbook["Quote Comparison"]["F4"].value == "Yes"
+    assert workbook["Quote Comparison"]["G4"].value == "Complete scope and confirmed delivery"
+    assert workbook["Quote Comparison"]["H4"].value == "Scope reviewed"
 
 
 def test_workbook_records_empty_assumptions_exclusions_and_line_items() -> None:

--- a/tests/backend/test_estimates.py
+++ b/tests/backend/test_estimates.py
@@ -85,7 +85,11 @@ def test_vendor_quotes_respect_selected_quote() -> None:
         vendor_quotes=[
             VendorQuoteInput(supplier="Lowest", scope="Paving", amount=10000),
             VendorQuoteInput(
-                supplier="Qualified selected", scope="Paving", amount=11250, is_selected=True
+                supplier="Qualified selected",
+                scope="Paving",
+                amount=11250,
+                is_selected=True,
+                selection_reason="Complete scope and schedule",
             ),
         ],
     )
@@ -94,6 +98,49 @@ def test_vendor_quotes_respect_selected_quote() -> None:
 
     assert result.subcontract_cost == 11250
     assert result.selected_quote_supplier == "Qualified selected"
+
+
+def test_vendor_quotes_ignore_unqualified_lower_quote() -> None:
+    item = EstimateLineItem(
+        description="Pipe supply",
+        quantity=1,
+        vendor_quotes=[
+            VendorQuoteInput(
+                supplier="Incomplete quote",
+                scope="Pipe",
+                amount=9000,
+                is_qualified=False,
+                qualification_notes=["Freight excluded"],
+            ),
+            VendorQuoteInput(supplier="Qualified quote", scope="Pipe", amount=10000),
+        ],
+    )
+
+    result = calculate_line_item(item)
+
+    assert result.subcontract_cost == 10000
+    assert result.selected_quote_supplier == "Qualified quote"
+
+
+def test_vendor_quotes_fall_back_to_lowest_when_non_low_selection_has_no_reason() -> None:
+    item = EstimateLineItem(
+        description="Paving",
+        quantity=1,
+        vendor_quotes=[
+            VendorQuoteInput(supplier="Lowest", scope="Paving", amount=10000),
+            VendorQuoteInput(
+                supplier="Undocumented selection",
+                scope="Paving",
+                amount=11250,
+                is_selected=True,
+            ),
+        ],
+    )
+
+    result = calculate_line_item(item)
+
+    assert result.subcontract_cost == 10000
+    assert result.selected_quote_supplier == "Lowest"
 
 
 def test_default_production_rate_activity_populates_crew_and_equipment() -> None:

--- a/tests/backend/test_quote_selection.py
+++ b/tests/backend/test_quote_selection.py
@@ -4,6 +4,7 @@ from app.schemas.quote_integration import (
     QuoteStatus,
     SupplierQuoteCreate,
 )
+from app.services.estimates import calculate_line_item
 from app.services.quote_comparison import compare_supplier_quotes
 from app.services.quote_selection import select_quotes_for_estimate
 
@@ -52,6 +53,9 @@ def test_automatically_selects_lowest_received_qualified_quote() -> None:
     assert result.decisions[0].qualified_quote_count == 2
     assert result.line_items[0].vendor_quotes[0].supplier == "Qualified B"
     assert result.line_items[0].vendor_quotes[0].is_selected is True
+    calculated = calculate_line_item(result.line_items[0])
+    assert calculated.material_cost == 9500
+    assert calculated.subcontract_cost == 0
 
 
 def test_preserves_documented_non_low_selection_in_estimate_line_item() -> None:

--- a/tests/backend/test_quote_selection.py
+++ b/tests/backend/test_quote_selection.py
@@ -1,0 +1,138 @@
+from app.schemas.quote_integration import (
+    QuoteComparisonRequest,
+    QuoteEstimateSelectionRequest,
+    QuoteStatus,
+    SupplierQuoteCreate,
+)
+from app.services.quote_comparison import compare_supplier_quotes
+from app.services.quote_selection import select_quotes_for_estimate
+
+
+def quote(
+    supplier: str,
+    amount: float,
+    *,
+    selected: bool = False,
+    reason: str | None = None,
+    qualified: bool = True,
+    status: QuoteStatus = QuoteStatus.received,
+    revision: int = 1,
+) -> SupplierQuoteCreate:
+    return SupplierQuoteCreate(
+        supplier_name=supplier,
+        quote_reference="Q-PIPE",
+        revision=revision,
+        line_item_code="PIPE-001",
+        line_item_description="PVC storm pipe supply",
+        scope="Supply PVC storm pipe",
+        amount=amount,
+        is_qualified=qualified,
+        status=status,
+        is_selected=selected,
+        selection_reason=reason,
+    )
+
+
+def test_automatically_selects_lowest_received_qualified_quote() -> None:
+    quotes = [
+        quote("Unqualified low", 8000, qualified=False),
+        quote("Bounced low", 8500, status=QuoteStatus.bounced),
+        quote("Qualified A", 10000),
+        quote("Qualified B", 9500),
+    ]
+
+    result = select_quotes_for_estimate(
+        QuoteEstimateSelectionRequest(quotes=quotes)
+    )
+
+    assert result.ready_for_estimate is True
+    assert result.blockers == []
+    assert result.decisions[0].lowest_qualified_supplier == "Qualified B"
+    assert result.decisions[0].selected_supplier == "Qualified B"
+    assert result.decisions[0].qualified_quote_count == 2
+    assert result.line_items[0].vendor_quotes[0].supplier == "Qualified B"
+    assert result.line_items[0].vendor_quotes[0].is_selected is True
+
+
+def test_preserves_documented_non_low_selection_in_estimate_line_item() -> None:
+    quotes = [
+        quote("Lowest", 10000),
+        quote(
+            "Preferred supplier",
+            11250,
+            selected=True,
+            reason="Complete scope and confirmed delivery",
+        ),
+    ]
+
+    result = select_quotes_for_estimate(
+        QuoteEstimateSelectionRequest(quotes=quotes)
+    )
+
+    decision = result.decisions[0]
+    selected_quote = result.line_items[0].vendor_quotes[0]
+    assert result.ready_for_estimate is True
+    assert decision.selected_supplier == "Preferred supplier"
+    assert decision.selected_is_lowest is False
+    assert decision.selection_reason == "Complete scope and confirmed delivery"
+    assert selected_quote.is_selected is True
+    assert selected_quote.selection_reason == "Complete scope and confirmed delivery"
+
+
+def test_blocks_non_low_selection_without_reason() -> None:
+    result = select_quotes_for_estimate(
+        QuoteEstimateSelectionRequest(
+            quotes=[
+                quote("Lowest", 10000),
+                quote("Undocumented choice", 11250, selected=True),
+            ]
+        )
+    )
+
+    assert result.ready_for_estimate is False
+    assert result.line_items == []
+    assert "explain why Undocumented choice is selected" in result.blockers[0]
+
+
+def test_blocks_multiple_manual_selections() -> None:
+    result = select_quotes_for_estimate(
+        QuoteEstimateSelectionRequest(
+            quotes=[
+                quote("Supplier A", 10000, selected=True),
+                quote("Supplier B", 10500, selected=True),
+            ]
+        )
+    )
+
+    assert result.ready_for_estimate is False
+    assert result.line_items == []
+    assert "multiple quotes are selected" in result.blockers[0]
+
+
+def test_uses_latest_supplier_quote_revision_and_comparison_policy() -> None:
+    quotes = [
+        quote("Revised supplier", 8000, revision=1),
+        quote("Revised supplier", 12000, revision=2),
+        quote("Current lowest", 11000),
+    ]
+
+    selection = select_quotes_for_estimate(
+        QuoteEstimateSelectionRequest(quotes=quotes)
+    )
+    comparison = compare_supplier_quotes(QuoteComparisonRequest(quotes=quotes))
+
+    assert selection.decisions[0].quote_count == 2
+    assert selection.decisions[0].selected_supplier == "Current lowest"
+    assert comparison.ready_for_estimate is True
+    assert comparison.total_lowest == 11000
+    assert comparison.total_selected == 11000
+
+
+def test_empty_quote_set_is_not_ready_for_estimate() -> None:
+    result = select_quotes_for_estimate(QuoteEstimateSelectionRequest())
+
+    assert result.ready_for_estimate is False
+    assert result.line_items == []
+    assert result.blockers == [
+        "Add at least one supplier quote before sending pricing to the estimate."
+    ]


### PR DESCRIPTION
## Summary

- add one backend policy for quote qualification, revision handling, automatic low selection, and documented manual selection
- expose quote-to-estimate decisions and ready `EstimateLineItem` records through `POST /api/v1/quotes/estimate-selection`
- connect Quote Comparison to Estimating while retaining qualified alternatives and selection evidence
- prevent unqualified or undocumented non-low quotes from setting estimate pricing
- preserve qualification and selection details in the estimate workbook

## Selection rules

- eligible quotes must be received/selected, positive, and qualified
- the lowest qualified quote is automatic when no manual selection exists
- exactly one manual selection is allowed
- a non-low manual selection requires a reason
- superseded revisions do not compete with current pricing

## Validation

- `npm run build`
- `npm test` — 7 component tests passed in the local focused harness
- Python compile check plus 19 backend estimate, selection, and workbook test functions passed in the local focused harness

Refs #1
