### PR TITLE
Build 205: design Gmail and Drive RFQ workflow

### DIFF
--- a/backend/app/api/v1/routes/rfqs.py
+++ b/backend/app/api/v1/routes/rfqs.py
@@ -19,7 +19,12 @@ from app.schemas.rfq_package import (
     SupplierRecipientCreate,
     SupplierRecipientStatusUpdate,
 )
-from app.services import rfq_drafts, rfq_packages
+from app.schemas.rfq_workflow import (
+    RFQCommunicationWorkflow,
+    RFQWorkflowPrepareRequest,
+    SupplierResponseCreate,
+)
+from app.services import rfq_drafts, rfq_packages, rfq_workflows
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
@@ -138,3 +143,43 @@ def build_rfq_supplier_packages(
     db: DBSession,
 ) -> RFQPackageBuildResponse:
     return rfq_packages.build_rfq_supplier_packages(db, rfq_package_id)
+
+
+@router.get(
+    "/{rfq_package_id}/communication-workflow",
+    response_model=RFQCommunicationWorkflow,
+)
+def read_rfq_communication_workflow(
+    rfq_package_id: UUID,
+    db: DBSession,
+) -> RFQCommunicationWorkflow:
+    return rfq_workflows.get_rfq_communication_workflow(db, rfq_package_id)
+
+
+@router.post(
+    "/{rfq_package_id}/communication-workflow/prepare",
+    response_model=RFQCommunicationWorkflow,
+)
+def prepare_rfq_communication_workflow(
+    rfq_package_id: UUID,
+    payload: RFQWorkflowPrepareRequest,
+    db: DBSession,
+) -> RFQCommunicationWorkflow:
+    return rfq_workflows.prepare_rfq_communication_workflow(
+        db,
+        rfq_package_id,
+        payload,
+    )
+
+
+@router.post(
+    "/{rfq_package_id}/supplier-responses",
+    response_model=RFQCommunicationWorkflow,
+    status_code=status.HTTP_201_CREATED,
+)
+def record_supplier_response(
+    rfq_package_id: UUID,
+    payload: SupplierResponseCreate,
+    db: DBSession,
+) -> RFQCommunicationWorkflow:
+    return rfq_workflows.record_supplier_response(db, rfq_package_id, payload)

--- a/backend/app/schemas/rfq_package.py
+++ b/backend/app/schemas/rfq_package.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import StrEnum
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class RFQPackageStatus(StrEnum):
@@ -30,6 +30,7 @@ class SupplierRecipientCreate(BaseModel):
     supplier_id: str = Field(min_length=1)
     supplier_name: str = Field(min_length=1)
     category: str | None = None
+    recipient_email: EmailStr | None = None
     scope_items: list[str] = Field(default_factory=list)
 
 
@@ -122,6 +123,7 @@ class SupplierRFQPackageDraft(BaseModel):
     supplier_id: str
     supplier_name: str
     category: str | None = None
+    recipient_email: EmailStr | None = None
     status: RFQRecipientStatus
     subject: str
     body: str

--- a/backend/app/schemas/rfq_workflow.py
+++ b/backend/app/schemas/rfq_workflow.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class RFQWorkflowPrepareRequest(BaseModel):
+    drive_folder_uri: str = Field(min_length=1)
+    drive_manifest_uri: str | None = None
+    sender_name: str = "Iron House"
+    sender_email: EmailStr | None = None
+    sender_phone: str | None = None
+
+
+class DrivePackageRecord(BaseModel):
+    folder_uri: str
+    manifest_uri: str | None = None
+    reusable: bool = True
+    document_references: list[str] = Field(default_factory=list)
+    saved_at: datetime
+    source_fingerprint: str
+
+
+class GmailDraftPlan(BaseModel):
+    recipient_id: UUID
+    supplier_id: str
+    supplier_name: str
+    to: EmailStr | None = None
+    subject: str
+    body: str
+    attachment_references: list[str] = Field(default_factory=list)
+    status: Literal["preview_only"] = "preview_only"
+    ready_for_draft_creation: bool
+    send_approved: Literal[False] = False
+
+
+class SupplierResponseCreate(BaseModel):
+    supplier_id: str = Field(min_length=1)
+    received_at: datetime | None = None
+    gmail_thread_uri: str | None = None
+    drive_file_uri: str | None = None
+    notes: str | None = None
+
+
+class SupplierResponseRecord(SupplierResponseCreate):
+    id: UUID
+    supplier_name: str
+    received_at: datetime
+    recorded_at: datetime
+
+
+class RFQCommunicationWorkflow(BaseModel):
+    rfq_package_id: UUID
+    status: Literal["preview_only"] = "preview_only"
+    prepared_at: datetime | None = None
+    stale: bool = False
+    drive_package: DrivePackageRecord | None = None
+    gmail_drafts: list[GmailDraftPlan] = Field(default_factory=list)
+    supplier_responses: list[SupplierResponseRecord] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    external_actions_performed: Literal[False] = False
+    send_requires_approval: Literal[True] = True

