### PR TITLE
Build 207: ship a production-ready IHOS web release

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,7 @@
+POSTGRES_DB=iron_house_os
+POSTGRES_USER=iron_house
+POSTGRES_PASSWORD=replace-with-a-long-random-database-password
+SECRET_KEY=replace-with-at-least-32-random-characters
+IHOS_ADMIN_USERNAME=jeremie
+IHOS_ADMIN_PASSWORD=replace-with-a-long-random-login-password
+IHOS_PORT=8080

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,58 @@
+name: Release readiness
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "docker-compose.production.yml"
+      - ".env.production.example"
+      - "scripts/release_smoke.py"
+      - ".github/workflows/release-readiness.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - "docker-compose.production.yml"
+      - ".env.production.example"
+      - "scripts/release_smoke.py"
+      - ".github/workflows/release-readiness.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  production-stack:
+    name: Production stack smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      POSTGRES_DB: iron_house_os
+      POSTGRES_USER: iron_house
+      POSTGRES_PASSWORD: build-207-ci-database-password
+      SECRET_KEY: build-207-ci-secret-key-at-least-32-characters
+      IHOS_ADMIN_USERNAME: build207
+      IHOS_ADMIN_PASSWORD: build-207-ci-login-password
+      IHOS_PORT: "8080"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate production configuration
+        run: docker compose --env-file .env.production.example -f docker-compose.production.yml config --quiet
+      - name: Start production stack
+        run: docker compose --env-file .env.production.example -f docker-compose.production.yml up -d --build --wait
+      - name: Run full release smoke path
+        run: >-
+          python scripts/release_smoke.py
+          --base-url http://127.0.0.1:8080
+          --username "$IHOS_ADMIN_USERNAME"
+          --password "$IHOS_ADMIN_PASSWORD"
+          --full
+      - name: Show production logs on failure
+        if: failure()
+        run: docker compose --env-file .env.production.example -f docker-compose.production.yml logs --no-color
+      - name: Stop production stack
+        if: always()
+        run: docker compose --env-file .env.production.example -f docker-compose.production.yml down --volumes

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+!.env.production.example
 
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm run dev
 
 ## Production Release
 
-Build 207 adds a production Compose stack with a compiled Nginx frontend, same-origin API proxying, startup migrations, PostgreSQL persistence, document and audit persistence, runtime readiness probes, temporary browser login protection, and a full release smoke test.
+Build 207 adds a production Compose stack with a compiled Nginx frontend, same-origin API proxying, startup migrations and schema bootstrap, PostgreSQL persistence, document and audit persistence, runtime readiness probes, temporary browser login protection, and a full release smoke test.
 
 ```bash
 cp .env.production.example .env.production

--- a/README.md
+++ b/README.md
@@ -1,58 +1,39 @@
 # Iron House OS
 
-Iron House OS is a civil construction operating system foundation for projects, RFQs, suppliers, bids, documents, equipment, tenders, and future AI-assisted workflows.
-
-This repository is Phase 1: a production-ready scaffold with clean architecture, developer tooling, Docker support, API documentation, placeholder application modules, database models, and seed data. It intentionally does not implement business logic yet.
+Iron House OS is a civil-construction operating system for projects, documents, drawing intelligence, estimates, supplier quotes, RFQ packages, bids, equipment, tenders, and municipality workflows.
 
 ## Stack
 
 - Frontend: React, TypeScript, Vite, Tailwind CSS
 - Backend: FastAPI, SQLAlchemy, Alembic, Pydantic Settings
 - Database: PostgreSQL
-- Tooling: Docker Compose, GitHub Actions, pytest, Ruff, ESLint
+- Runtime: Docker Compose, Nginx, persistent Docker volumes
+- Quality: GitHub Actions, pytest, Ruff, TypeScript, Vitest
 
-## Repository Structure
+## Local Development
 
-```text
-.
-|-- frontend/              # React dashboard shell
-|-- backend/               # FastAPI application
-|-- database/              # SQL schema and seed data
-|-- docker/                # Container support files
-|-- docs/                  # Architecture and development notes
-|-- scripts/               # Developer helper scripts
-|-- tests/                 # Backend smoke tests
-|-- .github/workflows/     # CI
-|-- docker-compose.yml
-|-- LICENSE
-`-- README.md
-```
-
-## Quick Start
-
-1. Optional: copy environment files if you want local overrides.
+1. Optional: copy environment files for local overrides.
 
 ```bash
 cp backend/.env.example backend/.env
 cp frontend/.env.example frontend/.env
 ```
 
