### PR TITLE
Build 204: build supplier-specific RFQ packages

### DIFF
--- a/backend/app/api/v1/routes/rfqs.py
+++ b/backend/app/api/v1/routes/rfqs.py
@@ -7,13 +7,17 @@ from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.schemas.rfq_draft import RFQDraftRequest, RFQDraftResponse
 from app.schemas.rfq_package import (
+    RFQPackageBuildResponse,
     RFQPackageCreate,
     RFQPackageDocumentCreate,
+    RFQPackageDocumentStatusUpdate,
     RFQPackageList,
     RFQPackageRead,
     RFQPackageReadiness,
     RFQPackageUpdateStatus,
+    RFQScopeGenerationRequest,
     SupplierRecipientCreate,
+    SupplierRecipientStatusUpdate,
 )
 from app.services import rfq_drafts, rfq_packages
 
@@ -66,6 +70,33 @@ def select_rfq_package_suppliers(
     return rfq_packages.select_rfq_package_suppliers(db, rfq_package_id, payload)
 
 
+@router.post("/{rfq_package_id}/supplier-scopes", response_model=RFQPackageRead)
+def generate_rfq_supplier_scopes(
+    rfq_package_id: UUID,
+    payload: RFQScopeGenerationRequest,
+    db: DBSession,
+) -> RFQPackageRead:
+    return rfq_packages.generate_rfq_supplier_scopes(db, rfq_package_id, payload)
+
+
+@router.patch(
+    "/{rfq_package_id}/suppliers/{recipient_id}/status",
+    response_model=RFQPackageRead,
+)
+def update_rfq_recipient_status(
+    rfq_package_id: UUID,
+    recipient_id: UUID,
+    payload: SupplierRecipientStatusUpdate,
+    db: DBSession,
+) -> RFQPackageRead:
+    return rfq_packages.update_rfq_recipient_status(
+        db,
+        rfq_package_id,
+        recipient_id,
+        payload,
+    )
+
+
 @router.put("/{rfq_package_id}/documents", response_model=RFQPackageRead)
 def register_rfq_package_documents(
     rfq_package_id: UUID,
@@ -75,9 +106,35 @@ def register_rfq_package_documents(
     return rfq_packages.register_rfq_package_documents(db, rfq_package_id, payload)
 
 
+@router.patch(
+    "/{rfq_package_id}/documents/{document_id}/status",
+    response_model=RFQPackageRead,
+)
+def update_rfq_document_status(
+    rfq_package_id: UUID,
+    document_id: UUID,
+    payload: RFQPackageDocumentStatusUpdate,
+    db: DBSession,
+) -> RFQPackageRead:
+    return rfq_packages.update_rfq_document_status(
+        db,
+        rfq_package_id,
+        document_id,
+        payload,
+    )
+
+
 @router.get("/{rfq_package_id}/readiness", response_model=RFQPackageReadiness)
 def read_rfq_package_readiness(
     rfq_package_id: UUID,
     db: DBSession,
 ) -> RFQPackageReadiness:
     return rfq_packages.get_rfq_package_readiness(db, rfq_package_id)
+
+
+@router.post("/{rfq_package_id}/build", response_model=RFQPackageBuildResponse)
+def build_rfq_supplier_packages(
+    rfq_package_id: UUID,
+    db: DBSession,
+) -> RFQPackageBuildResponse:
+    return rfq_packages.build_rfq_supplier_packages(db, rfq_package_id)

--- a/backend/app/schemas/rfq_package.py
+++ b/backend/app/schemas/rfq_package.py
@@ -13,15 +13,36 @@ class RFQPackageStatus(StrEnum):
     closed = "closed"
 
 
+class RFQRecipientStatus(StrEnum):
+    pending = "pending"
+    sent = "sent"
+    replied = "replied"
+    bounced = "bounced"
+
+
+class RFQPackageDocumentStatus(StrEnum):
+    pending = "pending"
+    attached = "attached"
+    not_applicable = "not_applicable"
+
+
 class SupplierRecipientCreate(BaseModel):
     supplier_id: str = Field(min_length=1)
     supplier_name: str = Field(min_length=1)
     category: str | None = None
+    scope_items: list[str] = Field(default_factory=list)
 
 
 class SupplierRecipientRead(SupplierRecipientCreate):
     id: UUID
-    status: str
+    status: RFQRecipientStatus
+    scope_summary: str | None = None
+    status_note: str | None = None
+
+
+class SupplierRecipientStatusUpdate(BaseModel):
+    status: RFQRecipientStatus
+    note: str | None = None
 
 
 class RFQPackageDocumentCreate(BaseModel):
@@ -29,12 +50,17 @@ class RFQPackageDocumentCreate(BaseModel):
     title: str = Field(min_length=1)
     required: bool = True
     storage_uri: str | None = None
+    status: RFQPackageDocumentStatus = RFQPackageDocumentStatus.pending
     metadata: dict = Field(default_factory=dict)
 
 
 class RFQPackageDocumentRead(RFQPackageDocumentCreate):
     id: UUID
-    status: str
+
+
+class RFQPackageDocumentStatusUpdate(BaseModel):
+    status: RFQPackageDocumentStatus
+    storage_uri: str | None = None
 
 
 class RFQPackageCreate(BaseModel):
@@ -85,3 +111,26 @@ class RFQPackageReadiness(BaseModel):
     ready: bool
     score: int
     items: list[RFQReadinessItem]
+
+
+class RFQScopeGenerationRequest(BaseModel):
+    force: bool = False
+
+
+class SupplierRFQPackageDraft(BaseModel):
+    recipient_id: UUID
+    supplier_id: str
+    supplier_name: str
+    category: str | None = None
+    status: RFQRecipientStatus
+    subject: str
+    body: str
+    scope_items: list[str]
+    attachment_names: list[str]
+
+
+class RFQPackageBuildResponse(BaseModel):
+    rfq_package_id: UUID
+    ready: bool
+    blockers: list[str] = Field(default_factory=list)
+    packages: list[SupplierRFQPackageDraft] = Field(default_factory=list)

--- a/backend/app/services/rfq_packages.py
+++ b/backend/app/services/rfq_packages.py
@@ -5,18 +5,55 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.core.errors import AppError
 from app.models.rfq import RFQPackage, RFQPackageDocument, RFQPackageSupplierRecipient
+from app.schemas.rfq_draft import RFQDraftRequest
 from app.schemas.rfq_package import (
+    RFQPackageBuildResponse,
     RFQPackageCreate,
     RFQPackageDocumentCreate,
     RFQPackageDocumentRead,
+    RFQPackageDocumentStatus,
+    RFQPackageDocumentStatusUpdate,
     RFQPackageRead,
     RFQPackageReadiness,
     RFQPackageStatus,
     RFQPackageUpdateStatus,
     RFQReadinessItem,
+    RFQRecipientStatus,
+    RFQScopeGenerationRequest,
     SupplierRecipientCreate,
     SupplierRecipientRead,
+    SupplierRecipientStatusUpdate,
+    SupplierRFQPackageDraft,
 )
+from app.services.rfq_drafts import build_rfq_draft
+
+
+CATEGORY_SCOPE_ITEMS: dict[str, list[str]] = {
+    "pipe": [
+        "Provide itemized pricing for the specified pipe, fittings, couplers, and appurtenances.",
+        "Confirm material standards, available lengths, lead times, and delivery requirements.",
+    ],
+    "aggregate": [
+        "Provide unit rates by material type and source, including applicable minimum quantities.",
+        "Separate material, loading, delivery, and fuel surcharge pricing.",
+    ],
+    "traffic": [
+        "Price traffic control personnel, devices, setup, maintenance, and removal.",
+        "State crew assumptions, shift rates, minimum call-outs, and plan preparation exclusions.",
+    ],
+    "concrete": [
+        "Price the complete concrete scope including supply, placement, finishing, and curing.",
+        "Separate reinforcing, formwork, pumping, testing, and winter-condition allowances.",
+    ],
+    "asphalt": [
+        "Price paving preparation, asphalt supply, placement, compaction, and tie-ins.",
+        "State mix assumptions, lift thicknesses, mobilization, and minimum-load charges.",
+    ],
+    "disposal": [
+        "Provide disposal and haul rates by material classification and receiving facility.",
+        "State testing, tipping, wait-time, minimum-load, and contaminated-material exclusions.",
+    ],
+}
 
 
 def create_rfq_package(db: Session, payload: RFQPackageCreate) -> RFQPackageRead:
@@ -68,22 +105,91 @@ def select_rfq_package_suppliers(
     rfq_package_id: UUID,
     payload: list[SupplierRecipientCreate],
 ) -> RFQPackageRead:
-    _load_package(db, rfq_package_id)
+    rfq_package = _load_package(db, rfq_package_id)
     db.execute(
         delete(RFQPackageSupplierRecipient).where(
             RFQPackageSupplierRecipient.rfq_package_id == rfq_package_id
         )
     )
-    db.add_all(
-        RFQPackageSupplierRecipient(
-            rfq_package_id=rfq_package_id,
-            supplier_id=item.supplier_id,
-            supplier_name=item.supplier_name,
-            category=item.category,
-            status="selected",
+
+    scopes: dict[str, dict[str, object]] = {}
+    for item in payload:
+        scope_items = _clean_scope_items(item.scope_items) or _default_scope_items(
+            item.category,
+            rfq_package.scope_summary,
         )
-        for item in payload
+        scopes[item.supplier_id] = {
+            "items": scope_items,
+            "summary": _scope_summary(scope_items),
+        }
+        db.add(
+            RFQPackageSupplierRecipient(
+                rfq_package_id=rfq_package_id,
+                supplier_id=item.supplier_id,
+                supplier_name=item.supplier_name,
+                category=item.category,
+                status=RFQRecipientStatus.pending.value,
+            )
+        )
+
+    metadata = _metadata(rfq_package)
+    metadata["supplier_scopes"] = scopes
+    metadata["supplier_status_notes"] = {}
+    rfq_package.metadata_json = metadata
+    db.commit()
+    return _to_schema(_load_package(db, rfq_package_id))
+
+
+def generate_rfq_supplier_scopes(
+    db: Session,
+    rfq_package_id: UUID,
+    payload: RFQScopeGenerationRequest,
+) -> RFQPackageRead:
+    rfq_package = _load_package(db, rfq_package_id)
+    metadata = _metadata(rfq_package)
+    scopes = dict(metadata.get("supplier_scopes") or {})
+
+    for recipient in rfq_package.recipients:
+        existing = scopes.get(recipient.supplier_id)
+        existing_items = (
+            _clean_scope_items(existing.get("items", []))
+            if isinstance(existing, dict)
+            else []
+        )
+        if payload.force or not existing_items:
+            items = _default_scope_items(recipient.category, rfq_package.scope_summary)
+            scopes[recipient.supplier_id] = {
+                "items": items,
+                "summary": _scope_summary(items),
+            }
+
+    metadata["supplier_scopes"] = scopes
+    rfq_package.metadata_json = metadata
+    db.commit()
+    return _to_schema(_load_package(db, rfq_package_id))
+
+
+def update_rfq_recipient_status(
+    db: Session,
+    rfq_package_id: UUID,
+    recipient_id: UUID,
+    payload: SupplierRecipientStatusUpdate,
+) -> RFQPackageRead:
+    rfq_package = _load_package(db, rfq_package_id)
+    recipient = next(
+        (item for item in rfq_package.recipients if item.id == recipient_id),
+        None,
     )
+    if recipient is None:
+        raise AppError("RFQ supplier recipient not found", status_code=404)
+
+    recipient.status = payload.status.value
+    if payload.note is not None:
+        metadata = _metadata(rfq_package)
+        notes = dict(metadata.get("supplier_status_notes") or {})
+        notes[recipient.supplier_id] = payload.note.strip() or None
+        metadata["supplier_status_notes"] = notes
+        rfq_package.metadata_json = metadata
     db.commit()
     return _to_schema(_load_package(db, rfq_package_id))
 
@@ -97,18 +203,54 @@ def register_rfq_package_documents(
     db.execute(
         delete(RFQPackageDocument).where(RFQPackageDocument.rfq_package_id == rfq_package_id)
     )
-    db.add_all(
-        RFQPackageDocument(
-            rfq_package_id=rfq_package_id,
-            document_type=item.document_type,
-            title=item.title,
-            required=item.required,
-            storage_uri=item.storage_uri,
-            metadata_json=item.metadata,
-            status="registered",
+    documents: list[RFQPackageDocument] = []
+    for item in payload:
+        document_status = item.status
+        if item.storage_uri and document_status == RFQPackageDocumentStatus.pending:
+            document_status = RFQPackageDocumentStatus.attached
+        if document_status == RFQPackageDocumentStatus.attached and not item.storage_uri:
+            raise AppError(
+                f"Attachment reference is required for '{item.title}'.",
+                status_code=422,
+            )
+        documents.append(
+            RFQPackageDocument(
+                rfq_package_id=rfq_package_id,
+                document_type=item.document_type,
+                title=item.title,
+                required=item.required,
+                storage_uri=item.storage_uri,
+                metadata_json=item.metadata,
+                status=document_status.value,
+            )
         )
-        for item in payload
+    db.add_all(documents)
+    db.commit()
+    return _to_schema(_load_package(db, rfq_package_id))
+
+
+def update_rfq_document_status(
+    db: Session,
+    rfq_package_id: UUID,
+    document_id: UUID,
+    payload: RFQPackageDocumentStatusUpdate,
+) -> RFQPackageRead:
+    rfq_package = _load_package(db, rfq_package_id)
+    document = next(
+        (item for item in rfq_package.documents if item.id == document_id),
+        None,
     )
+    if document is None:
+        raise AppError("RFQ package document not found", status_code=404)
+
+    storage_uri = payload.storage_uri if payload.storage_uri is not None else document.storage_uri
+    if payload.status == RFQPackageDocumentStatus.attached and not storage_uri:
+        raise AppError(
+            f"Attachment reference is required for '{document.title}'.",
+            status_code=422,
+        )
+    document.status = payload.status.value
+    document.storage_uri = storage_uri
     db.commit()
     return _to_schema(_load_package(db, rfq_package_id))
 
@@ -116,29 +258,53 @@ def register_rfq_package_documents(
 def get_rfq_package_readiness(db: Session, rfq_package_id: UUID) -> RFQPackageReadiness:
     rfq_package = _to_schema(_load_package(db, rfq_package_id))
     required_documents = [document for document in rfq_package.documents if document.required]
-    required_documents_registered = bool(required_documents) and all(
-        document.status == "registered" for document in required_documents
+    required_documents_attached = bool(required_documents) and all(
+        document.status == RFQPackageDocumentStatus.attached and bool(document.storage_uri)
+        for document in required_documents
+    )
+    supplier_scopes_ready = bool(rfq_package.recipients) and all(
+        bool(recipient.scope_items) for recipient in rfq_package.recipients
     )
     items = [
         RFQReadinessItem(
             key="scope",
-            label="Scope summary",
+            label="Package scope summary",
             ready=bool(rfq_package.scope_summary),
-            detail="Scope summary is present."
-            if rfq_package.scope_summary
-            else "Add a scope summary before issuing.",
+            detail=(
+                "Package scope summary is present."
+                if rfq_package.scope_summary
+                else "Add the overall package scope before building supplier RFQs."
+            ),
         ),
         RFQReadinessItem(
             key="suppliers",
             label="Supplier recipients",
             ready=bool(rfq_package.recipients),
-            detail=f"{len(rfq_package.recipients)} supplier recipients selected.",
+            detail=(
+                f"{len(rfq_package.recipients)} supplier recipient(s) selected."
+                if rfq_package.recipients
+                else "Add at least one supplier recipient."
+            ),
+        ),
+        RFQReadinessItem(
+            key="supplier_scopes",
+            label="Supplier-specific scopes",
+            ready=supplier_scopes_ready,
+            detail=(
+                "Every supplier has a generated or edited scope."
+                if supplier_scopes_ready
+                else "Generate or enter scope items for every supplier."
+            ),
         ),
         RFQReadinessItem(
             key="documents",
-            label="Required bid documents",
-            ready=required_documents_registered,
-            detail=f"{len(required_documents)} required documents registered.",
+            label="Required attachments",
+            ready=required_documents_attached,
+            detail=(
+                f"{len(required_documents)} required attachment(s) are ready."
+                if required_documents_attached
+                else "Attach every required drawing or document reference."
+            ),
         ),
     ]
     ready_count = sum(1 for item in items if item.ready)
@@ -148,6 +314,52 @@ def get_rfq_package_readiness(db: Session, rfq_package_id: UUID) -> RFQPackageRe
         ready=ready_count == len(items),
         score=round((ready_count / len(items)) * 100),
         items=items,
+    )
+
+
+def build_rfq_supplier_packages(
+    db: Session,
+    rfq_package_id: UUID,
+) -> RFQPackageBuildResponse:
+    rfq_package = _to_schema(_load_package(db, rfq_package_id))
+    readiness = get_rfq_package_readiness(db, rfq_package_id)
+    attachment_names = [
+        document.title
+        for document in rfq_package.documents
+        if document.status == RFQPackageDocumentStatus.attached
+    ]
+    packages: list[SupplierRFQPackageDraft] = []
+
+    for recipient in rfq_package.recipients:
+        draft = build_rfq_draft(
+            RFQDraftRequest(
+                project_name=rfq_package.project_name or rfq_package.title,
+                quote_return_deadline=rfq_package.due_at,
+                category=recipient.category or "Supplier pricing",
+                supplier_name=recipient.supplier_name,
+                scope_items=recipient.scope_items,
+                attachment_names=attachment_names,
+            )
+        )
+        packages.append(
+            SupplierRFQPackageDraft(
+                recipient_id=recipient.id,
+                supplier_id=recipient.supplier_id,
+                supplier_name=recipient.supplier_name,
+                category=recipient.category,
+                status=recipient.status,
+                subject=draft.subject,
+                body=draft.body,
+                scope_items=recipient.scope_items,
+                attachment_names=draft.attachment_names,
+            )
+        )
+
+    return RFQPackageBuildResponse(
+        rfq_package_id=rfq_package.id,
+        ready=readiness.ready,
+        blockers=[item.detail for item in readiness.items if not item.ready],
+        packages=packages,
     )
 
 
@@ -163,6 +375,77 @@ def _load_package(db: Session, rfq_package_id: UUID) -> RFQPackage:
     if rfq_package is None:
         raise AppError("RFQ package not found", status_code=404)
     return rfq_package
+
+
+def _metadata(rfq_package: RFQPackage) -> dict:
+    return dict(rfq_package.metadata_json or {})
+
+
+def _scope_for(rfq_package: RFQPackage, supplier_id: str) -> tuple[list[str], str | None]:
+    metadata = _metadata(rfq_package)
+    scopes = metadata.get("supplier_scopes") or {}
+    value = scopes.get(supplier_id) if isinstance(scopes, dict) else None
+    if not isinstance(value, dict):
+        return [], None
+    items = _clean_scope_items(value.get("items", []))
+    summary = value.get("summary")
+    return items, str(summary) if summary else None
+
+
+def _status_note_for(rfq_package: RFQPackage, supplier_id: str) -> str | None:
+    notes = _metadata(rfq_package).get("supplier_status_notes") or {}
+    if not isinstance(notes, dict):
+        return None
+    note = notes.get(supplier_id)
+    return str(note) if note else None
+
+
+def _clean_scope_items(items: object) -> list[str]:
+    if not isinstance(items, list):
+        return []
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _default_scope_items(category: str | None, package_scope: str | None) -> list[str]:
+    normalized = (category or "").strip().casefold()
+    template = next(
+        (
+            items
+            for keyword, items in CATEGORY_SCOPE_ITEMS.items()
+            if keyword in normalized
+        ),
+        [
+            "Price the complete applicable supplier or subcontractor scope.",
+            "Separate labour, material, equipment, delivery, mobilization, and taxes where applicable.",
+        ],
+    )
+    items = list(template)
+    if package_scope:
+        items.insert(0, f"Base pricing on this package scope: {package_scope.strip()}")
+    items.append(
+        "State exclusions, assumptions, lead time, quote validity, and proposed substitutions."
+    )
+    return items
+
+
+def _scope_summary(items: list[str]) -> str | None:
+    return " ".join(items) if items else None
+
+
+def _recipient_status(raw_status: str) -> RFQRecipientStatus:
+    if raw_status == "selected":
+        return RFQRecipientStatus.pending
+    return RFQRecipientStatus(raw_status)
+
+
+def _document_status(document: RFQPackageDocument) -> RFQPackageDocumentStatus:
+    if document.status == "registered":
+        return (
+            RFQPackageDocumentStatus.attached
+            if document.storage_uri
+            else RFQPackageDocumentStatus.pending
+        )
+    return RFQPackageDocumentStatus(document.status)
 
 
 def _to_schema(rfq_package: RFQPackage) -> RFQPackageRead:
@@ -182,7 +465,10 @@ def _to_schema(rfq_package: RFQPackage) -> RFQPackageRead:
                 supplier_id=recipient.supplier_id,
                 supplier_name=recipient.supplier_name,
                 category=recipient.category,
-                status=recipient.status,
+                status=_recipient_status(recipient.status),
+                scope_items=_scope_for(rfq_package, recipient.supplier_id)[0],
+                scope_summary=_scope_for(rfq_package, recipient.supplier_id)[1],
+                status_note=_status_note_for(rfq_package, recipient.supplier_id),
             )
             for recipient in rfq_package.recipients
         ],
@@ -192,7 +478,7 @@ def _to_schema(rfq_package: RFQPackage) -> RFQPackageRead:
                 document_type=document.document_type,
                 title=document.title,
                 required=document.required,
-                status=document.status,
+                status=_document_status(document),
                 storage_uri=document.storage_uri,
                 metadata=document.metadata_json or {},
             )

--- a/backend/app/services/rfq_packages.py
+++ b/backend/app/services/rfq_packages.py
@@ -106,6 +106,13 @@ def select_rfq_package_suppliers(
     payload: list[SupplierRecipientCreate],
 ) -> RFQPackageRead:
     rfq_package = _load_package(db, rfq_package_id)
+    existing_statuses = {
+        recipient.supplier_id: _recipient_status(recipient.status).value
+        for recipient in rfq_package.recipients
+    }
+    existing_notes = dict(
+        _metadata(rfq_package).get("supplier_status_notes") or {}
+    )
     db.execute(
         delete(RFQPackageSupplierRecipient).where(
             RFQPackageSupplierRecipient.rfq_package_id == rfq_package_id
@@ -128,13 +135,20 @@ def select_rfq_package_suppliers(
                 supplier_id=item.supplier_id,
                 supplier_name=item.supplier_name,
                 category=item.category,
-                status=RFQRecipientStatus.pending.value,
+                status=existing_statuses.get(
+                    item.supplier_id,
+                    RFQRecipientStatus.pending.value,
+                ),
             )
         )
 
     metadata = _metadata(rfq_package)
     metadata["supplier_scopes"] = scopes
-    metadata["supplier_status_notes"] = {}
+    metadata["supplier_status_notes"] = {
+        item.supplier_id: existing_notes[item.supplier_id]
+        for item in payload
+        if item.supplier_id in existing_notes
+    }
     rfq_package.metadata_json = metadata
     db.commit()
     return _to_schema(_load_package(db, rfq_package_id))
@@ -470,7 +484,10 @@ def _to_schema(rfq_package: RFQPackage) -> RFQPackageRead:
                 scope_summary=_scope_for(rfq_package, recipient.supplier_id)[1],
                 status_note=_status_note_for(rfq_package, recipient.supplier_id),
             )
-            for recipient in rfq_package.recipients
+            for recipient in sorted(
+                rfq_package.recipients,
+                key=lambda item: (item.supplier_id.casefold(), item.supplier_name.casefold()),
+            )
         ],
         documents=[
             RFQPackageDocumentRead(
@@ -482,7 +499,10 @@ def _to_schema(rfq_package: RFQPackage) -> RFQPackageRead:
                 storage_uri=document.storage_uri,
                 metadata=document.metadata_json or {},
             )
-            for document in rfq_package.documents
+            for document in sorted(
+                rfq_package.documents,
+                key=lambda item: (item.title.casefold(), item.document_type.casefold()),
+            )
         ],
         created_at=rfq_package.created_at,
         updated_at=rfq_package.updated_at,

--- a/docs/rfq-package-builder.md
+++ b/docs/rfq-package-builder.md
@@ -1,0 +1,41 @@
+# RFQ Package Builder (Build 204)
+
+Build 204 turns the existing RFQ package shell into a reviewable, supplier-specific package workflow.
+
+## Workflow
+
+1. Create an RFQ package with project, overall scope, return deadline, and supplier categories.
+2. Add supplier recipients and optionally enter one scope item per line.
+3. Generate missing supplier scopes from civil category defaults.
+4. Complete the drawing and document checklist with attachment references.
+5. Build individualized draft subjects, message bodies, scope lists, and attachment lists.
+6. Manually record each recipient as `pending`, `sent`, `replied`, or `bounced`.
+
+Building a package or changing a tracking status does **not** send an email or contact a supplier.
+
+## Readiness contract
+
+A package is ready only when:
+
+- the overall package scope exists;
+- at least one supplier recipient exists;
+- every recipient has supplier-specific scope items; and
+- every required document is marked attached with a storage reference.
+
+Optional documents may remain pending or be marked not applicable.
+
+## API
+
+- `PUT /api/v1/rfqs/{id}/suppliers` saves recipients and generates missing scopes.
+- `POST /api/v1/rfqs/{id}/supplier-scopes` generates missing scopes or force-regenerates them.
+- `PATCH /api/v1/rfqs/{id}/suppliers/{recipient_id}/status` records manual delivery status and notes.
+- `PUT /api/v1/rfqs/{id}/documents` saves the attachment checklist.
+- `PATCH /api/v1/rfqs/{id}/documents/{document_id}/status` updates one checklist item.
+- `GET /api/v1/rfqs/{id}/readiness` returns the four-part readiness score.
+- `POST /api/v1/rfqs/{id}/build` returns supplier-specific draft packages and blockers.
+
+## Known limitations
+
+- Supplier scopes and tracking notes are stored in the RFQ package metadata until dedicated database fields are introduced.
+- Attachment references are recorded but files are not uploaded by this build.
+- Email delivery and Gmail/Drive persistence remain part of the next workflow-design task.

--- a/frontend/src/api/rfqPackages.ts
+++ b/frontend/src/api/rfqPackages.ts
@@ -1,25 +1,37 @@
 export type RFQPackageStatus = "draft" | "assembling" | "ready" | "issued" | "closed";
+export type RFQRecipientStatus = "pending" | "sent" | "replied" | "bounced";
+export type RFQPackageDocumentStatus = "pending" | "attached" | "not_applicable";
 
-export type SupplierRecipient = {
-  id: string;
+export type SupplierRecipientCreate = {
   supplier_id: string;
   supplier_name: string;
-  category: string | null;
-  status: string;
+  category?: string | null;
+  scope_items: string[];
 };
 
-export type RFQPackageDocument = {
+export type SupplierRecipient = SupplierRecipientCreate & {
   id: string;
+  status: RFQRecipientStatus;
+  scope_summary?: string | null;
+  status_note?: string | null;
+};
+
+export type RFQPackageDocumentCreate = {
   document_type: string;
   title: string;
   required: boolean;
-  storage_uri: string | null;
+  storage_uri?: string | null;
+  status: RFQPackageDocumentStatus;
   metadata: Record<string, unknown>;
-  status: string;
+};
+
+export type RFQPackageDocument = RFQPackageDocumentCreate & {
+  id: string;
 };
 
 export type RFQPackage = {
   id: string;
+  project_id?: string | null;
   title: string;
   project_name: string | null;
   scope_summary: string | null;
@@ -55,9 +67,30 @@ export type RFQReadiness = {
 
 export type RFQPackageCreatePayload = {
   title: string;
+  project_id?: string;
   project_name?: string;
   scope_summary?: string;
+  due_at?: string;
   supplier_category_targets: string[];
+};
+
+export type SupplierRFQPackageDraft = {
+  recipient_id: string;
+  supplier_id: string;
+  supplier_name: string;
+  category?: string | null;
+  status: RFQRecipientStatus;
+  subject: string;
+  body: string;
+  scope_items: string[];
+  attachment_names: string[];
+};
+
+export type RFQPackageBuildResponse = {
+  rfq_package_id: string;
+  ready: boolean;
+  blockers: string[];
+  packages: SupplierRFQPackageDraft[];
 };
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
@@ -72,7 +105,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   });
 
   if (!response.ok) {
-    throw new Error(`Request failed with ${response.status}`);
+    const payload = await response.json().catch(() => null) as { detail?: string } | null;
+    throw new Error(payload?.detail ?? `Request failed with ${response.status}`);
   }
 
   return response.json() as Promise<T>;
@@ -91,15 +125,44 @@ export const rfqPackagesApi = {
       method: "PATCH",
       body: JSON.stringify({ status }),
     }),
-  selectSuppliers: (id: string, payload: Omit<SupplierRecipient, "id" | "status">[]) =>
+  selectSuppliers: (id: string, payload: SupplierRecipientCreate[]) =>
     request<RFQPackage>(`/rfqs/${id}/suppliers`, {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
-  registerDocuments: (id: string, payload: Omit<RFQPackageDocument, "id" | "status">[]) =>
+  generateScopes: (id: string, force = false) =>
+    request<RFQPackage>(`/rfqs/${id}/supplier-scopes`, {
+      method: "POST",
+      body: JSON.stringify({ force }),
+    }),
+  updateRecipientStatus: (
+    id: string,
+    recipientId: string,
+    status: RFQRecipientStatus,
+    note?: string,
+  ) =>
+    request<RFQPackage>(`/rfqs/${id}/suppliers/${recipientId}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status, note: note || null }),
+    }),
+  registerDocuments: (id: string, payload: RFQPackageDocumentCreate[]) =>
     request<RFQPackage>(`/rfqs/${id}/documents`, {
       method: "PUT",
       body: JSON.stringify(payload),
     }),
+  updateDocumentStatus: (
+    id: string,
+    documentId: string,
+    status: RFQPackageDocumentStatus,
+    storageUri?: string,
+  ) =>
+    request<RFQPackage>(`/rfqs/${id}/documents/${documentId}/status`, {
+      method: "PATCH",
+      body: JSON.stringify({ status, storage_uri: storageUri || null }),
+    }),
   readiness: (id: string) => request<RFQReadiness>(`/rfqs/${id}/readiness`),
+  build: (id: string) =>
+    request<RFQPackageBuildResponse>(`/rfqs/${id}/build`, {
+      method: "POST",
+    }),
 };

--- a/frontend/src/pages/RFQBuilderPage.test.tsx
+++ b/frontend/src/pages/RFQBuilderPage.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RFQBuilderPage } from "./RFQBuilderPage";
+
+const requests: Array<{ url: string; method: string; body: unknown }> = [];
+
+let packageState: Record<string, any>;
+let attachmentsReady = false;
+
+function resetPackage() {
+  attachmentsReady = false;
+  packageState = {
+    id: "rfq-1",
+    project_id: null,
+    title: "Stormwater Pipe RFQ",
+    project_name: "King George Utility Upgrade",
+    scope_summary: "Supply pipe and appurtenances.",
+    due_at: "2026-07-20T16:00:00Z",
+    status: "assembling",
+    supplier_category_targets: ["pipe"],
+    metadata: {},
+    recipients: [],
+    documents: [],
+    created_at: "2026-07-13T10:00:00Z",
+    updated_at: "2026-07-13T10:00:00Z",
+  };
+}
+
+function readiness() {
+  const suppliersReady = packageState.recipients.length > 0;
+  return {
+    rfq_package_id: "rfq-1",
+    status: packageState.status,
+    ready: suppliersReady && attachmentsReady,
+    score: suppliersReady && attachmentsReady ? 100 : suppliersReady ? 75 : 25,
+    items: [
+      { key: "scope", label: "Package scope summary", ready: true, detail: "Scope ready." },
+      { key: "suppliers", label: "Supplier recipients", ready: suppliersReady, detail: "Recipients." },
+      { key: "supplier_scopes", label: "Supplier-specific scopes", ready: suppliersReady, detail: "Scopes." },
+      { key: "documents", label: "Required attachments", ready: attachmentsReady, detail: "Attachments." },
+    ],
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("RFQBuilderPage", () => {
+  beforeEach(() => {
+    requests.length = 0;
+    resetPackage();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        const body = init?.body ? JSON.parse(String(init.body)) : null;
+        requests.push({ url, method, body });
+
+        if (url.endsWith("/rfqs") && method === "GET") {
+          return jsonResponse({ items: [packageState], total: 1 });
+        }
+        if (url.endsWith("/rfqs/rfq-1/readiness")) {
+          return jsonResponse(readiness());
+        }
+        if (url.endsWith("/rfqs/rfq-1") && method === "GET") {
+          return jsonResponse(packageState);
+        }
+        if (url.endsWith("/rfqs/rfq-1/suppliers") && method === "PUT") {
+          packageState = {
+            ...packageState,
+            recipients: body.map((supplier: Record<string, any>, index: number) => ({
+              ...supplier,
+              id: `recipient-${index + 1}`,
+              scope_items: supplier.scope_items.length
+                ? supplier.scope_items
+                : [
+                    "Provide itemized pricing for the specified pipe and fittings.",
+                    "Confirm lead time and delivery.",
+                  ],
+              scope_summary: "Generated pipe scope.",
+              status: "pending",
+              status_note: null,
+            })),
+          };
+          return jsonResponse(packageState);
+        }
+        if (url.includes("/suppliers/recipient-1/status") && method === "PATCH") {
+          packageState = {
+            ...packageState,
+            recipients: packageState.recipients.map((recipient: Record<string, any>) =>
+              recipient.id === "recipient-1"
+                ? { ...recipient, status: body.status, status_note: body.note }
+                : recipient,
+            ),
+          };
+          return jsonResponse(packageState);
+        }
+        if (url.endsWith("/rfqs/rfq-1/documents") && method === "PUT") {
+          attachmentsReady = true;
+          packageState = {
+            ...packageState,
+            documents: body.map((document: Record<string, any>, index: number) => ({
+              ...document,
+              id: `document-${index + 1}`,
+            })),
+          };
+          return jsonResponse(packageState);
+        }
+        if (url.endsWith("/rfqs/rfq-1/build") && method === "POST") {
+          return jsonResponse({
+            rfq_package_id: "rfq-1",
+            ready: true,
+            blockers: [],
+            packages: [
+              {
+                recipient_id: "recipient-1",
+                supplier_id: packageState.recipients[0].supplier_id,
+                supplier_name: "Pacific Pipe Supply",
+                category: "pipe",
+                status: "sent",
+                subject: "RFQ - King George Utility Upgrade - pipe - Pacific Pipe Supply",
+                body: "Hello,\n\nPlease price the generated pipe scope.",
+                scope_items: packageState.recipients[0].scope_items,
+                attachment_names: ["Civil drawings", "Project specifications"],
+              },
+            ],
+          });
+        }
+        throw new Error(`Unexpected request: ${method} ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("builds supplier scopes, attachment checklist, tracking, and draft packages", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/rfq-builder/rfq-1?projectName=King%20George"]}>
+        <Routes>
+          <Route path="/rfq-builder/:rfqPackageId" element={<RFQBuilderPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByLabelText("Supplier 1 name")).toBeInTheDocument();
+    expect(
+      screen.getByText("Draft-only workflow: building or changing tracking status does not send email or contact suppliers."),
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Supplier 1 name"), "Pacific Pipe Supply");
+    await user.type(screen.getByLabelText("Supplier 1 category"), "pipe");
+    await user.click(screen.getByRole("button", { name: "Save suppliers and scopes" }));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText("Supplier 1 scope items") as HTMLTextAreaElement).value)
+        .toContain("Provide itemized pricing");
+    });
+    expect(screen.getByText("Pacific Pipe Supply")).toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByLabelText("Pacific Pipe Supply tracking status"),
+      "sent",
+    );
+    await user.type(
+      screen.getByLabelText("Pacific Pipe Supply tracking note"),
+      "Issued manually at 09:00.",
+    );
+    await user.click(screen.getByRole("button", { name: "Save status" }));
+
+    await waitFor(() => {
+      expect(
+        requests.some(
+          (request) =>
+            request.url.includes("/suppliers/recipient-1/status")
+            && (request.body as Record<string, unknown>).status === "sent",
+        ),
+      ).toBe(true);
+    });
+
+    await user.selectOptions(screen.getByLabelText("Document 1 status"), "attached");
+    await user.type(
+      screen.getByLabelText("Document 1 attachment reference"),
+      "drive://projects/kg/civil-drawings.pdf",
+    );
+    await user.selectOptions(screen.getByLabelText("Document 2 status"), "attached");
+    await user.type(
+      screen.getByLabelText("Document 2 attachment reference"),
+      "drive://projects/kg/specifications.pdf",
+    );
+    await user.click(screen.getByRole("button", { name: "Save attachment checklist" }));
+
+    await waitFor(() => expect(screen.getByText("100%")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "Build draft packages" }));
+
+    expect(
+      await screen.findByText("Package is ready for manual review and issue."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Pacific Pipe Supply — RFQ - King George Utility Upgrade - pipe - Pacific Pipe Supply",
+      ),
+    ).toBeInTheDocument();
+
+    const supplierRequest = requests.find(
+      (request) => request.url.endsWith("/rfqs/rfq-1/suppliers") && request.method === "PUT",
+    );
+    expect(supplierRequest?.body).toEqual([
+      expect.objectContaining({
+        supplier_name: "Pacific Pipe Supply",
+        category: "pipe",
+        scope_items: [],
+      }),
+    ]);
+  });
+});

--- a/frontend/src/pages/RFQBuilderPage.tsx
+++ b/frontend/src/pages/RFQBuilderPage.tsx
@@ -128,7 +128,8 @@ export function RFQBuilderPage() {
     setIsMutating(true);
     setError(null);
     try {
-      await action();
+      const updated = await action();
+      setSelectedPackage(updated);
       setBuildResult(null);
       await refresh();
     } catch (currentError) {

--- a/frontend/src/pages/RFQBuilderPage.tsx
+++ b/frontend/src/pages/RFQBuilderPage.tsx
@@ -1,52 +1,83 @@
-import { CheckCircle2, Circle, FilePlus2, Plus, RefreshCw, Send, Users } from "lucide-react";
-import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  CheckCircle2,
+  Circle,
+  FilePlus2,
+  PackageCheck,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Users,
+} from "lucide-react";
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import {
   RFQPackage,
+  RFQPackageBuildResponse,
   RFQPackageCreatePayload,
+  RFQPackageDocumentCreate,
+  RFQPackageDocumentStatus,
   RFQPackageStatus,
   RFQReadiness,
+  RFQRecipientStatus,
+  SupplierRecipientCreate,
   rfqPackagesApi,
 } from "../api/rfqPackages";
+import { ProjectScopeNotice } from "../components/ProjectScopeNotice";
+import { readProjectContext } from "../utils/projectContext";
 
-const sampleSuppliers = [
-  { supplier_id: "supplier-001", supplier_name: "Pacific Pipe Supply", category: "pipe" },
-  { supplier_id: "supplier-002", supplier_name: "Fraser Valley Aggregates", category: "aggregates" },
-  { supplier_id: "supplier-003", supplier_name: "Coastal Traffic Control", category: "traffic" },
-];
+const recipientStatuses: RFQRecipientStatus[] = ["pending", "sent", "replied", "bounced"];
+const documentStatuses: RFQPackageDocumentStatus[] = ["pending", "attached", "not_applicable"];
 
-const sampleDocuments = [
-  {
-    document_type: "drawing",
-    title: "Civil drawings",
-    required: true,
-    storage_uri: null,
-    metadata: { source: "manual registration" },
-  },
-  {
-    document_type: "specification",
-    title: "Project specifications",
-    required: true,
-    storage_uri: null,
-    metadata: { source: "manual registration" },
-  },
-  {
-    document_type: "addenda",
-    title: "Addenda log",
-    required: false,
-    storage_uri: null,
-    metadata: { source: "manual registration" },
-  },
-];
+function blankSupplier(): SupplierRecipientCreate {
+  return {
+    supplier_id: `manual-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    supplier_name: "",
+    category: "",
+    scope_items: [],
+  };
+}
+
+function defaultDocuments(): RFQPackageDocumentCreate[] {
+  return [
+    {
+      document_type: "drawing",
+      title: "Civil drawings",
+      required: true,
+      storage_uri: "",
+      status: "pending",
+      metadata: {},
+    },
+    {
+      document_type: "specification",
+      title: "Project specifications",
+      required: true,
+      storage_uri: "",
+      status: "pending",
+      metadata: {},
+    },
+    {
+      document_type: "addenda",
+      title: "Current addenda",
+      required: false,
+      storage_uri: "",
+      status: "pending",
+      metadata: {},
+    },
+  ];
+}
 
 export function RFQBuilderPage() {
   const { rfqPackageId } = useParams();
+  const location = useLocation();
   const navigate = useNavigate();
+  const projectContext = readProjectContext(location.search);
   const [packages, setPackages] = useState<RFQPackage[]>([]);
   const [selectedPackage, setSelectedPackage] = useState<RFQPackage | null>(null);
   const [readiness, setReadiness] = useState<RFQReadiness | null>(null);
+  const [buildResult, setBuildResult] = useState<RFQPackageBuildResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isMutating, setIsMutating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
@@ -74,32 +105,50 @@ export function RFQBuilderPage() {
   }, [rfqPackageId]);
 
   useEffect(() => {
-    // This effect synchronizes the page with the backend when the selected RFQ changes.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
   }, [refresh]);
 
   async function createPackage(payload: RFQPackageCreatePayload) {
-    const created = await rfqPackagesApi.create(payload);
-    navigate(`/rfq-builder/${created.id}`);
+    setIsMutating(true);
+    setError(null);
+    try {
+      const created = await rfqPackagesApi.create(payload);
+      navigate({
+        pathname: `/rfq-builder/${created.id}`,
+        search: location.search,
+      });
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to create RFQ package");
+    } finally {
+      setIsMutating(false);
+    }
   }
 
-  async function updateStatus(status: RFQPackageStatus) {
-    if (!selectedPackage) return;
-    await rfqPackagesApi.updateStatus(selectedPackage.id, status);
-    await refresh();
+  async function mutate(action: () => Promise<RFQPackage>) {
+    setIsMutating(true);
+    setError(null);
+    try {
+      await action();
+      setBuildResult(null);
+      await refresh();
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to update RFQ package");
+    } finally {
+      setIsMutating(false);
+    }
   }
 
-  async function selectSuppliers() {
+  async function buildPackages() {
     if (!selectedPackage) return;
-    await rfqPackagesApi.selectSuppliers(selectedPackage.id, sampleSuppliers);
-    await refresh();
-  }
-
-  async function registerDocuments() {
-    if (!selectedPackage) return;
-    await rfqPackagesApi.registerDocuments(selectedPackage.id, sampleDocuments);
-    await refresh();
+    setIsMutating(true);
+    setError(null);
+    try {
+      setBuildResult(await rfqPackagesApi.build(selectedPackage.id));
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to build RFQ drafts");
+    } finally {
+      setIsMutating(false);
+    }
   }
 
   return (
@@ -108,8 +157,7 @@ export function RFQBuilderPage() {
         <div>
           <h1 className="text-3xl font-semibold text-iron-950">RFQ Package Builder</h1>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-500">
-            Create supplier RFQ packages, select recipients, register required bid documents, and
-            review package readiness before future issue automation is added.
+            Build supplier-specific RFQ scopes, confirm drawing and document attachments, preview draft packages, and manually track delivery responses.
           </p>
         </div>
         <button
@@ -122,29 +170,62 @@ export function RFQBuilderPage() {
         </button>
       </div>
 
+      <ProjectScopeNotice name={projectContext.projectName} />
+      <div className="rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
+        Draft-only workflow: building or changing tracking status does not send email or contact suppliers.
+      </div>
       {error ? <StatusNotice tone="error" message={error} /> : null}
       {isLoading ? <StatusNotice tone="neutral" message="Loading RFQ packages..." /> : null}
 
       <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
         <div className="space-y-6">
-          <CreateRFQPackageForm onSubmit={(payload) => void createPackage(payload)} />
-          <RFQPackageList packages={packages} selectedId={rfqPackageId} />
+          <CreateRFQPackageForm
+            defaultProjectName={projectContext.projectName ?? ""}
+            isBusy={isMutating}
+            onSubmit={(payload) => void createPackage(payload)}
+          />
+          <RFQPackageList
+            packages={packages}
+            selectedId={rfqPackageId}
+            search={location.search}
+          />
         </div>
 
         {selectedPackage ? (
           <RFQPackageDetail
             rfqPackage={selectedPackage}
             readiness={readiness}
-            onStatusChange={(status) => void updateStatus(status)}
-            onSelectSuppliers={() => void selectSuppliers()}
-            onRegisterDocuments={() => void registerDocuments()}
+            buildResult={buildResult}
+            isBusy={isMutating}
+            onStatusChange={(status) =>
+              void mutate(() => rfqPackagesApi.updateStatus(selectedPackage.id, status))
+            }
+            onSaveSuppliers={(suppliers) =>
+              void mutate(() => rfqPackagesApi.selectSuppliers(selectedPackage.id, suppliers))
+            }
+            onGenerateScopes={() =>
+              void mutate(() => rfqPackagesApi.generateScopes(selectedPackage.id))
+            }
+            onSaveDocuments={(documents) =>
+              void mutate(() => rfqPackagesApi.registerDocuments(selectedPackage.id, documents))
+            }
+            onRecipientStatus={(recipientId, status, note) =>
+              void mutate(() =>
+                rfqPackagesApi.updateRecipientStatus(
+                  selectedPackage.id,
+                  recipientId,
+                  status,
+                  note,
+                ),
+              )
+            }
+            onBuild={() => void buildPackages()}
           />
         ) : (
           <div className="rounded-md border border-iron-100 bg-white p-6">
             <h2 className="text-base font-semibold text-iron-950">No RFQ selected</h2>
             <p className="mt-2 text-sm leading-6 text-iron-500">
-              Create a package or select one from the list to review recipients, documents, and
-              readiness.
+              Create a package or select one to edit supplier scopes, attachments, and tracking.
             </p>
           </div>
         )}
@@ -154,29 +235,34 @@ export function RFQBuilderPage() {
 }
 
 function CreateRFQPackageForm({
+  defaultProjectName,
+  isBusy,
   onSubmit,
 }: {
+  defaultProjectName: string;
+  isBusy: boolean;
   onSubmit: (payload: RFQPackageCreatePayload) => void;
 }) {
   const [title, setTitle] = useState("");
-  const [projectName, setProjectName] = useState("");
+  const [projectName, setProjectName] = useState(defaultProjectName);
   const [scopeSummary, setScopeSummary] = useState("");
+  const [dueAt, setDueAt] = useState("");
   const [supplierTargets, setSupplierTargets] = useState("pipe, aggregates, traffic");
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!title.trim()) return;
+    if (!title.trim() || !scopeSummary.trim()) return;
     onSubmit({
       title: title.trim(),
       project_name: projectName.trim() || undefined,
-      scope_summary: scopeSummary.trim() || undefined,
+      scope_summary: scopeSummary.trim(),
+      due_at: dueAt ? new Date(dueAt).toISOString() : undefined,
       supplier_category_targets: supplierTargets
         .split(",")
         .map((target) => target.trim())
         .filter(Boolean),
     });
     setTitle("");
-    setProjectName("");
     setScopeSummary("");
   }
 
@@ -189,6 +275,7 @@ function CreateRFQPackageForm({
       <div className="space-y-4">
         <Field label="Package title">
           <input
+            required
             value={title}
             onChange={(event) => setTitle(event.target.value)}
             className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
@@ -200,18 +287,26 @@ function CreateRFQPackageForm({
             value={projectName}
             onChange={(event) => setProjectName(event.target.value)}
             className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
-            placeholder="King George utility upgrade"
           />
         </Field>
-        <Field label="Scope summary">
+        <Field label="Package scope">
           <textarea
+            required
             value={scopeSummary}
             onChange={(event) => setScopeSummary(event.target.value)}
             className="min-h-24 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
-            placeholder="Summarize the quote request scope."
+            placeholder="Define the overall supplier pricing scope."
           />
         </Field>
-        <Field label="Supplier category targeting">
+        <Field label="Quote return deadline">
+          <input
+            type="datetime-local"
+            value={dueAt}
+            onChange={(event) => setDueAt(event.target.value)}
+            className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+          />
+        </Field>
+        <Field label="Supplier category targets">
           <input
             value={supplierTargets}
             onChange={(event) => setSupplierTargets(event.target.value)}
@@ -221,10 +316,11 @@ function CreateRFQPackageForm({
       </div>
       <button
         type="submit"
-        className="mt-5 inline-flex items-center gap-2 rounded-md bg-iron-950 px-3 py-2 text-sm font-semibold text-white"
+        disabled={isBusy}
+        className="mt-5 inline-flex items-center gap-2 rounded-md bg-iron-950 px-3 py-2 text-sm font-semibold text-white disabled:bg-iron-300"
       >
         <Plus className="h-4 w-4" />
-        Create
+        Create package
       </button>
     </form>
   );
@@ -233,9 +329,11 @@ function CreateRFQPackageForm({
 function RFQPackageList({
   packages,
   selectedId,
+  search,
 }: {
   packages: RFQPackage[];
   selectedId: string | undefined;
+  search: string;
 }) {
   return (
     <div className="rounded-md border border-iron-100 bg-white p-5">
@@ -247,7 +345,7 @@ function RFQPackageList({
           packages.map((rfqPackage) => (
             <Link
               key={rfqPackage.id}
-              to={`/rfq-builder/${rfqPackage.id}`}
+              to={{ pathname: `/rfq-builder/${rfqPackage.id}`, search }}
               className={[
                 "block rounded-md border px-3 py-3 text-sm transition",
                 selectedId === rfqPackage.id
@@ -268,21 +366,27 @@ function RFQPackageList({
 function RFQPackageDetail({
   rfqPackage,
   readiness,
+  buildResult,
+  isBusy,
   onStatusChange,
-  onSelectSuppliers,
-  onRegisterDocuments,
+  onSaveSuppliers,
+  onGenerateScopes,
+  onSaveDocuments,
+  onRecipientStatus,
+  onBuild,
 }: {
   rfqPackage: RFQPackage;
   readiness: RFQReadiness | null;
+  buildResult: RFQPackageBuildResponse | null;
+  isBusy: boolean;
   onStatusChange: (status: RFQPackageStatus) => void;
-  onSelectSuppliers: () => void;
-  onRegisterDocuments: () => void;
+  onSaveSuppliers: (suppliers: SupplierRecipientCreate[]) => void;
+  onGenerateScopes: () => void;
+  onSaveDocuments: (documents: RFQPackageDocumentCreate[]) => void;
+  onRecipientStatus: (recipientId: string, status: RFQRecipientStatus, note: string) => void;
+  onBuild: () => void;
 }) {
   const statusOptions: RFQPackageStatus[] = ["draft", "assembling", "ready", "issued", "closed"];
-  const categoryTargets = useMemo(
-    () => rfqPackage.supplier_category_targets.join(", ") || "No targets set",
-    [rfqPackage.supplier_category_targets],
-  );
 
   return (
     <div className="space-y-6">
@@ -295,28 +399,52 @@ function RFQPackageDetail({
               {rfqPackage.scope_summary ?? "No scope summary yet."}
             </p>
           </div>
-          <select
-            value={rfqPackage.status}
-            onChange={(event) => onStatusChange(event.target.value as RFQPackageStatus)}
-            className="rounded-md border border-iron-100 bg-white px-3 py-2 text-sm"
-          >
-            {statusOptions.map((status) => (
-              <option key={status} value={status}>
-                {status}
-              </option>
-            ))}
-          </select>
+          <label className="grid gap-1 text-xs font-semibold uppercase tracking-wide text-iron-500">
+            Package status
+            <select
+              value={rfqPackage.status}
+              onChange={(event) => onStatusChange(event.target.value as RFQPackageStatus)}
+              className="rounded-md border border-iron-100 bg-white px-3 py-2 text-sm font-normal normal-case text-iron-800"
+            >
+              {statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}
+            </select>
+          </label>
         </div>
         <dl className="mt-5 grid gap-4 md:grid-cols-3">
           <InfoTile label="Project" value={rfqPackage.project_name ?? "Unassigned"} />
-          <InfoTile label="Category targets" value={categoryTargets} />
-          <InfoTile label="Status" value={rfqPackage.status} />
+          <InfoTile
+            label="Category targets"
+            value={rfqPackage.supplier_category_targets.join(", ") || "No targets set"}
+          />
+          <InfoTile
+            label="Quote return"
+            value={rfqPackage.due_at ? new Date(rfqPackage.due_at).toLocaleString("en-CA") : "Not set"}
+          />
         </dl>
       </div>
 
       <ReadinessPanel readiness={readiness} />
-      <SupplierSelectionTable rfqPackage={rfqPackage} onSelectSuppliers={onSelectSuppliers} />
-      <DocumentChecklistTable rfqPackage={rfqPackage} onRegisterDocuments={onRegisterDocuments} />
+      <SupplierScopeEditor
+        rfqPackage={rfqPackage}
+        isBusy={isBusy}
+        onSave={onSaveSuppliers}
+        onGenerate={onGenerateScopes}
+      />
+      <DocumentChecklistEditor
+        rfqPackage={rfqPackage}
+        isBusy={isBusy}
+        onSave={onSaveDocuments}
+      />
+      <RecipientTracking
+        rfqPackage={rfqPackage}
+        isBusy={isBusy}
+        onUpdate={onRecipientStatus}
+      />
+      <RFQDraftPackages
+        result={buildResult}
+        isBusy={isBusy}
+        onBuild={onBuild}
+      />
     </div>
   );
 }
@@ -328,14 +456,14 @@ function ReadinessPanel({ readiness }: { readiness: RFQReadiness | null }) {
         <div>
           <h2 className="text-base font-semibold text-iron-950">Package Readiness</h2>
           <p className="mt-1 text-sm text-iron-500">
-            Summary payload for deciding whether the package is ready to issue later.
+            All four checks must pass before the draft package is ready for manual issue.
           </p>
         </div>
         <div className="rounded-md bg-iron-950 px-3 py-2 text-sm font-semibold text-white">
           {readiness?.score ?? 0}%
         </div>
       </div>
-      <div className="mt-4 grid gap-3 md:grid-cols-3">
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {readiness?.items.map((item) => (
           <div key={item.key} className="rounded-md border border-iron-100 p-3">
             <div className="flex items-center gap-2 text-sm font-medium text-iron-950">
@@ -354,121 +482,391 @@ function ReadinessPanel({ readiness }: { readiness: RFQReadiness | null }) {
   );
 }
 
-function SupplierSelectionTable({
+function SupplierScopeEditor({
   rfqPackage,
-  onSelectSuppliers,
+  isBusy,
+  onSave,
+  onGenerate,
 }: {
   rfqPackage: RFQPackage;
-  onSelectSuppliers: () => void;
+  isBusy: boolean;
+  onSave: (suppliers: SupplierRecipientCreate[]) => void;
+  onGenerate: () => void;
 }) {
-  const rows = rfqPackage.recipients.length > 0 ? rfqPackage.recipients : sampleSuppliers;
-
-  return (
-    <DataPanel
-      icon={<Users className="h-4 w-4" />}
-      title="Supplier Selection"
-      actionLabel="Use Placeholder Selection"
-      onAction={onSelectSuppliers}
-    >
-      <Table
-        headers={["Supplier", "Category", "Status"]}
-        rows={rows.map((row) => [
-          row.supplier_name,
-          row.category ?? "Uncategorized",
-          "status" in row ? row.status : "candidate",
-        ])}
-      />
-    </DataPanel>
+  const [suppliers, setSuppliers] = useState<SupplierRecipientCreate[]>(() =>
+    rfqPackage.recipients.length
+      ? rfqPackage.recipients.map(({ supplier_id, supplier_name, category, scope_items }) => ({
+          supplier_id,
+          supplier_name,
+          category,
+          scope_items,
+        }))
+      : [blankSupplier()],
   );
-}
 
-function DocumentChecklistTable({
-  rfqPackage,
-  onRegisterDocuments,
-}: {
-  rfqPackage: RFQPackage;
-  onRegisterDocuments: () => void;
-}) {
-  const rows = rfqPackage.documents.length > 0 ? rfqPackage.documents : sampleDocuments;
+  useEffect(() => {
+    setSuppliers(
+      rfqPackage.recipients.length
+        ? rfqPackage.recipients.map(({ supplier_id, supplier_name, category, scope_items }) => ({
+            supplier_id,
+            supplier_name,
+            category,
+            scope_items,
+          }))
+        : [blankSupplier()],
+    );
+  }, [rfqPackage.id, rfqPackage.recipients]);
 
-  return (
-    <DataPanel
-      icon={<Send className="h-4 w-4" />}
-      title="Document Checklist"
-      actionLabel="Register Placeholder Documents"
-      onAction={onRegisterDocuments}
-    >
-      <Table
-        headers={["Document", "Type", "Required", "Status"]}
-        rows={rows.map((row) => [
-          row.title,
-          row.document_type,
-          row.required ? "Required" : "Optional",
-          "status" in row ? row.status : "pending",
-        ])}
-      />
-    </DataPanel>
-  );
-}
+  function update(index: number, patch: Partial<SupplierRecipientCreate>) {
+    setSuppliers((current) =>
+      current.map((supplier, supplierIndex) =>
+        supplierIndex === index ? { ...supplier, ...patch } : supplier,
+      ),
+    );
+  }
 
-function DataPanel({
-  icon,
-  title,
-  actionLabel,
-  onAction,
-  children,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  actionLabel: string;
-  onAction: () => void;
-  children: React.ReactNode;
-}) {
+  function save() {
+    onSave(
+      suppliers
+        .filter((supplier) => supplier.supplier_name.trim())
+        .map((supplier) => ({
+          ...supplier,
+          supplier_name: supplier.supplier_name.trim(),
+          category: supplier.category?.trim() || null,
+          scope_items: supplier.scope_items.map((item) => item.trim()).filter(Boolean),
+        })),
+    );
+  }
+
   return (
     <div className="rounded-md border border-iron-100 bg-white p-5">
-      <div className="mb-4 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-2 text-base font-semibold text-iron-950">
-          {icon}
-          {title}
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="h-4 w-4" />
+          <div>
+            <h2 className="text-base font-semibold text-iron-950">Supplier-specific scopes</h2>
+            <p className="text-sm text-iron-500">Leave scope blank to generate civil defaults from the supplier category.</p>
+          </div>
         </div>
-        <button
-          type="button"
-          onClick={onAction}
-          className="rounded-md border border-iron-100 px-3 py-2 text-xs font-semibold text-iron-800"
-        >
-          {actionLabel}
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" disabled={isBusy || !rfqPackage.recipients.length} onClick={onGenerate} className="rounded-md border border-iron-100 px-3 py-2 text-xs font-semibold disabled:text-iron-300">
+            Generate missing scopes
+          </button>
+          <button type="button" onClick={() => setSuppliers((current) => [...current, blankSupplier()])} className="inline-flex items-center gap-1 rounded-md border border-iron-100 px-3 py-2 text-xs font-semibold">
+            <Plus className="h-3 w-3" /> Add supplier
+          </button>
+        </div>
       </div>
-      {children}
+
+      <div className="mt-4 space-y-4">
+        {suppliers.map((supplier, index) => (
+          <div key={supplier.supplier_id} className="rounded-md border border-iron-100 p-4">
+            <div className="grid gap-3 md:grid-cols-[1fr_220px_100px]">
+              <input
+                aria-label={`Supplier ${index + 1} name`}
+                value={supplier.supplier_name}
+                onChange={(event) => update(index, { supplier_name: event.target.value })}
+                className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+                placeholder="Supplier name"
+              />
+              <input
+                aria-label={`Supplier ${index + 1} category`}
+                value={supplier.category ?? ""}
+                onChange={(event) => update(index, { category: event.target.value })}
+                className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+                placeholder="pipe, aggregates, traffic..."
+              />
+              <button
+                type="button"
+                disabled={suppliers.length <= 1}
+                onClick={() => setSuppliers((current) => current.filter((_, rowIndex) => rowIndex !== index))}
+                className="inline-flex items-center justify-center gap-1 text-sm text-red-700 disabled:text-iron-300"
+              >
+                <Trash2 className="h-4 w-4" /> Remove
+              </button>
+            </div>
+            <textarea
+              aria-label={`Supplier ${index + 1} scope items`}
+              value={supplier.scope_items.join("\n")}
+              onChange={(event) => update(index, { scope_items: event.target.value.split("\n") })}
+              className="mt-3 min-h-28 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="One supplier-specific scope item per line"
+            />
+          </div>
+        ))}
+      </div>
+      <button type="button" disabled={isBusy} onClick={save} className="mt-4 rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-iron-300">
+        Save suppliers and scopes
+      </button>
     </div>
   );
 }
 
-function Table({ headers, rows }: { headers: string[]; rows: string[][] }) {
+function DocumentChecklistEditor({
+  rfqPackage,
+  isBusy,
+  onSave,
+}: {
+  rfqPackage: RFQPackage;
+  isBusy: boolean;
+  onSave: (documents: RFQPackageDocumentCreate[]) => void;
+}) {
+  const [documents, setDocuments] = useState<RFQPackageDocumentCreate[]>(() =>
+    rfqPackage.documents.length
+      ? rfqPackage.documents.map(({ document_type, title, required, storage_uri, status, metadata }) => ({
+          document_type,
+          title,
+          required,
+          storage_uri,
+          status,
+          metadata,
+        }))
+      : defaultDocuments(),
+  );
+
+  useEffect(() => {
+    setDocuments(
+      rfqPackage.documents.length
+        ? rfqPackage.documents.map(({ document_type, title, required, storage_uri, status, metadata }) => ({
+            document_type,
+            title,
+            required,
+            storage_uri,
+            status,
+            metadata,
+          }))
+        : defaultDocuments(),
+    );
+  }, [rfqPackage.id, rfqPackage.documents]);
+
+  function update(index: number, patch: Partial<RFQPackageDocumentCreate>) {
+    setDocuments((current) =>
+      current.map((document, documentIndex) =>
+        documentIndex === index ? { ...document, ...patch } : document,
+      ),
+    );
+  }
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse text-left text-sm">
-        <thead>
-          <tr className="border-b border-iron-100 text-xs uppercase tracking-wide text-iron-500">
-            {headers.map((header) => (
-              <th key={header} className="py-2 pr-4 font-semibold">
-                {header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => (
-            <tr key={row.join("-")} className="border-b border-iron-100 last:border-b-0">
-              {row.map((cell) => (
-                <td key={cell} className="py-3 pr-4 text-iron-800">
-                  {cell}
-                </td>
-              ))}
-            </tr>
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-iron-950">Drawing and document checklist</h2>
+          <p className="mt-1 text-sm text-iron-500">Attached items require a Drive, document, or storage reference.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() =>
+            setDocuments((current) => [
+              ...current,
+              {
+                document_type: "other",
+                title: "",
+                required: false,
+                storage_uri: "",
+                status: "pending",
+                metadata: {},
+              },
+            ])
+          }
+          className="inline-flex items-center gap-1 rounded-md border border-iron-100 px-3 py-2 text-xs font-semibold"
+        >
+          <Plus className="h-3 w-3" /> Add document
+        </button>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {documents.map((document, index) => (
+          <div key={index} className="grid gap-3 rounded-md border border-iron-100 p-3 md:grid-cols-[1fr_150px_140px_1fr_90px]">
+            <input
+              aria-label={`Document ${index + 1} title`}
+              value={document.title}
+              onChange={(event) => update(index, { title: event.target.value })}
+              className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="Document title"
+            />
+            <input
+              aria-label={`Document ${index + 1} type`}
+              value={document.document_type}
+              onChange={(event) => update(index, { document_type: event.target.value })}
+              className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="drawing"
+            />
+            <select
+              aria-label={`Document ${index + 1} status`}
+              value={document.status}
+              onChange={(event) => update(index, { status: event.target.value as RFQPackageDocumentStatus })}
+              className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+            >
+              {documentStatuses.map((status) => <option key={status} value={status}>{status}</option>)}
+            </select>
+            <input
+              aria-label={`Document ${index + 1} attachment reference`}
+              required={document.status === "attached"}
+              value={document.storage_uri ?? ""}
+              onChange={(event) => update(index, { storage_uri: event.target.value })}
+              className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="Drive URL or document reference"
+            />
+            <label className="flex items-center gap-2 text-sm text-iron-700">
+              <input
+                aria-label={`Document ${index + 1} required`}
+                type="checkbox"
+                checked={document.required}
+                onChange={(event) => update(index, { required: event.target.checked })}
+              />
+              Required
+            </label>
+            <button
+              type="button"
+              disabled={documents.length <= 1}
+              onClick={() => setDocuments((current) => current.filter((_, rowIndex) => rowIndex !== index))}
+              className="inline-flex items-center gap-1 text-xs text-red-700 md:col-span-5"
+            >
+              <Trash2 className="h-3 w-3" /> Remove document
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        disabled={isBusy}
+        onClick={() => onSave(documents.filter((document) => document.title.trim()))}
+        className="mt-4 rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-iron-300"
+      >
+        Save attachment checklist
+      </button>
+    </div>
+  );
+}
+
+function RecipientTracking({
+  rfqPackage,
+  isBusy,
+  onUpdate,
+}: {
+  rfqPackage: RFQPackage;
+  isBusy: boolean;
+  onUpdate: (recipientId: string, status: RFQRecipientStatus, note: string) => void;
+}) {
+  const [statuses, setStatuses] = useState<Record<string, RFQRecipientStatus>>({});
+  const [notes, setNotes] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    setStatuses(Object.fromEntries(rfqPackage.recipients.map((item) => [item.id, item.status])));
+    setNotes(Object.fromEntries(rfqPackage.recipients.map((item) => [item.id, item.status_note ?? ""])));
+  }, [rfqPackage.id, rfqPackage.recipients]);
+
+  return (
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <h2 className="text-base font-semibold text-iron-950">Supplier delivery tracking</h2>
+      <p className="mt-1 text-sm text-iron-500">Manual status log only; no supplier message is sent from this screen.</p>
+      <div className="mt-4 space-y-3">
+        {rfqPackage.recipients.length ? rfqPackage.recipients.map((recipient) => (
+          <div key={recipient.id} className="grid gap-3 rounded-md border border-iron-100 p-3 md:grid-cols-[1fr_150px_1fr_110px]">
+            <div>
+              <div className="text-sm font-semibold text-iron-950">{recipient.supplier_name}</div>
+              <div className="text-xs text-iron-500">{recipient.category ?? "Uncategorized"}</div>
+            </div>
+            <select
+              aria-label={`${recipient.supplier_name} tracking status`}
+              value={statuses[recipient.id] ?? recipient.status}
+              onChange={(event) =>
+                setStatuses((current) => ({
+                  ...current,
+                  [recipient.id]: event.target.value as RFQRecipientStatus,
+                }))
+              }
+              className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+            >
+              {recipientStatuses.map((status) => <option key={status} value={status}>{status}</option>)}
+            </select>
+            <input
+              aria-label={`${recipient.supplier_name} tracking note`}
+              value={notes[recipient.id] ?? ""}
+              onChange={(event) =>
+                setNotes((current) => ({ ...current, [recipient.id]: event.target.value }))
+              }
+              className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="Manual tracking note"
+            />
+            <button
+              type="button"
+              disabled={isBusy}
+              onClick={() =>
+                onUpdate(
+                  recipient.id,
+                  statuses[recipient.id] ?? recipient.status,
+                  notes[recipient.id] ?? "",
+                )
+              }
+              className="rounded-md border border-iron-100 px-3 py-2 text-xs font-semibold disabled:text-iron-300"
+            >
+              Save status
+            </button>
+          </div>
+        )) : <p className="text-sm text-iron-500">Save supplier recipients to begin tracking.</p>}
+      </div>
+    </div>
+  );
+}
+
+function RFQDraftPackages({
+  result,
+  isBusy,
+  onBuild,
+}: {
+  result: RFQPackageBuildResponse | null;
+  isBusy: boolean;
+  onBuild: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-base font-semibold text-iron-950">Supplier draft packages</h2>
+          <p className="mt-1 text-sm text-iron-500">Generate individualized subjects, scope bodies, and attachment lists for review.</p>
+        </div>
+        <button
+          type="button"
+          disabled={isBusy}
+          onClick={onBuild}
+          className="inline-flex items-center gap-2 rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-iron-300"
+        >
+          <PackageCheck className="h-4 w-4" /> Build draft packages
+        </button>
+      </div>
+
+      {result ? (
+        <div className="mt-4 space-y-4">
+          {result.ready ? (
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+              Package is ready for manual review and issue.
+            </div>
+          ) : (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+              <div className="font-semibold">Drafts generated with readiness blockers</div>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                {result.blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
+              </ul>
+            </div>
+          )}
+          {result.packages.map((draft) => (
+            <details key={draft.recipient_id} className="rounded-md border border-iron-100 p-4">
+              <summary className="cursor-pointer text-sm font-semibold text-iron-950">
+                {draft.supplier_name} — {draft.subject}
+              </summary>
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <InfoTile label="Tracking status" value={draft.status} />
+                <InfoTile label="Attachments" value={draft.attachment_names.join(", ") || "None"} />
+              </div>
+              <pre className="mt-3 whitespace-pre-wrap rounded-md bg-iron-50 p-4 text-xs leading-5 text-iron-800">
+                {draft.body}
+              </pre>
+            </details>
           ))}
-        </tbody>
-      </table>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/RFQBuilderPage.tsx
+++ b/frontend/src/pages/RFQBuilderPage.tsx
@@ -194,6 +194,7 @@ export function RFQBuilderPage() {
 
         {selectedPackage ? (
           <RFQPackageDetail
+            key={selectedPackage.id}
             rfqPackage={selectedPackage}
             readiness={readiness}
             buildResult={buildResult}
@@ -506,17 +507,16 @@ function SupplierScopeEditor({
   );
 
   useEffect(() => {
+    if (!rfqPackage.recipients.length) return;
     setSuppliers(
-      rfqPackage.recipients.length
-        ? rfqPackage.recipients.map(({ supplier_id, supplier_name, category, scope_items }) => ({
-            supplier_id,
-            supplier_name,
-            category,
-            scope_items,
-          }))
-        : [blankSupplier()],
+      rfqPackage.recipients.map(({ supplier_id, supplier_name, category, scope_items }) => ({
+        supplier_id,
+        supplier_name,
+        category,
+        scope_items,
+      })),
     );
-  }, [rfqPackage.id, rfqPackage.recipients]);
+  }, [rfqPackage.recipients]);
 
   function update(index: number, patch: Partial<SupplierRecipientCreate>) {
     setSuppliers((current) =>
@@ -626,19 +626,18 @@ function DocumentChecklistEditor({
   );
 
   useEffect(() => {
+    if (!rfqPackage.documents.length) return;
     setDocuments(
-      rfqPackage.documents.length
-        ? rfqPackage.documents.map(({ document_type, title, required, storage_uri, status, metadata }) => ({
-            document_type,
-            title,
-            required,
-            storage_uri,
-            status,
-            metadata,
-          }))
-        : defaultDocuments(),
+      rfqPackage.documents.map(({ document_type, title, required, storage_uri, status, metadata }) => ({
+        document_type,
+        title,
+        required,
+        storage_uri,
+        status,
+        metadata,
+      })),
     );
-  }, [rfqPackage.id, rfqPackage.documents]);
+  }, [rfqPackage.documents]);
 
   function update(index: number, patch: Partial<RFQPackageDocumentCreate>) {
     setDocuments((current) =>

--- a/tests/backend/test_rfq_packages.py
+++ b/tests/backend/test_rfq_packages.py
@@ -13,6 +13,7 @@ def create_package() -> dict:
             "title": "Stormwater Pipe RFQ",
             "project_name": "King George Utility Upgrade",
             "scope_summary": "Supply pipe, fittings, and appurtenances for civil utility works.",
+            "due_at": "2026-07-20T16:00:00Z",
             "supplier_category_targets": ["pipe", "civil materials"],
             "metadata": {"estimator": "Phase 2"},
         },
@@ -22,31 +23,65 @@ def create_package() -> dict:
     return response.json()
 
 
-def test_create_rfq_package() -> None:
+def add_suppliers(rfq_package_id: str) -> dict:
+    response = client.put(
+        f"/api/v1/rfqs/{rfq_package_id}/suppliers",
+        json=[
+            {
+                "supplier_id": "supplier-001",
+                "supplier_name": "Pacific Pipe Supply",
+                "category": "pipe",
+            },
+            {
+                "supplier_id": "supplier-002",
+                "supplier_name": "Coastal Traffic Control",
+                "category": "traffic control",
+            },
+        ],
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def add_ready_documents(rfq_package_id: str) -> dict:
+    response = client.put(
+        f"/api/v1/rfqs/{rfq_package_id}/documents",
+        json=[
+            {
+                "document_type": "drawing",
+                "title": "C-101 Utility Plan",
+                "required": True,
+                "status": "attached",
+                "storage_uri": "drive://projects/kg/C-101.pdf",
+                "metadata": {"revision": "A"},
+            },
+            {
+                "document_type": "specification",
+                "title": "MMCD Supplemental Specifications",
+                "required": True,
+                "status": "attached",
+                "storage_uri": "drive://projects/kg/specifications.pdf",
+            },
+        ],
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+def test_create_list_and_read_rfq_package() -> None:
     payload = create_package()
 
     assert payload["title"] == "Stormwater Pipe RFQ"
     assert payload["status"] == "draft"
     assert payload["supplier_category_targets"] == ["pipe", "civil materials"]
 
+    listing = client.get("/api/v1/rfqs")
+    detail = client.get(f"/api/v1/rfqs/{payload['id']}")
 
-def test_list_rfq_packages() -> None:
-    create_package()
-
-    response = client.get("/api/v1/rfqs")
-
-    assert response.status_code == 200
-    assert response.json()["total"] == 1
-    assert response.json()["items"][0]["title"] == "Stormwater Pipe RFQ"
-
-
-def test_read_rfq_package_detail() -> None:
-    rfq_package = create_package()
-
-    response = client.get(f"/api/v1/rfqs/{rfq_package['id']}")
-
-    assert response.status_code == 200
-    assert response.json()["id"] == rfq_package["id"]
+    assert listing.status_code == 200
+    assert listing.json()["total"] == 1
+    assert detail.status_code == 200
+    assert detail.json()["id"] == payload["id"]
 
 
 def test_update_rfq_package_status() -> None:
@@ -61,9 +96,22 @@ def test_update_rfq_package_status() -> None:
     assert response.json()["status"] == "assembling"
 
 
-def test_select_rfq_package_suppliers() -> None:
+def test_supplier_selection_generates_category_specific_scopes() -> None:
     rfq_package = create_package()
 
+    payload = add_suppliers(rfq_package["id"])
+
+    assert len(payload["recipients"]) == 2
+    pipe_recipient, traffic_recipient = payload["recipients"]
+    assert pipe_recipient["status"] == "pending"
+    assert traffic_recipient["status"] == "pending"
+    assert any("pipe" in item.lower() for item in pipe_recipient["scope_items"])
+    assert any("traffic control" in item.lower() for item in traffic_recipient["scope_items"])
+    assert pipe_recipient["scope_items"] != traffic_recipient["scope_items"]
+
+
+def test_custom_supplier_scope_is_preserved_until_forced_regeneration() -> None:
+    rfq_package = create_package()
     response = client.put(
         f"/api/v1/rfqs/{rfq_package['id']}/suppliers",
         json=[
@@ -71,58 +119,33 @@ def test_select_rfq_package_suppliers() -> None:
                 "supplier_id": "supplier-001",
                 "supplier_name": "Pacific Pipe Supply",
                 "category": "pipe",
-            },
-            {
-                "supplier_id": "supplier-002",
-                "supplier_name": "Fraser Valley Aggregates",
-                "category": "aggregates",
-            },
-        ],
-    )
-
-    assert response.status_code == 200
-    assert len(response.json()["recipients"]) == 2
-    assert response.json()["recipients"][0]["status"] == "selected"
-
-
-def test_register_rfq_package_documents() -> None:
-    rfq_package = create_package()
-
-    response = client.put(
-        f"/api/v1/rfqs/{rfq_package['id']}/documents",
-        json=[
-            {
-                "document_type": "drawing",
-                "title": "C-101 Utility Plan",
-                "required": True,
-                "metadata": {"revision": "A"},
-            },
-            {
-                "document_type": "specification",
-                "title": "MMCD Supplemental Specifications",
-                "required": True,
-            },
-        ],
-    )
-
-    assert response.status_code == 200
-    assert len(response.json()["documents"]) == 2
-    assert response.json()["documents"][0]["status"] == "registered"
-
-
-def test_rfq_package_readiness_summary() -> None:
-    rfq_package = create_package()
-    client.put(
-        f"/api/v1/rfqs/{rfq_package['id']}/suppliers",
-        json=[
-            {
-                "supplier_id": "supplier-001",
-                "supplier_name": "Pacific Pipe Supply",
-                "category": "pipe",
+                "scope_items": ["Price DR35 PVC pipe only."],
             }
         ],
     )
-    client.put(
+    assert response.status_code == 200
+
+    preserved = client.post(
+        f"/api/v1/rfqs/{rfq_package['id']}/supplier-scopes",
+        json={"force": False},
+    )
+    regenerated = client.post(
+        f"/api/v1/rfqs/{rfq_package['id']}/supplier-scopes",
+        json={"force": True},
+    )
+
+    assert preserved.json()["recipients"][0]["scope_items"] == ["Price DR35 PVC pipe only."]
+    assert regenerated.status_code == 200
+    assert regenerated.json()["recipients"][0]["scope_items"] != [
+        "Price DR35 PVC pipe only."
+    ]
+
+
+def test_document_checklist_requires_attachment_references() -> None:
+    rfq_package = create_package()
+    add_suppliers(rfq_package["id"])
+
+    pending = client.put(
         f"/api/v1/rfqs/{rfq_package['id']}/documents",
         json=[
             {
@@ -132,51 +155,92 @@ def test_rfq_package_readiness_summary() -> None:
             }
         ],
     )
+    pending_readiness = client.get(
+        f"/api/v1/rfqs/{rfq_package['id']}/readiness"
+    )
+    invalid = client.put(
+        f"/api/v1/rfqs/{rfq_package['id']}/documents",
+        json=[
+            {
+                "document_type": "drawing",
+                "title": "C-101 Utility Plan",
+                "required": True,
+                "status": "attached",
+            }
+        ],
+    )
+
+    assert pending.status_code == 200
+    assert pending.json()["documents"][0]["status"] == "pending"
+    assert pending_readiness.json()["ready"] is False
+    assert invalid.status_code == 422
+
+
+def test_rfq_package_readiness_requires_scopes_and_attached_documents() -> None:
+    rfq_package = create_package()
+    add_suppliers(rfq_package["id"])
+    add_ready_documents(rfq_package["id"])
 
     response = client.get(f"/api/v1/rfqs/{rfq_package['id']}/readiness")
 
     assert response.status_code == 200
     assert response.json()["ready"] is True
     assert response.json()["score"] == 100
-    assert len(response.json()["items"]) == 3
+    assert len(response.json()["items"]) == 4
 
 
-def test_rfq_package_persists_across_requests() -> None:
+def test_track_supplier_sent_replied_and_bounced_statuses() -> None:
     rfq_package = create_package()
+    payload = add_suppliers(rfq_package["id"])
+    first, second = payload["recipients"]
+
+    sent = client.patch(
+        f"/api/v1/rfqs/{rfq_package['id']}/suppliers/{first['id']}/status",
+        json={"status": "sent", "note": "Issued manually at 09:00."},
+    )
+    replied = client.patch(
+        f"/api/v1/rfqs/{rfq_package['id']}/suppliers/{first['id']}/status",
+        json={"status": "replied", "note": "Quote received."},
+    )
+    bounced = client.patch(
+        f"/api/v1/rfqs/{rfq_package['id']}/suppliers/{second['id']}/status",
+        json={"status": "bounced", "note": "Mailbox rejected the address."},
+    )
+
+    assert sent.status_code == 200
+    assert replied.json()["recipients"][0]["status"] == "replied"
+    assert replied.json()["recipients"][0]["status_note"] == "Quote received."
+    assert bounced.json()["recipients"][1]["status"] == "bounced"
+
+
+def test_build_supplier_specific_rfq_drafts_without_sending() -> None:
+    rfq_package = create_package()
+    add_suppliers(rfq_package["id"])
+    add_ready_documents(rfq_package["id"])
+
+    response = client.post(f"/api/v1/rfqs/{rfq_package['id']}/build")
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["ready"] is True
+    assert payload["blockers"] == []
+    assert len(payload["packages"]) == 2
+    assert payload["packages"][0]["supplier_name"] == "Pacific Pipe Supply"
+    assert "Pacific Pipe Supply" in payload["packages"][0]["subject"]
+    assert "C-101 Utility Plan" in payload["packages"][0]["attachment_names"]
+    assert payload["packages"][0]["scope_items"] != payload["packages"][1]["scope_items"]
+    assert payload["packages"][0]["status"] == "pending"
+
+
+def test_rfq_package_children_and_metadata_persist_across_requests() -> None:
+    rfq_package = create_package()
+    add_suppliers(rfq_package["id"])
+    add_ready_documents(rfq_package["id"])
 
     first_response = client.get(f"/api/v1/rfqs/{rfq_package['id']}")
     second_response = client.get(f"/api/v1/rfqs/{rfq_package['id']}")
 
     assert first_response.status_code == 200
     assert second_response.status_code == 200
-    assert second_response.json()["id"] == rfq_package["id"]
-
-
-def test_rfq_package_children_persist_across_requests() -> None:
-    rfq_package = create_package()
-    client.put(
-        f"/api/v1/rfqs/{rfq_package['id']}/suppliers",
-        json=[
-            {
-                "supplier_id": "supplier-001",
-                "supplier_name": "Pacific Pipe Supply",
-                "category": "pipe",
-            }
-        ],
-    )
-    client.put(
-        f"/api/v1/rfqs/{rfq_package['id']}/documents",
-        json=[
-            {
-                "document_type": "drawing",
-                "title": "C-101 Utility Plan",
-                "required": True,
-            }
-        ],
-    )
-
-    response = client.get(f"/api/v1/rfqs/{rfq_package['id']}")
-
-    assert response.status_code == 200
-    assert response.json()["recipients"][0]["supplier_name"] == "Pacific Pipe Supply"
-    assert response.json()["documents"][0]["title"] == "C-101 Utility Plan"
+    assert second_response.json()["recipients"][0]["scope_items"]
+    assert second_response.json()["documents"][0]["storage_uri"].startswith("drive://")

--- a/tests/backend/test_rfq_packages.py
+++ b/tests/backend/test_rfq_packages.py
@@ -206,11 +206,21 @@ def test_track_supplier_sent_replied_and_bounced_statuses() -> None:
         f"/api/v1/rfqs/{rfq_package['id']}/suppliers/{second['id']}/status",
         json={"status": "bounced", "note": "Mailbox rejected the address."},
     )
+    resaved = add_suppliers(rfq_package["id"])
+    recipients_by_supplier = {
+        recipient["supplier_id"]: recipient for recipient in resaved["recipients"]
+    }
 
     assert sent.status_code == 200
     assert replied.json()["recipients"][0]["status"] == "replied"
     assert replied.json()["recipients"][0]["status_note"] == "Quote received."
     assert bounced.json()["recipients"][1]["status"] == "bounced"
+    assert recipients_by_supplier["supplier-001"]["status"] == "replied"
+    assert recipients_by_supplier["supplier-001"]["status_note"] == "Quote received."
+    assert recipients_by_supplier["supplier-002"]["status"] == "bounced"
+    assert recipients_by_supplier["supplier-002"]["status_note"] == (
+        "Mailbox rejected the address."
+    )
 
 
 def test_build_supplier_specific_rfq_drafts_without_sending() -> None:


### PR DESCRIPTION
## Summary
- replace the placeholder RFQ screen with a project-scoped package builder
- generate and edit category-specific supplier scopes
- manage a real drawing/document attachment checklist with required reference validation
- track supplier RFQs as pending, sent, replied, or bounced without sending messages
- build individualized draft packages with readiness blockers and attachment references

## Safety boundary
This workflow only builds drafts and records manual delivery status. It does not email suppliers, submit bids, accept contracts, or spend money.

## Validation
- frontend production build
- frontend test suite: 4 files / 8 tests
- Python compile validation for all changed backend modules
- backend API regression coverage added for scopes, attachments, readiness, status persistence, and draft builds

Closes the Build 204 item in #1.