--- a/backend/app/services/rfq_packages.py
+++ b/backend/app/services/rfq_packages.py
@@ -144,6 +144,11 @@ def select_rfq_package_suppliers(
 
     metadata = _metadata(rfq_package)
     metadata["supplier_scopes"] = scopes
+    metadata["supplier_contacts"] = {
+        item.supplier_id: {"recipient_email": str(item.recipient_email)}
+        for item in payload
+        if item.recipient_email
+    }
     metadata["supplier_status_notes"] = {
         item.supplier_id: existing_notes[item.supplier_id]
         for item in payload
@@ -351,6 +356,7 @@ def build_rfq_supplier_packages(
                 quote_return_deadline=rfq_package.due_at,
                 category=recipient.category or "Supplier pricing",
                 supplier_name=recipient.supplier_name,
+                recipient_email=recipient.recipient_email,
                 scope_items=recipient.scope_items,
                 attachment_names=attachment_names,
             )
@@ -361,6 +367,7 @@ def build_rfq_supplier_packages(
                 supplier_id=recipient.supplier_id,
                 supplier_name=recipient.supplier_name,
                 category=recipient.category,
+                recipient_email=recipient.recipient_email,
                 status=recipient.status,
                 subject=draft.subject,
                 body=draft.body,
@@ -412,6 +419,17 @@ def _status_note_for(rfq_package: RFQPackage, supplier_id: str) -> str | None:
         return None
     note = notes.get(supplier_id)
     return str(note) if note else None
+
+
+def _recipient_email_for(rfq_package: RFQPackage, supplier_id: str) -> str | None:
+    contacts = _metadata(rfq_package).get("supplier_contacts") or {}
+    if not isinstance(contacts, dict):
+        return None
+    contact = contacts.get(supplier_id)
+    if not isinstance(contact, dict):
+        return None
+    recipient_email = contact.get("recipient_email")
+    return str(recipient_email) if recipient_email else None
 
 
 def _clean_scope_items(items: object) -> list[str]:
@@ -479,6 +497,7 @@ def _to_schema(rfq_package: RFQPackage) -> RFQPackageRead:
                 supplier_id=recipient.supplier_id,
                 supplier_name=recipient.supplier_name,
                 category=recipient.category,
+                recipient_email=_recipient_email_for(rfq_package, recipient.supplier_id),
                 status=_recipient_status(recipient.status),
                 scope_items=_scope_for(rfq_package, recipient.supplier_id)[0],
                 scope_summary=_scope_for(rfq_package, recipient.supplier_id)[1],

--- a/backend/app/services/rfq_workflows.py
+++ b/backend/app/services/rfq_workflows.py
@@ -1,0 +1,265 @@
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, selectinload
+
+from app.core.errors import AppError
+from app.models.rfq import RFQPackage
+from app.schemas.rfq_draft import RFQDraftRequest
+from app.schemas.rfq_package import RFQPackageDocumentStatus, RFQRecipientStatus
+from app.schemas.rfq_workflow import (
+    DrivePackageRecord,
+    GmailDraftPlan,
+    RFQCommunicationWorkflow,
+    RFQWorkflowPrepareRequest,
+    SupplierResponseCreate,
+    SupplierResponseRecord,
+)
+from app.services.rfq_drafts import build_rfq_draft
+from app.services.rfq_packages import build_rfq_supplier_packages
+
+
+WORKFLOW_METADATA_KEY = "gmail_drive_workflow"
+RESPONSE_METADATA_KEY = "supplier_responses"
+
+
+def get_rfq_communication_workflow(
+    db: Session,
+    rfq_package_id: UUID,
+) -> RFQCommunicationWorkflow:
+    rfq_package = _load_package(db, rfq_package_id)
+    metadata = _metadata(rfq_package)
+    stored = metadata.get(WORKFLOW_METADATA_KEY) or {}
+    drive_payload = stored.get("drive_package") if isinstance(stored, dict) else None
+    drive_package = (
+        DrivePackageRecord.model_validate(drive_payload)
+        if isinstance(drive_payload, dict)
+        else None
+    )
+    gmail_payloads = stored.get("gmail_drafts", []) if isinstance(stored, dict) else []
+    response_payloads = metadata.get(RESPONSE_METADATA_KEY) or []
+    return RFQCommunicationWorkflow(
+        rfq_package_id=rfq_package.id,
+        prepared_at=stored.get("prepared_at") if isinstance(stored, dict) else None,
+        stale=(
+            drive_package is not None
+            and drive_package.source_fingerprint != _source_fingerprint(rfq_package)
+        ),
+        drive_package=drive_package,
+        gmail_drafts=[
+            GmailDraftPlan.model_validate(item)
+            for item in gmail_payloads
+            if isinstance(item, dict)
+        ],
+        supplier_responses=[
+            SupplierResponseRecord.model_validate(item)
+            for item in response_payloads
+            if isinstance(item, dict)
+        ],
+        blockers=(
+            [str(item) for item in stored.get("blockers", [])]
+            if isinstance(stored, dict)
+            else []
+        ),
+    )
+
+
+def prepare_rfq_communication_workflow(
+    db: Session,
+    rfq_package_id: UUID,
+    payload: RFQWorkflowPrepareRequest,
+) -> RFQCommunicationWorkflow:
+    if not payload.drive_folder_uri.strip():
+        raise AppError("A Drive folder reference is required.", status_code=422)
+
+    rfq_package = _load_package(db, rfq_package_id)
+    build = build_rfq_supplier_packages(db, rfq_package_id)
+    attachment_references = sorted(
+        {
+            document.storage_uri
+            for document in rfq_package.documents
+            if document.status in {"attached", "registered"} and document.storage_uri
+        }
+    )
+    blockers = list(build.blockers)
+    gmail_drafts: list[GmailDraftPlan] = []
+    for draft in build.packages:
+        if not draft.recipient_email:
+            blockers.append(f"Add a recipient email for {draft.supplier_name}.")
+        email_draft = build_rfq_draft(
+            RFQDraftRequest(
+                project_name=rfq_package.project_name or rfq_package.title,
+                quote_return_deadline=rfq_package.due_at,
+                category=draft.category or "Supplier pricing",
+                supplier_name=draft.supplier_name,
+                recipient_email=draft.recipient_email,
+                scope_items=draft.scope_items,
+                attachment_names=draft.attachment_names,
+                sender_name=payload.sender_name,
+                sender_email=payload.sender_email,
+                sender_phone=payload.sender_phone,
+            )
+        )
+        gmail_drafts.append(
+            GmailDraftPlan(
+                recipient_id=draft.recipient_id,
+                supplier_id=draft.supplier_id,
+                supplier_name=draft.supplier_name,
+                to=draft.recipient_email,
+                subject=email_draft.subject,
+                body=email_draft.body,
+                attachment_references=attachment_references,
+                ready_for_draft_creation=build.ready and bool(draft.recipient_email),
+            )
+        )
+
+    now = datetime.now(timezone.utc)
+    drive_package = DrivePackageRecord(
+        folder_uri=payload.drive_folder_uri.strip(),
+        manifest_uri=(payload.drive_manifest_uri or "").strip() or None,
+        document_references=attachment_references,
+        saved_at=now,
+        source_fingerprint=_source_fingerprint(rfq_package),
+    )
+    metadata = _metadata(rfq_package)
+    metadata[WORKFLOW_METADATA_KEY] = {
+        "prepared_at": now.isoformat(),
+        "drive_package": drive_package.model_dump(mode="json"),
+        "gmail_drafts": [item.model_dump(mode="json") for item in gmail_drafts],
+        "blockers": list(dict.fromkeys(blockers)),
+        "sender": {
+            "name": payload.sender_name,
+            "email": str(payload.sender_email) if payload.sender_email else None,
+            "phone": payload.sender_phone,
+        },
+    }
+    rfq_package.metadata_json = metadata
+    db.commit()
+    return get_rfq_communication_workflow(db, rfq_package_id)
+
+
+def record_supplier_response(
+    db: Session,
+    rfq_package_id: UUID,
+    payload: SupplierResponseCreate,
+) -> RFQCommunicationWorkflow:
+    if not (payload.gmail_thread_uri or "").strip() and not (
+        payload.drive_file_uri or ""
+    ).strip():
+        raise AppError(
+            "A Gmail thread or Drive file reference is required.",
+            status_code=422,
+        )
+
+    rfq_package = _load_package(db, rfq_package_id)
+    recipient = next(
+        (
+            item
+            for item in rfq_package.recipients
+            if item.supplier_id == payload.supplier_id
+        ),
+        None,
+    )
+    if recipient is None:
+        raise AppError("RFQ supplier recipient not found", status_code=404)
+
+    now = datetime.now(timezone.utc)
+    record = SupplierResponseRecord(
+        id=uuid4(),
+        supplier_id=recipient.supplier_id,
+        supplier_name=recipient.supplier_name,
+        received_at=payload.received_at or now,
+        recorded_at=now,
+        gmail_thread_uri=(payload.gmail_thread_uri or "").strip() or None,
+        drive_file_uri=(payload.drive_file_uri or "").strip() or None,
+        notes=(payload.notes or "").strip() or None,
+    )
+    metadata = _metadata(rfq_package)
+    responses = list(metadata.get(RESPONSE_METADATA_KEY) or [])
+    responses.append(record.model_dump(mode="json"))
+    metadata[RESPONSE_METADATA_KEY] = responses
+    notes = dict(metadata.get("supplier_status_notes") or {})
+    notes[recipient.supplier_id] = record.notes or "Supplier response recorded."
+    metadata["supplier_status_notes"] = notes
+    rfq_package.metadata_json = metadata
+    recipient.status = RFQRecipientStatus.replied.value
+    db.commit()
+    return get_rfq_communication_workflow(db, rfq_package_id)
+
+
+def _load_package(db: Session, rfq_package_id: UUID) -> RFQPackage:
+    rfq_package = db.scalar(
+        select(RFQPackage)
+        .where(RFQPackage.id == rfq_package_id)
+        .options(
+            selectinload(RFQPackage.recipients),
+            selectinload(RFQPackage.documents),
+        )
+    )
+    if rfq_package is None:
+        raise AppError("RFQ package not found", status_code=404)
+    return rfq_package
+
+
+def _metadata(rfq_package: RFQPackage) -> dict:
+    return dict(rfq_package.metadata_json or {})
+
+
+def _recipient_email(rfq_package: RFQPackage, supplier_id: str) -> str | None:
+    contacts = _metadata(rfq_package).get("supplier_contacts") or {}
+    if not isinstance(contacts, dict):
+        return None
+    contact = contacts.get(supplier_id)
+    if not isinstance(contact, dict):
+        return None
+    value = contact.get("recipient_email")
+    return str(value) if value else None
+
+
+def _supplier_scope(rfq_package: RFQPackage, supplier_id: str) -> list[str]:
+    scopes = _metadata(rfq_package).get("supplier_scopes") or {}
+    scope = scopes.get(supplier_id) if isinstance(scopes, dict) else None
+    items = scope.get("items", []) if isinstance(scope, dict) else []
+    return [str(item) for item in items] if isinstance(items, list) else []
+
+
+def _source_fingerprint(rfq_package: RFQPackage) -> str:
+    source = {
+        "title": rfq_package.title,
+        "project_name": rfq_package.project_name,
+        "scope_summary": rfq_package.scope_summary,
+        "due_at": rfq_package.due_at.isoformat() if rfq_package.due_at else None,
+        "recipients": sorted(
+            [
+                {
+                    "supplier_id": item.supplier_id,
+                    "supplier_name": item.supplier_name,
+                    "category": item.category,
+                    "recipient_email": _recipient_email(rfq_package, item.supplier_id),
+                    "scope_items": _supplier_scope(rfq_package, item.supplier_id),
+                }
+                for item in rfq_package.recipients
+            ],
+            key=lambda item: str(item["supplier_id"]),
+        ),
+        "documents": sorted(
+            [
+                {
+                    "title": item.title,
+                    "status": (
+                        RFQPackageDocumentStatus.attached.value
+                        if item.status == "registered" and item.storage_uri
+                        else item.status
+                    ),
+                    "storage_uri": item.storage_uri,
+                }
+                for item in rfq_package.documents
+            ],
+            key=lambda item: str(item["title"]),
+        ),
+    }
+    encoded = json.dumps(source, sort_keys=True, separators=(",", ":")).encode()
+    return sha256(encoded).hexdigest()

--- a/docs/gmail-drive-workflow.md
+++ b/docs/gmail-drive-workflow.md
@@ -1,0 +1,37 @@
+# Gmail and Drive workflow design
+
+Build 205 adds a connector-neutral workflow around the RFQ package builder. It prepares reusable package manifests, Gmail-ready draft plans, and supplier response references while keeping every Google-side action outside the application boundary.
+
+## Safety boundary
+
+- Preparing a workflow stores an IHOS manifest only. It does not create a Drive folder, upload a file, or create a Gmail draft.
+- Draft plans are always returned as `preview_only` with `send_approved: false`.
+- Sending supplier communication requires a separate, explicit approval and is not implemented by this build.
+- Recording a response stores existing Gmail or Drive references. It does not read, move, copy, or modify those external items.
+
+## Workflow
+
+1. Add each supplier's estimating email to the supplier-specific scope.
+2. Complete RFQ readiness and attach Drive or storage references.
+3. Save a reusable draft workflow with a Drive folder reference and optional manifest reference.
+4. Review the generated Gmail draft plan, blockers, recipients, and attachments.
+5. After a response arrives outside IHOS, register its Gmail thread or Drive file reference. IHOS marks that supplier as replied.
+
+The saved plan includes a fingerprint of the package recipients, scopes, dates, and attachment references. IHOS reports the workflow as stale whenever those inputs change.
+
+## API
+
+- `GET /api/v1/rfqs/{id}/communication-workflow` returns the persisted preview and supplier response index.
+- `POST /api/v1/rfqs/{id}/communication-workflow/prepare` stores a reusable Drive manifest record and Gmail-ready draft plans.
+- `POST /api/v1/rfqs/{id}/supplier-responses` stores an existing Gmail thread or Drive file reference and marks the supplier replied.
+
+## Persistence
+
+The workflow manifest, supplier contact emails, and response index are stored in `RFQPackage.metadata_json`. This keeps Build 205 migration-free and preserves package portability. A future connector implementation can move these records into dedicated tables without changing the public API.
+
+## Known limitations
+
+- Gmail and Drive APIs are not called; OAuth and provider adapters remain future work.
+- Attachment and response references must be entered or selected by the user.
+- Supplier responses are indexed but their files and message bodies are not ingested.
+- Concurrent edits use the RFQ package's normal last-write behavior; provider-side version reconciliation is not implemented.

--- a/frontend/src/api/rfqPackages.ts
+++ b/frontend/src/api/rfqPackages.ts
@@ -6,6 +6,7 @@ export type SupplierRecipientCreate = {
   supplier_id: string;
   supplier_name: string;
   category?: string | null;
+  recipient_email?: string | null;
   scope_items: string[];
 };
 
@@ -93,6 +94,68 @@ export type RFQPackageBuildResponse = {
   packages: SupplierRFQPackageDraft[];
 };
 
+export type GmailDraftPlan = {
+  recipient_id: string;
+  supplier_id: string;
+  supplier_name: string;
+  to?: string | null;
+  subject: string;
+  body: string;
+  attachment_references: string[];
+  status: "preview_only";
+  ready_for_draft_creation: boolean;
+  send_approved: false;
+};
+
+export type DrivePackageRecord = {
+  folder_uri: string;
+  manifest_uri?: string | null;
+  reusable: boolean;
+  document_references: string[];
+  saved_at: string;
+  source_fingerprint: string;
+};
+
+export type SupplierResponse = {
+  id: string;
+  supplier_id: string;
+  supplier_name: string;
+  received_at: string;
+  recorded_at: string;
+  gmail_thread_uri?: string | null;
+  drive_file_uri?: string | null;
+  notes?: string | null;
+};
+
+export type SupplierResponseCreatePayload = {
+  supplier_id: string;
+  received_at?: string;
+  gmail_thread_uri?: string;
+  drive_file_uri?: string;
+  notes?: string;
+};
+
+export type RFQCommunicationWorkflow = {
+  rfq_package_id: string;
+  status: "preview_only";
+  prepared_at?: string | null;
+  stale: boolean;
+  drive_package?: DrivePackageRecord | null;
+  gmail_drafts: GmailDraftPlan[];
+  supplier_responses: SupplierResponse[];
+  blockers: string[];
+  external_actions_performed: false;
+  send_requires_approval: true;
+};
+
+export type RFQWorkflowPreparePayload = {
+  drive_folder_uri: string;
+  drive_manifest_uri?: string;
+  sender_name: string;
+  sender_email?: string;
+  sender_phone?: string;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -164,5 +227,17 @@ export const rfqPackagesApi = {
   build: (id: string) =>
     request<RFQPackageBuildResponse>(`/rfqs/${id}/build`, {
       method: "POST",
+    }),
+  communicationWorkflow: (id: string) =>
+    request<RFQCommunicationWorkflow>(`/rfqs/${id}/communication-workflow`),
+  prepareCommunicationWorkflow: (id: string, payload: RFQWorkflowPreparePayload) =>
+    request<RFQCommunicationWorkflow>(`/rfqs/${id}/communication-workflow/prepare`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  recordSupplierResponse: (id: string, payload: SupplierResponseCreatePayload) =>
+    request<RFQCommunicationWorkflow>(`/rfqs/${id}/supplier-responses`, {
+      method: "POST",
+      body: JSON.stringify(payload),
     }),
 };

--- a/frontend/src/api/rfqPackages.ts
+++ b/frontend/src/api/rfqPackages.ts
@@ -80,6 +80,7 @@ export type SupplierRFQPackageDraft = {
   supplier_id: string;
   supplier_name: string;
   category?: string | null;
+  recipient_email?: string | null;
   status: RFQRecipientStatus;
   subject: string;
   body: string;

--- a/frontend/src/pages/RFQBuilderPage.test.tsx
+++ b/frontend/src/pages/RFQBuilderPage.test.tsx
@@ -9,6 +9,7 @@ const requests: Array<{ url: string; method: string; body: unknown }> = [];
 
 let packageState: Record<string, any>;
 let attachmentsReady = false;
+let workflowState: Record<string, any>;
 
 function resetPackage() {
   attachmentsReady = false;
@@ -26,6 +27,18 @@ function resetPackage() {
     documents: [],
     created_at: "2026-07-13T10:00:00Z",
     updated_at: "2026-07-13T10:00:00Z",
+  };
+  workflowState = {
+    rfq_package_id: "rfq-1",
+    status: "preview_only",
+    prepared_at: null,
+    stale: false,
+    drive_package: null,
+    gmail_drafts: [],
+    supplier_responses: [],
+    blockers: [],
+    external_actions_performed: false,
+    send_requires_approval: true,
   };
 }
 
@@ -69,6 +82,9 @@ describe("RFQBuilderPage", () => {
         }
         if (url.endsWith("/rfqs/rfq-1/readiness")) {
           return jsonResponse(readiness());
+        }
+        if (url.endsWith("/rfqs/rfq-1/communication-workflow") && method === "GET") {
+          return jsonResponse(workflowState);
         }
         if (url.endsWith("/rfqs/rfq-1") && method === "GET") {
           return jsonResponse(packageState);
@@ -134,6 +150,66 @@ describe("RFQBuilderPage", () => {
             ],
           });
         }
+        if (url.endsWith("/rfqs/rfq-1/communication-workflow/prepare") && method === "POST") {
+          workflowState = {
+            ...workflowState,
+            prepared_at: "2026-07-13T15:40:00Z",
+            drive_package: {
+              folder_uri: body.drive_folder_uri,
+              manifest_uri: body.drive_manifest_uri ?? null,
+              reusable: true,
+              document_references: packageState.documents.map(
+                (document: Record<string, any>) => document.storage_uri,
+              ),
+              saved_at: "2026-07-13T15:40:00Z",
+              source_fingerprint: "fingerprint-1",
+            },
+            gmail_drafts: [
+              {
+                recipient_id: "recipient-1",
+                supplier_id: packageState.recipients[0].supplier_id,
+                supplier_name: packageState.recipients[0].supplier_name,
+                to: packageState.recipients[0].recipient_email,
+                subject: "RFQ - King George Utility Upgrade - pipe - Pacific Pipe Supply",
+                body: "Hello, draft only.",
+                attachment_references: packageState.documents.map(
+                  (document: Record<string, any>) => document.storage_uri,
+                ),
+                status: "preview_only",
+                ready_for_draft_creation: true,
+                send_approved: false,
+              },
+            ],
+          };
+          return jsonResponse(workflowState);
+        }
+        if (url.endsWith("/rfqs/rfq-1/supplier-responses") && method === "POST") {
+          workflowState = {
+            ...workflowState,
+            supplier_responses: [
+              ...workflowState.supplier_responses,
+              {
+                id: "response-1",
+                supplier_id: body.supplier_id,
+                supplier_name: "Pacific Pipe Supply",
+                received_at: "2026-07-13T15:45:00Z",
+                recorded_at: "2026-07-13T15:45:00Z",
+                gmail_thread_uri: body.gmail_thread_uri ?? null,
+                drive_file_uri: body.drive_file_uri ?? null,
+                notes: body.notes ?? null,
+              },
+            ],
+          };
+          packageState = {
+            ...packageState,
+            recipients: packageState.recipients.map((recipient: Record<string, any>) => ({
+              ...recipient,
+              status: recipient.supplier_id === body.supplier_id ? "replied" : recipient.status,
+              status_note: recipient.supplier_id === body.supplier_id ? body.notes : recipient.status_note,
+            })),
+          };
+          return jsonResponse(workflowState, 201);
+        }
         throw new Error(`Unexpected request: ${method} ${url}`);
       }),
     );
@@ -160,13 +236,41 @@ describe("RFQBuilderPage", () => {
 
     await user.type(screen.getByLabelText("Supplier 1 name"), "Pacific Pipe Supply");
     await user.type(screen.getByLabelText("Supplier 1 category"), "pipe");
+    await user.type(
+      screen.getByLabelText("Supplier 1 email"),
+      "estimating@pacific-pipe.example",
+    );
     await user.click(screen.getByRole("button", { name: "Save suppliers and scopes" }));
 
+    await waitFor(() => {
+      expect(
+        requests.some(
+          (request) =>
+            request.url.endsWith("/rfqs/rfq-1/suppliers")
+            && request.method === "PUT",
+        ),
+      ).toBe(true);
+    });
+    expect(
+      requests.find(
+        (request) =>
+          request.url.endsWith("/rfqs/rfq-1/suppliers")
+          && request.method === "PUT",
+      )?.body,
+    ).toEqual([
+      expect.objectContaining({
+        supplier_name: "Pacific Pipe Supply",
+        category: "pipe",
+      }),
+    ]);
+    expect(
+      await screen.findByLabelText("Pacific Pipe Supply tracking status"),
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect((screen.getByLabelText("Supplier 1 scope items") as HTMLTextAreaElement).value)
         .toContain("Provide itemized pricing");
     });
-    expect(screen.getByText("Pacific Pipe Supply")).toBeInTheDocument();
+    expect(screen.getAllByText("Pacific Pipe Supply").length).toBeGreaterThan(0);
 
     await user.selectOptions(
       screen.getByLabelText("Pacific Pipe Supply tracking status"),
@@ -213,6 +317,35 @@ describe("RFQBuilderPage", () => {
       ),
     ).toBeInTheDocument();
 
+    await user.type(
+      screen.getByLabelText("Drive package folder reference"),
+      "drive://projects/kg/rfq/stormwater",
+    );
+    await user.type(
+      screen.getByLabelText("Workflow sender email"),
+      "estimating@ironhouse.example",
+    );
+    await user.click(screen.getByRole("button", { name: "Save reusable draft workflow" }));
+
+    expect(
+      await screen.findByText("Preview-only workflow saved. No Gmail or Drive action was performed."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Ready for separately approved draft creation"),
+    ).toBeInTheDocument();
+
+    await user.type(
+      screen.getByLabelText("Drive response file reference"),
+      "drive://projects/kg/responses/pacific-pipe.pdf",
+    );
+    await user.type(
+      screen.getByLabelText("Response notes"),
+      "Quote received and saved.",
+    );
+    await user.click(screen.getByRole("button", { name: "Record response reference" }));
+
+    expect(await screen.findByText("Quote received and saved.")).toBeInTheDocument();
+
     const supplierRequest = requests.find(
       (request) => request.url.endsWith("/rfqs/rfq-1/suppliers") && request.method === "PUT",
     );
@@ -220,8 +353,23 @@ describe("RFQBuilderPage", () => {
       expect.objectContaining({
         supplier_name: "Pacific Pipe Supply",
         category: "pipe",
+        recipient_email: "estimating@pacific-pipe.example",
         scope_items: [],
       }),
     ]);
+    expect(
+      requests.some(
+        (request) =>
+          request.url.endsWith("/communication-workflow/prepare")
+          && request.method === "POST",
+      ),
+    ).toBe(true);
+    expect(
+      requests.some(
+        (request) =>
+          request.url.endsWith("/supplier-responses")
+          && request.method === "POST",
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/src/pages/RFQBuilderPage.tsx
+++ b/frontend/src/pages/RFQBuilderPage.tsx
@@ -14,12 +14,15 @@ import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   RFQPackage,
   RFQPackageBuildResponse,
+  RFQCommunicationWorkflow,
   RFQPackageCreatePayload,
   RFQPackageDocumentCreate,
   RFQPackageDocumentStatus,
   RFQPackageStatus,
   RFQReadiness,
   RFQRecipientStatus,
+  RFQWorkflowPreparePayload,
+  SupplierResponseCreatePayload,
   SupplierRecipientCreate,
   rfqPackagesApi,
 } from "../api/rfqPackages";
@@ -34,6 +37,7 @@ function blankSupplier(): SupplierRecipientCreate {
     supplier_id: `manual-${Date.now()}-${Math.random().toString(16).slice(2)}`,
     supplier_name: "",
     category: "",
+    recipient_email: "",
     scope_items: [],
   };
 }
@@ -76,6 +80,7 @@ export function RFQBuilderPage() {
   const [selectedPackage, setSelectedPackage] = useState<RFQPackage | null>(null);
   const [readiness, setReadiness] = useState<RFQReadiness | null>(null);
   const [buildResult, setBuildResult] = useState<RFQPackageBuildResponse | null>(null);
+  const [workflow, setWorkflow] = useState<RFQCommunicationWorkflow | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isMutating, setIsMutating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -87,15 +92,18 @@ export function RFQBuilderPage() {
       const list = await rfqPackagesApi.list();
       setPackages(list.items);
       if (rfqPackageId) {
-        const [detail, readinessPayload] = await Promise.all([
+        const [detail, readinessPayload, workflowPayload] = await Promise.all([
           rfqPackagesApi.detail(rfqPackageId),
           rfqPackagesApi.readiness(rfqPackageId),
+          rfqPackagesApi.communicationWorkflow(rfqPackageId),
         ]);
         setSelectedPackage(detail);
         setReadiness(readinessPayload);
+        setWorkflow(workflowPayload);
       } else {
         setSelectedPackage(null);
         setReadiness(null);
+        setWorkflow(null);
       }
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to load RFQs");
@@ -152,6 +160,22 @@ export function RFQBuilderPage() {
     }
   }
 
+  async function mutateWorkflow(
+    action: () => Promise<RFQCommunicationWorkflow>,
+    refreshPackage = false,
+  ) {
+    setIsMutating(true);
+    setError(null);
+    try {
+      setWorkflow(await action());
+      if (refreshPackage) await refresh();
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to update communication workflow");
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
   return (
     <section className="space-y-6">
       <div className="flex flex-col gap-4 border-b border-iron-100 pb-6 lg:flex-row lg:items-end lg:justify-between">
@@ -198,6 +222,7 @@ export function RFQBuilderPage() {
             rfqPackage={selectedPackage}
             readiness={readiness}
             buildResult={buildResult}
+            workflow={workflow}
             isBusy={isMutating}
             onStatusChange={(status) =>
               void mutate(() => rfqPackagesApi.updateStatus(selectedPackage.id, status))
@@ -222,6 +247,17 @@ export function RFQBuilderPage() {
               )
             }
             onBuild={() => void buildPackages()}
+            onPrepareWorkflow={(payload) =>
+              void mutateWorkflow(() =>
+                rfqPackagesApi.prepareCommunicationWorkflow(selectedPackage.id, payload),
+              )
+            }
+            onRecordResponse={(payload) =>
+              void mutateWorkflow(
+                () => rfqPackagesApi.recordSupplierResponse(selectedPackage.id, payload),
+                true,
+              )
+            }
           />
         ) : (
           <div className="rounded-md border border-iron-100 bg-white p-6">
@@ -369,6 +405,7 @@ function RFQPackageDetail({
   rfqPackage,
   readiness,
   buildResult,
+  workflow,
   isBusy,
   onStatusChange,
   onSaveSuppliers,
@@ -376,10 +413,13 @@ function RFQPackageDetail({
   onSaveDocuments,
   onRecipientStatus,
   onBuild,
+  onPrepareWorkflow,
+  onRecordResponse,
 }: {
   rfqPackage: RFQPackage;
   readiness: RFQReadiness | null;
   buildResult: RFQPackageBuildResponse | null;
+  workflow: RFQCommunicationWorkflow | null;
   isBusy: boolean;
   onStatusChange: (status: RFQPackageStatus) => void;
   onSaveSuppliers: (suppliers: SupplierRecipientCreate[]) => void;
@@ -387,6 +427,8 @@ function RFQPackageDetail({
   onSaveDocuments: (documents: RFQPackageDocumentCreate[]) => void;
   onRecipientStatus: (recipientId: string, status: RFQRecipientStatus, note: string) => void;
   onBuild: () => void;
+  onPrepareWorkflow: (payload: RFQWorkflowPreparePayload) => void;
+  onRecordResponse: (payload: SupplierResponseCreatePayload) => void;
 }) {
   const statusOptions: RFQPackageStatus[] = ["draft", "assembling", "ready", "issued", "closed"];
 
@@ -447,6 +489,13 @@ function RFQPackageDetail({
         isBusy={isBusy}
         onBuild={onBuild}
       />
+      <CommunicationWorkflowPanel
+        rfqPackage={rfqPackage}
+        workflow={workflow}
+        isBusy={isBusy}
+        onPrepare={onPrepareWorkflow}
+        onRecordResponse={onRecordResponse}
+      />
     </div>
   );
 }
@@ -497,10 +546,11 @@ function SupplierScopeEditor({
 }) {
   const [suppliers, setSuppliers] = useState<SupplierRecipientCreate[]>(() =>
     rfqPackage.recipients.length
-      ? rfqPackage.recipients.map(({ supplier_id, supplier_name, category, scope_items }) => ({
+      ? rfqPackage.recipients.map(({ supplier_id, supplier_name, category, recipient_email, scope_items }) => ({
           supplier_id,
           supplier_name,
           category,
+          recipient_email,
           scope_items,
         }))
       : [blankSupplier()],
@@ -509,10 +559,11 @@ function SupplierScopeEditor({
   useEffect(() => {
     if (!rfqPackage.recipients.length) return;
     setSuppliers(
-      rfqPackage.recipients.map(({ supplier_id, supplier_name, category, scope_items }) => ({
+      rfqPackage.recipients.map(({ supplier_id, supplier_name, category, recipient_email, scope_items }) => ({
         supplier_id,
         supplier_name,
         category,
+        recipient_email,
         scope_items,
       })),
     );
@@ -534,6 +585,7 @@ function SupplierScopeEditor({
           ...supplier,
           supplier_name: supplier.supplier_name.trim(),
           category: supplier.category?.trim() || null,
+          recipient_email: supplier.recipient_email?.trim() || null,
           scope_items: supplier.scope_items.map((item) => item.trim()).filter(Boolean),
         })),
     );
@@ -562,7 +614,7 @@ function SupplierScopeEditor({
       <div className="mt-4 space-y-4">
         {suppliers.map((supplier, index) => (
           <div key={supplier.supplier_id} className="rounded-md border border-iron-100 p-4">
-            <div className="grid gap-3 md:grid-cols-[1fr_220px_100px]">
+            <div className="grid gap-3 md:grid-cols-[1fr_220px_260px_100px]">
               <input
                 aria-label={`Supplier ${index + 1} name`}
                 value={supplier.supplier_name}
@@ -576,6 +628,14 @@ function SupplierScopeEditor({
                 onChange={(event) => update(index, { category: event.target.value })}
                 className="rounded-md border border-iron-100 px-3 py-2 text-sm"
                 placeholder="pipe, aggregates, traffic..."
+              />
+              <input
+                aria-label={`Supplier ${index + 1} email`}
+                type="email"
+                value={supplier.recipient_email ?? ""}
+                onChange={(event) => update(index, { recipient_email: event.target.value })}
+                className="rounded-md border border-iron-100 px-3 py-2 text-sm"
+                placeholder="estimating@supplier.example"
               />
               <button
                 type="button"
@@ -867,6 +927,194 @@ function RFQDraftPackages({
           ))}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function CommunicationWorkflowPanel({
+  rfqPackage,
+  workflow,
+  isBusy,
+  onPrepare,
+  onRecordResponse,
+}: {
+  rfqPackage: RFQPackage;
+  workflow: RFQCommunicationWorkflow | null;
+  isBusy: boolean;
+  onPrepare: (payload: RFQWorkflowPreparePayload) => void;
+  onRecordResponse: (payload: SupplierResponseCreatePayload) => void;
+}) {
+  const [driveFolderUri, setDriveFolderUri] = useState(
+    workflow?.drive_package?.folder_uri ?? "",
+  );
+  const [driveManifestUri, setDriveManifestUri] = useState(
+    workflow?.drive_package?.manifest_uri ?? "",
+  );
+  const [senderName, setSenderName] = useState("Iron House");
+  const [senderEmail, setSenderEmail] = useState("");
+  const [senderPhone, setSenderPhone] = useState("");
+  const [supplierId, setSupplierId] = useState(
+    rfqPackage.recipients[0]?.supplier_id ?? "",
+  );
+  const [gmailThreadUri, setGmailThreadUri] = useState("");
+  const [driveFileUri, setDriveFileUri] = useState("");
+  const [responseNotes, setResponseNotes] = useState("");
+
+  useEffect(() => {
+    if (workflow?.drive_package) {
+      setDriveFolderUri(workflow.drive_package.folder_uri);
+      setDriveManifestUri(workflow.drive_package.manifest_uri ?? "");
+    }
+  }, [workflow?.drive_package]);
+
+  useEffect(() => {
+    if (!rfqPackage.recipients.some((recipient) => recipient.supplier_id === supplierId)) {
+      setSupplierId(rfqPackage.recipients[0]?.supplier_id ?? "");
+    }
+  }, [rfqPackage.recipients, supplierId]);
+
+  function prepare(event: FormEvent) {
+    event.preventDefault();
+    onPrepare({
+      drive_folder_uri: driveFolderUri.trim(),
+      drive_manifest_uri: driveManifestUri.trim() || undefined,
+      sender_name: senderName.trim() || "Iron House",
+      sender_email: senderEmail.trim() || undefined,
+      sender_phone: senderPhone.trim() || undefined,
+    });
+  }
+
+  function recordResponse(event: FormEvent) {
+    event.preventDefault();
+    if (!supplierId) return;
+    onRecordResponse({
+      supplier_id: supplierId,
+      gmail_thread_uri: gmailThreadUri.trim() || undefined,
+      drive_file_uri: driveFileUri.trim() || undefined,
+      notes: responseNotes.trim() || undefined,
+    });
+    setGmailThreadUri("");
+    setDriveFileUri("");
+    setResponseNotes("");
+  }
+
+  return (
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <div>
+        <h2 className="text-base font-semibold text-iron-950">Gmail + Drive workflow plan</h2>
+        <p className="mt-1 text-sm leading-6 text-iron-500">
+          Save a reusable Drive manifest and review Gmail-ready drafts. This screen records references only and performs no Google action.
+        </p>
+      </div>
+
+      <div className="mt-4 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
+        Preview-only: no Gmail draft, email send, Drive folder, or Drive file is created here. Sending always requires separate approval.
+      </div>
+
+      <form onSubmit={prepare} className="mt-4 space-y-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <Field label="Drive package folder reference">
+            <input
+              aria-label="Drive package folder reference"
+              required
+              value={driveFolderUri}
+              onChange={(event) => setDriveFolderUri(event.target.value)}
+              className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="drive://projects/project-id/rfqs/package-id"
+            />
+          </Field>
+          <Field label="Drive manifest reference">
+            <input
+              aria-label="Drive manifest reference"
+              value={driveManifestUri}
+              onChange={(event) => setDriveManifestUri(event.target.value)}
+              className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="Optional manifest URL or document ID"
+            />
+          </Field>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Field label="Sender name">
+            <input aria-label="Workflow sender name" value={senderName} onChange={(event) => setSenderName(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" />
+          </Field>
+          <Field label="Sender email">
+            <input aria-label="Workflow sender email" type="email" value={senderEmail} onChange={(event) => setSenderEmail(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" />
+          </Field>
+          <Field label="Sender phone">
+            <input aria-label="Workflow sender phone" value={senderPhone} onChange={(event) => setSenderPhone(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" />
+          </Field>
+        </div>
+        <button type="submit" disabled={isBusy} className="rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:bg-iron-300">
+          Save reusable draft workflow
+        </button>
+      </form>
+
+      {workflow?.prepared_at ? (
+        <div className="mt-5 space-y-3">
+          <div className={`rounded-md border p-3 text-sm ${workflow.stale ? "border-amber-200 bg-amber-50 text-amber-900" : "border-emerald-200 bg-emerald-50 text-emerald-800"}`}>
+            {workflow.stale
+              ? "Saved workflow is stale because RFQ recipients, scopes, or attachments changed. Rebuild it before creating drafts."
+              : "Preview-only workflow saved. No Gmail or Drive action was performed."}
+          </div>
+          {workflow.blockers.length ? (
+            <ul className="list-disc space-y-1 pl-5 text-sm text-amber-900">
+              {workflow.blockers.map((blocker) => <li key={blocker}>{blocker}</li>)}
+            </ul>
+          ) : null}
+          <div className="grid gap-3 md:grid-cols-2">
+            {workflow.gmail_drafts.map((draft) => (
+              <div key={draft.recipient_id} className="rounded-md border border-iron-100 p-3">
+                <div className="text-sm font-semibold text-iron-950">{draft.supplier_name}</div>
+                <div className="mt-1 text-xs text-iron-500">To: {draft.to ?? "Recipient email missing"}</div>
+                <div className="mt-2 text-xs font-medium text-iron-800">{draft.subject}</div>
+                <div className="mt-2 text-xs text-iron-500">
+                  {draft.ready_for_draft_creation ? "Ready for separately approved draft creation" : "Blocked"}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-6 border-t border-iron-100 pt-5">
+        <h3 className="text-sm font-semibold text-iron-950">Record supplier response</h3>
+        <p className="mt-1 text-xs leading-5 text-iron-500">
+          Register an existing Gmail thread or Drive file and mark the supplier replied. This does not read or move either item.
+        </p>
+        <form onSubmit={recordResponse} className="mt-3 grid gap-3 md:grid-cols-2">
+          <Field label="Supplier">
+            <select aria-label="Response supplier" required value={supplierId} onChange={(event) => setSupplierId(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm">
+              <option value="">Select supplier</option>
+              {rfqPackage.recipients.map((recipient) => (
+                <option key={recipient.supplier_id} value={recipient.supplier_id}>{recipient.supplier_name}</option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Gmail thread reference">
+            <input aria-label="Gmail thread reference" value={gmailThreadUri} onChange={(event) => setGmailThreadUri(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="gmail://threads/..." />
+          </Field>
+          <Field label="Drive response file reference">
+            <input aria-label="Drive response file reference" value={driveFileUri} onChange={(event) => setDriveFileUri(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="drive://projects/.../response.pdf" />
+          </Field>
+          <Field label="Response notes">
+            <input aria-label="Response notes" value={responseNotes} onChange={(event) => setResponseNotes(event.target.value)} className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm" placeholder="Quote received and saved" />
+          </Field>
+          <button type="submit" disabled={isBusy || !supplierId || (!gmailThreadUri.trim() && !driveFileUri.trim())} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold disabled:text-iron-300 md:col-span-2 md:justify-self-start">
+            Record response reference
+          </button>
+        </form>
+
+        {workflow?.supplier_responses.length ? (
+          <div className="mt-4 space-y-2">
+            {workflow.supplier_responses.map((response) => (
+              <div key={response.id} className="rounded-md border border-iron-100 p-3 text-sm">
+                <span className="font-semibold text-iron-950">{response.supplier_name}</span>
+                <span className="ml-2 text-iron-500">{response.notes ?? "Response recorded"}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/tests/backend/test_rfq_packages.py
+++ b/tests/backend/test_rfq_packages.py
@@ -31,11 +31,13 @@ def add_suppliers(rfq_package_id: str) -> dict:
                 "supplier_id": "supplier-001",
                 "supplier_name": "Pacific Pipe Supply",
                 "category": "pipe",
+                "recipient_email": "estimating@pacific-pipe.example",
             },
             {
                 "supplier_id": "supplier-002",
                 "supplier_name": "Coastal Traffic Control",
                 "category": "traffic control",
+                "recipient_email": "quotes@coastal-traffic.example",
             },
         ],
     )
@@ -105,6 +107,7 @@ def test_supplier_selection_generates_category_specific_scopes() -> None:
     pipe_recipient, traffic_recipient = payload["recipients"]
     assert pipe_recipient["status"] == "pending"
     assert traffic_recipient["status"] == "pending"
+    assert pipe_recipient["recipient_email"] == "estimating@pacific-pipe.example"
     assert any("pipe" in item.lower() for item in pipe_recipient["scope_items"])
     assert any("traffic control" in item.lower() for item in traffic_recipient["scope_items"])
     assert pipe_recipient["scope_items"] != traffic_recipient["scope_items"]
@@ -254,3 +257,95 @@ def test_rfq_package_children_and_metadata_persist_across_requests() -> None:
     assert second_response.status_code == 200
     assert second_response.json()["recipients"][0]["scope_items"]
     assert second_response.json()["documents"][0]["storage_uri"].startswith("drive://")
+
+
+def test_prepare_gmail_drive_workflow_is_preview_only_and_persistent() -> None:
+    rfq_package = create_package()
+    add_suppliers(rfq_package["id"])
+    add_ready_documents(rfq_package["id"])
+
+    response = client.post(
+        f"/api/v1/rfqs/{rfq_package['id']}/communication-workflow/prepare",
+        json={
+            "drive_folder_uri": "drive://projects/kg/rfq/stormwater",
+            "drive_manifest_uri": "drive://projects/kg/rfq/stormwater/manifest.json",
+            "sender_name": "Jeremie",
+            "sender_email": "estimating@ironhouse.example",
+        },
+    )
+
+    payload = response.json()
+    assert response.status_code == 200
+    assert payload["status"] == "preview_only"
+    assert payload["external_actions_performed"] is False
+    assert payload["send_requires_approval"] is True
+    assert payload["stale"] is False
+    assert payload["drive_package"]["reusable"] is True
+    assert payload["drive_package"]["folder_uri"].startswith("drive://")
+    assert len(payload["gmail_drafts"]) == 2
+    assert payload["gmail_drafts"][0]["status"] == "preview_only"
+    assert payload["gmail_drafts"][0]["send_approved"] is False
+    assert payload["gmail_drafts"][0]["ready_for_draft_creation"] is True
+    assert payload["gmail_drafts"][0]["to"] == "estimating@pacific-pipe.example"
+    assert "estimating@ironhouse.example" in payload["gmail_drafts"][0]["body"]
+
+    persisted = client.get(
+        f"/api/v1/rfqs/{rfq_package['id']}/communication-workflow"
+    )
+    assert persisted.status_code == 200
+    assert persisted.json()["drive_package"] == payload["drive_package"]
+    assert persisted.json()["gmail_drafts"] == payload["gmail_drafts"]
+
+    changed_documents = client.put(
+        f"/api/v1/rfqs/{rfq_package['id']}/documents",
+        json=[
+            {
+                "document_type": "drawing",
+                "title": "C-102 Revised Utility Plan",
+                "required": True,
+                "status": "attached",
+                "storage_uri": "drive://projects/kg/C-102.pdf",
+            }
+        ],
+    )
+    stale = client.get(
+        f"/api/v1/rfqs/{rfq_package['id']}/communication-workflow"
+    )
+    assert changed_documents.status_code == 200
+    assert stale.json()["stale"] is True
+
+
+def test_record_supplier_response_updates_tracking_without_external_action() -> None:
+    rfq_package = create_package()
+    add_suppliers(rfq_package["id"])
+
+    invalid = client.post(
+        f"/api/v1/rfqs/{rfq_package['id']}/supplier-responses",
+        json={"supplier_id": "supplier-001", "notes": "Missing references."},
+    )
+    response = client.post(
+        f"/api/v1/rfqs/{rfq_package['id']}/supplier-responses",
+        json={
+            "supplier_id": "supplier-001",
+            "gmail_thread_uri": "gmail://threads/thread-123",
+            "drive_file_uri": "drive://projects/kg/responses/pacific-pipe.pdf",
+            "notes": "Quote received and saved for comparison.",
+        },
+    )
+
+    assert invalid.status_code == 422
+    assert response.status_code == 201
+    assert response.json()["external_actions_performed"] is False
+    assert response.json()["supplier_responses"][0]["supplier_name"] == (
+        "Pacific Pipe Supply"
+    )
+    assert response.json()["supplier_responses"][0]["drive_file_uri"].startswith(
+        "drive://"
+    )
+
+    detail = client.get(f"/api/v1/rfqs/{rfq_package['id']}").json()
+    recipient = next(
+        item for item in detail["recipients"] if item["supplier_id"] == "supplier-001"
+    )
+    assert recipient["status"] == "replied"
+    assert recipient["status_note"] == "Quote received and saved for comparison."


### PR DESCRIPTION
## Summary
- add connector-neutral Gmail and Drive workflow contracts for RFQ packages
- persist reusable Drive manifest references and Gmail-ready draft previews
- add supplier estimating emails and stale-plan fingerprint detection
- register existing Gmail/Drive response references and mark suppliers replied
- integrate the preview-only workflow into the RFQ builder

## Safety boundary
This build performs no Gmail or Drive API action. It creates no draft, sends no email, uploads no file, and modifies no external item. Every draft plan has `send_approved: false`; sending remains a separately approved future action.

## Validation
- frontend test suite: 4 files / 8 tests
- frontend production TypeScript build
- Python compile validation for all changed backend modules
- backend API tests cover preview persistence, stale detection, missing-reference rejection, and response tracking

Implements Build 205 from #1.