-2. Start the local stack.
+2. Start the development stack.
 
 ```bash
 docker compose up --build
 ```
 
-3. Open the apps.
+3. Open the services.
 
 - Frontend: http://localhost:5173
 - Backend API: http://localhost:8000
 - API docs: http://localhost:8000/docs
 - Health: http://localhost:8000/health
+- Readiness: http://localhost:8000/readiness
 
-## Local Development
-
-Backend:
+Backend without Docker:
 
 ```bash
 cd backend
@@ -62,7 +43,7 @@ pip install -r requirements-dev.txt
 uvicorn app.main:app --reload
 ```
 
-Frontend:
+Frontend without Docker:
 
 ```bash
 cd frontend
@@ -70,81 +51,31 @@ npm install
 npm run dev
 ```
 
-Database migrations:
+## Production Release
+
+Build 207 adds a production Compose stack with a compiled Nginx frontend, same-origin API proxying, startup migrations, PostgreSQL persistence, document and audit persistence, runtime readiness probes, temporary browser login protection, and a full release smoke test.
 
 ```bash
-cd backend
-alembic revision --autogenerate -m "describe change"
-alembic upgrade head
+cp .env.production.example .env.production
+# Replace every placeholder secret in .env.production before continuing.
+docker compose --env-file .env.production -f docker-compose.production.yml up -d --build --wait
+python scripts/release_smoke.py --base-url http://127.0.0.1:8080 --full
 ```
 
-## Placeholder Modules
+The smoke test expects `IHOS_ADMIN_USERNAME` and `IHOS_ADMIN_PASSWORD` in the environment when the login gate is enabled. It creates clearly named validation records in full mode; omit `--full` for a read-only health and application-shell check.
 
-The frontend includes navigation and placeholder pages for:
+See [the release runbook](docs/deployment.md) before exposing IHOS outside a trusted network. A public deployment must terminate HTTPS upstream and back up both persistent volumes.
 
-- Dashboard
-- Projects
-- RFQ Builder
-- Supplier Database
-- Estimating
-- Tender Tracker
-- Document Library
-- Equipment
-- Reporting
-- Settings
+## Core Application Areas
 
-The backend includes placeholder REST routes for:
-
-- `/projects`
-- `/suppliers`
-- `/rfqs`
-- `/bids`
-- `/documents`
-- `/equipment`
-- `/users`
-- `/auth`
-
-## Data Model Foundation
-
-The backend and schema define these initial entities:
-
-- Project
-- Supplier
-- Contact
-- RFQ
-- Quote
-- Bid
-- Drawing
-- Takeoff
-- Equipment
-- Employee
-- Municipality
-- Tender
-
-## Phase 1 Scope
-
-Included:
-
-- Dockerized development environment
-- Environment-driven configuration
-- Structured logging
-- Centralized error handling
-- Health endpoint
-- API documentation
-- Example seed data
-- GitHub Actions workflow
-- Clean service boundaries for future AI agents
-
-Not included yet:
-
-- RFQ package generation
-- Supplier CRM workflows
-- BC Bid scraping
-- Drawing ingestion
-- Quantity takeoff automation
-- Bid engine business logic
-- Municipality standards intelligence
-- Google Drive or Gmail integration
+- Project workspaces and project-scoped launchers
+- Document library, integrity metadata, signed downloads, and audit events
+- Civil PDF ingestion, quantity candidates, and review flags
+- Quantity takeoff and estimate handoff
+- Estimate workspace and workbook generation
+- Supplier quote comparison and explicit quote selection
+- Supplier-specific RFQ packages and preview-only communication workflows
+- Tender, bid-readiness, municipality, supplier, and equipment modules
 
 ## License
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
+COPY alembic.ini ./alembic.ini
+COPY alembic ./alembic
 COPY app ./app
 COPY pyproject.toml ./pyproject.toml
 

--- a/backend/app/db/bootstrap.py
+++ b/backend/app/db/bootstrap.py
@@ -1,0 +1,14 @@
+import app.models  # noqa: F401
+
+from app.db.base import Base
+from app.db.session import engine
+
+
+def bootstrap_schema() -> None:
+    """Create model-backed tables when a deployment has no Alembic baseline yet."""
+
+    Base.metadata.create_all(bind=engine)
+
+
+if __name__ == "__main__":
+    bootstrap_schema()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1.router import api_router
@@ -18,7 +18,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title=settings.app_name,
         version="0.1.0",
-        description="Phase 1 API scaffold for Iron House OS.",
+        description="Iron House OS API.",
         docs_url="/docs",
         redoc_url="/redoc",
         openapi_url="/openapi.json",
@@ -40,8 +40,11 @@ def create_app() -> FastAPI:
         return {"status": "ok", "service": settings.app_name}
 
     @app.get("/readiness", tags=["system"])
-    def readiness() -> dict[str, object]:
-        return get_system_readiness()
+    def readiness(response: Response) -> dict[str, object]:
+        report = get_system_readiness(probe_runtime=True)
+        if report["status"] != "ready":
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return report
 
     return app
 

--- a/backend/app/services/system_readiness.py
+++ b/backend/app/services/system_readiness.py
@@ -1,26 +1,63 @@
+from tempfile import NamedTemporaryFile
+
+from sqlalchemy import text
+
 from app.core.config import get_settings
+from app.db.session import engine
+from app.services import file_storage
+from app.services.file_storage import LocalFileStorageProvider
 
 
-def get_system_readiness() -> dict[str, object]:
+def _database_readiness() -> tuple[bool, str]:
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+    except Exception:
+        return False, "unavailable"
+    return True, "ready"
+
+
+def _storage_readiness() -> tuple[bool, str]:
+    provider = file_storage.storage_provider
+    if not isinstance(provider, LocalFileStorageProvider):
+        return False, "unsupported"
+    try:
+        provider.root.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(prefix=".readiness-", dir=provider.root):
+            pass
+    except OSError:
+        return False, "unavailable"
+    return True, "ready"
+
+
+def get_system_readiness(*, probe_runtime: bool = False) -> dict[str, object]:
     settings = get_settings()
+    checks = {
+        "api_router": "mounted",
+        "cors": "configured",
+        "docs": "enabled",
+        "project_workspace": "enabled",
+        "document_library": "enabled",
+        "civil_pdf_ingestion": "enabled",
+        "drawing_quantity_candidates": "enabled",
+        "drawing_review_flags": "enabled",
+        "takeoff_engine": "enabled",
+        "takeoff_persistence": "enabled",
+        "estimate_handoff": "enabled",
+        "estimate_workspace": "enabled",
+        "rfq_linkage": "enabled",
+        "project_readiness": "enabled",
+        "deployment_environment": settings.environment,
+    }
+    ready = True
+    if probe_runtime:
+        database_ready, checks["database"] = _database_readiness()
+        storage_ready, checks["document_storage"] = _storage_readiness()
+        ready = database_ready and storage_ready
+
     return {
-        "status": "ready",
+        "status": "ready" if ready else "not_ready",
         "service": settings.app_name,
         "api_prefix": settings.api_v1_prefix,
-        "checks": {
-            "api_router": "mounted",
-            "cors": "configured",
-            "docs": "enabled",
-            "project_workspace": "enabled",
-            "document_library": "enabled",
-            "civil_pdf_ingestion": "enabled",
-            "drawing_quantity_candidates": "enabled",
-            "drawing_review_flags": "enabled",
-            "takeoff_engine": "enabled",
-            "takeoff_persistence": "enabled",
-            "estimate_handoff": "enabled",
-            "estimate_workspace": "enabled",
-            "rfq_linkage": "enabled",
-            "project_readiness": "enabled",
-        },
+        "checks": checks,
     }

--- a/backend/app/services/system_readiness.py
+++ b/backend/app/services/system_readiness.py
@@ -1,6 +1,6 @@
 from tempfile import NamedTemporaryFile
 
-from sqlalchemy import text
+from sqlalchemy import inspect, text
 
 from app.core.config import get_settings
 from app.db.session import engine
@@ -12,6 +12,10 @@ def _database_readiness() -> tuple[bool, str]:
     try:
         with engine.connect() as connection:
             connection.execute(text("SELECT 1"))
+            inspector = inspect(connection)
+            required_tables = ("projects", "documents", "rfq_packages")
+            if any(not inspector.has_table(table) for table in required_tables):
+                return False, "schema_incomplete"
     except Exception:
         return False, "unavailable"
     return True, "ready"

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -34,6 +34,7 @@ services:
       - -c
       - >-
         alembic upgrade head &&
+        python -m app.db.bootstrap &&
         exec uvicorn app.main:app --host 0.0.0.0 --port 8000
         --proxy-headers --forwarded-allow-ips="*"
     depends_on:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -70,7 +70,7 @@ services:
     ports:
       - "${IHOS_PORT:-8080}:80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost/healthz"]
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/healthz"]
       interval: 10s
       timeout: 5s
       retries: 6

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,80 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    environment:
+      ENVIRONMENT: production
+      LOG_LEVEL: INFO
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
+      BACKEND_CORS_ORIGINS: '[]'
+      IHOS_STORAGE_BACKEND: local
+      IHOS_STORAGE_ROOT: /app/data/uploads
+      DOCUMENT_AUDIT_STORE: jsonl
+      DOCUMENT_AUDIT_JSONL_PATH: /app/data/audit/document-events.jsonl
+    command:
+      - /bin/sh
+      - -c
+      - >-
+        alembic upgrade head &&
+        exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+        --proxy-headers --forwarded-allow-ips="*"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - backend_data:/app/data
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.urlopen('http://localhost:8000/readiness', timeout=4)
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: /api/v1
+    restart: unless-stopped
+    environment:
+      IHOS_ADMIN_USERNAME: ${IHOS_ADMIN_USERNAME:?IHOS_ADMIN_USERNAME is required}
+      IHOS_ADMIN_PASSWORD: ${IHOS_ADMIN_PASSWORD:?IHOS_ADMIN_PASSWORD is required}
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - "${IHOS_PORT:-8080}:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+
+volumes:
+  postgres_data:
+  backend_data:

--- a/docs/builds/BUILD_207.md
+++ b/docs/builds/BUILD_207.md
@@ -1,0 +1,21 @@
+# Build 207 — working web-app release
+
+## Outcome
+
+IHOS can now run as a production-shaped single-node web application behind one URL. The release stack compiles the frontend, proxies browser API traffic through the same origin, migrates the database before startup, persists uploads and audit events, and blocks access with a browser login.
+
+## Status
+
+- Production Compose, Nginx login gate, same-origin API routing, PostgreSQL, uploads, audit persistence, and readiness probes are implemented.
+- GitHub release validation boots the actual production stack and tests project creation, estimate calculation, RFQ creation, and civil PDF upload.
+- Cloud infrastructure is intentionally not provisioned because the repository has no selected host, domain, credentials, or approved spend.
+
+## Risks
+
+- A single shared browser credential is only a staging access gate; per-user identity and authorization remain unfinished.
+- Docker volumes need host-level backups and a restore drill before production data is entrusted to the stack.
+- Public access requires an HTTPS ingress, DNS, and a hosting decision outside this code change.
+
+## Exact first deployment step
+
+Copy `.env.production.example` to `.env.production`, replace every placeholder with generated secrets, then run `docker compose --env-file .env.production -f docker-compose.production.yml up -d --build --wait` on the chosen staging Docker host.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,88 @@
+# Iron House OS release runbook
+
+Build 207 packages IHOS as a single-node production stack. Nginx serves the compiled responsive web app, protects it with a temporary browser login, and proxies `/api/v1` to FastAPI. FastAPI runs migrations before accepting traffic and stores uploads and audit events on a persistent volume. PostgreSQL uses a separate persistent volume.
+
+## Host requirements
+
+- A Docker host with Docker Compose v2
+- A DNS name pointed at the host
+- An HTTPS reverse proxy or managed load balancer in front of port 8080
+- Automated backups for the `postgres_data` and `backend_data` volumes
+
+Do not expose the Compose port directly to the public internet. The built-in login gate is suitable for controlled staging access, but HTTPS must be terminated upstream so credentials and project data are encrypted in transit.
+
+## First deployment
+
+1. Create the environment file and replace every placeholder.
+
+```bash
+cp .env.production.example .env.production
+openssl rand -hex 32
+```
+
+Use generated values for the database password, application secret, and browser login password. Keep `.env.production` out of source control.
+
+2. Validate the fully rendered Compose configuration.
+
+```bash
+docker compose --env-file .env.production -f docker-compose.production.yml config --quiet
+```
+
+3. Build and start the stack. The backend applies Alembic migrations before Uvicorn starts.
+
+```bash
+docker compose --env-file .env.production -f docker-compose.production.yml up -d --build --wait
+```
+
+4. Run the read-only release check first.
+
+```bash
+set -a
+source .env.production
+set +a
+python scripts/release_smoke.py --base-url http://127.0.0.1:8080
+```
+
+5. Run the full project-to-drawing smoke path. This creates a project, calculates a one-line estimate, creates an RFQ package, and uploads a small civil PDF.
+
+```bash
+python scripts/release_smoke.py --base-url http://127.0.0.1:8080 --full
+```
+
+6. Point the HTTPS proxy at the host and repeat the read-only check against the public staging URL.
+
+```bash
+python scripts/release_smoke.py --base-url https://your-staging-host.example
+```
+
+The public URL can then be shared from a phone or desktop browser as a QR code. Credentials must be shared separately and rotated when staging access changes.
+
+## Operations
+
+Inspect service health and logs:
+
+```bash
+docker compose --env-file .env.production -f docker-compose.production.yml ps
+docker compose --env-file .env.production -f docker-compose.production.yml logs --tail=200
+```
+
+Deploy a new revision without removing persistent data:
+
+```bash
+docker compose --env-file .env.production -f docker-compose.production.yml up -d --build --wait
+```
+
+Stop services without deleting data:
+
+```bash
+docker compose --env-file .env.production -f docker-compose.production.yml down
+```
+
+Never add `--volumes` to the production shutdown command unless a verified restore is available and data deletion is intentional.
+
+## Known limitations
+
+- Build 207 does not provision a cloud account, domain, certificate, or paid infrastructure.
+- The temporary Nginx browser login is one shared credential, not per-user authorization or an audit identity.
+- Local Docker volumes are single-node storage; object storage, replication, and automated restore drills remain future release work.
+- Gmail and Drive remain preview-only and perform no external actions.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Iron House OS release runbook
 
-Build 207 packages IHOS as a single-node production stack. Nginx serves the compiled responsive web app, protects it with a temporary browser login, and proxies `/api/v1` to FastAPI. FastAPI runs migrations before accepting traffic and stores uploads and audit events on a persistent volume. PostgreSQL uses a separate persistent volume.
+Build 207 packages IHOS as a single-node production stack. Nginx serves the compiled responsive web app, protects it with a temporary browser login, and proxies `/api/v1` to FastAPI. FastAPI runs Alembic and an idempotent model-schema bootstrap before accepting traffic, then stores uploads and audit events on a persistent volume. PostgreSQL uses a separate persistent volume.
 
 ## Host requirements
 
@@ -28,7 +28,7 @@ Use generated values for the database password, application secret, and browser 
 docker compose --env-file .env.production -f docker-compose.production.yml config --quiet
 ```
 
-3. Build and start the stack. The backend applies Alembic migrations before Uvicorn starts.
+3. Build and start the stack. The backend applies Alembic, creates any model-backed tables missing from a clean database, and then starts Uvicorn.
 
 ```bash
 docker compose --env-file .env.production -f docker-compose.production.yml up -d --build --wait
@@ -83,6 +83,7 @@ Never add `--volumes` to the production shutdown command unless a verified resto
 ## Known limitations
 
 - Build 207 does not provision a cloud account, domain, certificate, or paid infrastructure.
+- The repository does not yet have an Alembic baseline; clean deployments use an idempotent SQLAlchemy model-schema bootstrap after Alembic.
 - The temporary Nginx browser login is one shared credential, not per-user authorization or an audit identity.
 - Local Docker volumes are single-node storage; object storage, replication, and automated restore drills remain future release work.
 - Gmail and Drive remain preview-only and perform no external actions.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,10 +4,15 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
+ARG VITE_API_BASE_URL=/api/v1
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 RUN npm run build
 
 FROM nginx:1.27-alpine
+RUN apk add --no-cache apache2-utils
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.d/40-ihos-basic-auth.sh /docker-entrypoint.d/40-ihos-basic-auth.sh
+RUN chmod +x /docker-entrypoint.d/40-ihos-basic-auth.sh
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/docker-entrypoint.d/40-ihos-basic-auth.sh
+++ b/frontend/docker-entrypoint.d/40-ihos-basic-auth.sh
@@ -6,4 +6,5 @@ set -eu
 
 printf '%s\n' "$IHOS_ADMIN_PASSWORD" | \
   htpasswd -ciB /etc/nginx/.htpasswd "$IHOS_ADMIN_USERNAME"
-chmod 600 /etc/nginx/.htpasswd
+chown root:nginx /etc/nginx/.htpasswd
+chmod 640 /etc/nginx/.htpasswd

--- a/frontend/docker-entrypoint.d/40-ihos-basic-auth.sh
+++ b/frontend/docker-entrypoint.d/40-ihos-basic-auth.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+: "${IHOS_ADMIN_USERNAME:?IHOS_ADMIN_USERNAME is required}"
+: "${IHOS_ADMIN_PASSWORD:?IHOS_ADMIN_PASSWORD is required}"
+
+printf '%s\n' "$IHOS_ADMIN_PASSWORD" | \
+  htpasswd -ciB /etc/nginx/.htpasswd "$IHOS_ADMIN_USERNAME"
+chmod 600 /etc/nginx/.htpasswd

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,12 +4,48 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
-  location / {
-    try_files $uri $uri/ /index.html;
+  client_max_body_size 100m;
+  auth_basic "Iron House OS";
+  auth_basic_user_file /etc/nginx/.htpasswd;
+
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Referrer-Policy "same-origin" always;
+
+  location = /healthz {
+    auth_basic off;
+    access_log off;
+    default_type text/plain;
+    return 200 "ok\n";
   }
 
-  location /health {
+  location = /readiness {
+    auth_basic off;
     access_log off;
-    return 200 "ok\n";
+    proxy_pass http://backend:8000/readiness;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:8000;
+    proxy_http_version 1.1;
+    proxy_request_buffering off;
+    proxy_read_timeout 300s;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Request-ID $request_id;
+  }
+
+  location /assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
   }
 }

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Smoke-test a deployed Iron House OS release using only the standard library."""
+
+from argparse import ArgumentParser
+from base64 import b64encode
+from datetime import UTC, datetime
+import json
+import os
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+
+def _authorization(username: str | None, password: str | None) -> str | None:
+    if not username and not password:
+        return None
+    if not username or not password:
+        raise SystemExit("Both username and password are required when authentication is enabled.")
+    token = b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
+
+
+def _request(
+    base_url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    payload: dict | None = None,
+    body: bytes | None = None,
+    content_type: str | None = None,
+    authorization: str | None = None,
+    expected: tuple[int, ...] = (200,),
+) -> tuple[int, bytes]:
+    headers = {"Accept": "application/json"}
+    if authorization:
+        headers["Authorization"] = authorization
+    if payload is not None:
+        body = json.dumps(payload).encode()
+        content_type = "application/json"
+    if content_type:
+        headers["Content-Type"] = content_type
+    request = Request(
+        f"{base_url.rstrip('/')}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            status_code = response.status
+            response_body = response.read()
+    except HTTPError as exc:
+        response_body = exc.read()
+        raise RuntimeError(
+            f"{method} {path} returned {exc.code}: {response_body.decode(errors='replace')}"
+        ) from exc
+    if status_code not in expected:
+        raise RuntimeError(f"{method} {path} returned {status_code}; expected {expected}")
+    return status_code, response_body
+
+
+def _json_request(*args, **kwargs) -> dict:
+    _, body = _request(*args, **kwargs)
+    return json.loads(body)
+
+
+def _minimal_pdf(text: str) -> bytes:
+    escaped = text.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+    stream = f"BT /F1 12 Tf 72 720 Td ({escaped}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    output = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for number, value in enumerate(objects, start=1):
+        offsets.append(len(output))
+        output.extend(f"{number} 0 obj\n".encode())
+        output.extend(value)
+        output.extend(b"\nendobj\n")
+    xref_offset = len(output)
+    output.extend(f"xref\n0 {len(objects) + 1}\n".encode())
+    output.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        output.extend(f"{offset:010d} 00000 n \n".encode())
+    output.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n".encode()
+    )
+    return bytes(output)
+
+
+def _multipart(fields: dict[str, str], filename: str, file_bytes: bytes) -> tuple[bytes, str]:
+    boundary = f"ihos-{uuid4().hex}"
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode(),
+                value.encode(),
+                b"\r\n",
+            ]
+        )
+    chunks.extend(
+        [
+            f"--{boundary}\r\n".encode(),
+            (
+                'Content-Disposition: form-data; name="file"; '
+                f'filename="{filename}"\r\n'
+            ).encode(),
+            b"Content-Type: application/pdf\r\n\r\n",
+            file_bytes,
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    return b"".join(chunks), f"multipart/form-data; boundary={boundary}"
+
+
+def run(base_url: str, authorization: str | None, full: bool) -> dict:
+    _, homepage = _request(base_url, "/", authorization=authorization)
+    if b"Iron House" not in homepage:
+        raise RuntimeError("The frontend response did not contain the Iron House application shell.")
+    readiness = _json_request(base_url, "/readiness", authorization=authorization)
+    if readiness.get("status") != "ready":
+        raise RuntimeError(f"Release is not ready: {readiness}")
+    if not full:
+        return {"mode": "read-only", "status": "passed"}
+
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    project = _json_request(
+        base_url,
+        "/api/v1/projects",
+        method="POST",
+        payload={
+            "name": f"Build 207 release smoke {stamp}",
+            "municipality": "Surrey",
+            "project_number": f"SMOKE-{stamp}",
+        },
+        authorization=authorization,
+        expected=(201,),
+    )
+    estimate = _json_request(
+        base_url,
+        "/api/v1/estimates/summary",
+        method="POST",
+        payload={
+            "project_name": project["name"],
+            "project_code": project["project_number"],
+            "line_items": [
+                {
+                    "code": "SMOKE-001",
+                    "description": "Release validation item",
+                    "item_type": "material",
+                    "quantity": 1,
+                    "unit": "EA",
+                    "labour": [],
+                    "equipment": [],
+                    "materials": [],
+                    "disposal": [],
+                    "vendor_quotes": [],
+                    "direct_unit_cost": 1,
+                }
+            ],
+            "indirects": [],
+            "risks": [],
+            "markup": {
+                "overhead_percent": 0,
+                "profit_percent": 0,
+                "contingency_percent": 0,
+                "bonding_percent": 0,
+                "insurance_percent": 0,
+            },
+            "assumptions": ["Automated release validation only."],
+            "exclusions": [],
+        },
+        authorization=authorization,
+    )
+    if estimate.get("final_price") != 1:
+        raise RuntimeError(f"Unexpected estimate result: {estimate}")
+
+    rfq = _json_request(
+        base_url,
+        "/api/v1/rfqs",
+        method="POST",
+        payload={
+            "title": f"Build 207 release RFQ {stamp}",
+            "project_id": project["id"],
+            "project_name": project["name"],
+            "scope_summary": "Automated release validation only.",
+            "supplier_category_targets": [],
+        },
+        authorization=authorization,
+        expected=(201,),
+    )
+
+    pdf = _minimal_pdf("Quantity Schedule: 12 m storm pipe. Field verify utility crossing.")
+    multipart, content_type = _multipart(
+        {
+            "project_id": project["id"],
+            "title": "Build 207 release drawing",
+            "municipality": "Surrey",
+        },
+        "build-207-release.pdf",
+        pdf,
+    )
+    drawing = _json_request(
+        base_url,
+        "/api/v1/drawing-intelligence/ingest",
+        method="POST",
+        body=multipart,
+        content_type=content_type,
+        authorization=authorization,
+        expected=(201,),
+    )
+    if drawing["source"]["project_id"] != project["id"]:
+        raise RuntimeError("Drawing upload was not linked to the release-smoke project.")
+
+    return {
+        "mode": "full",
+        "status": "passed",
+        "project_id": project["id"],
+        "rfq_package_id": rfq["id"],
+        "drawing_document_id": drawing["source"]["document_id"],
+    }
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--base-url", default=os.getenv("IHOS_BASE_URL", "http://127.0.0.1:8080"))
+    parser.add_argument("--username", default=os.getenv("IHOS_ADMIN_USERNAME"))
+    parser.add_argument("--password", default=os.getenv("IHOS_ADMIN_PASSWORD"))
+    parser.add_argument("--full", action="store_true", help="Create release-smoke records and upload a PDF.")
+    args = parser.parse_args()
+    authorization = _authorization(args.username, args.password)
+    print(json.dumps(run(args.base_url, authorization, args.full), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backend/test_release_readiness.py
+++ b/tests/backend/test_release_readiness.py
@@ -1,0 +1,26 @@
+from app.services import system_readiness
+
+
+def test_runtime_readiness_probes_database_and_storage(monkeypatch) -> None:
+    monkeypatch.setattr(system_readiness, "_database_readiness", lambda: (True, "ready"))
+    monkeypatch.setattr(system_readiness, "_storage_readiness", lambda: (True, "ready"))
+
+    readiness = system_readiness.get_system_readiness(probe_runtime=True)
+
+    assert readiness["status"] == "ready"
+    assert readiness["checks"]["database"] == "ready"
+    assert readiness["checks"]["document_storage"] == "ready"
+
+
+def test_runtime_readiness_fails_when_a_dependency_is_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(
+        system_readiness,
+        "_database_readiness",
+        lambda: (False, "unavailable"),
+    )
+    monkeypatch.setattr(system_readiness, "_storage_readiness", lambda: (True, "ready"))
+
+    readiness = system_readiness.get_system_readiness(probe_runtime=True)
+
+    assert readiness["status"] == "not_ready"
+    assert readiness["checks"]["database"] == "unavailable"


### PR DESCRIPTION
## What changed

- added a production Docker Compose stack with PostgreSQL, startup Alembic plus an idempotent clean-database schema bootstrap, persistent uploads, persistent document audit events, and health-gated startup
- compiled the React app into Nginx, routed API calls through the same origin, allowed 100 MB drawing uploads, and added a temporary bcrypt-backed browser login gate
- changed backend readiness from static flags to real database, required-table, and storage probes
- added a release workflow that boots the production stack and runs project → estimate → RFQ → civil PDF ingestion
- added production environment guidance, an operator runbook, and Build 207 status/risks

## Why

Builds 201–206 completed the active product workflow, but IHOS still lacked a production-shaped runtime behind one usable URL. This change closes the code-side release gap without provisioning external infrastructure or incurring spend.

## User impact

A staging Docker host can now launch IHOS on one protected URL. Desktop and mobile browsers use the same frontend origin for API calls, and project uploads survive container restarts.

## Validation

- CI: backend lint/tests and frontend lint/tests/build passed
- Release readiness: clean production Compose stack reached healthy
- Full release smoke: project creation, estimate calculation, RFQ creation, and civil PDF upload/analysis passed
- Local: Python compilation, YAML parsing, shell syntax, and generated-PDF extraction passed

## Known limits

- no cloud host, DNS, TLS certificate, or paid infrastructure is provisioned
- the shared browser login is a staging gate, not per-user authorization
- the repository still needs an Alembic baseline migration; clean deployments use the documented idempotent model-schema bootstrap
- persistent volumes still require host backups and a restore drill