### PR TITLE
Build 210: module role permissions

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -6,7 +6,10 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.core.config import get_settings
+from app.services.access_control import can_access_module, required_permission
 from app.services.auth import AuthenticatedUser, account_to_principal, decode_session_token, get_account
+from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
+from app.services.request_context import get_request_audit_context
 
 
 def require_authenticated_user(
@@ -40,6 +43,44 @@ def require_authenticated_user(
 
 
 CurrentUser = Annotated[AuthenticatedUser, Depends(require_authenticated_user)]
+
+
+def require_module_access(request: Request, user: CurrentUser) -> AuthenticatedUser:
+    prefix = get_settings().api_v1_prefix.strip("/").split("/")
+    path_parts = request.url.path.strip("/").split("/")
+    if path_parts[: len(prefix)] != prefix or len(path_parts) <= len(prefix):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="The requested module is not available.",
+        )
+    module = path_parts[len(prefix)]
+    permission = required_permission(module, request.method)
+    if can_access_module(user.role, module, permission):
+        return user
+
+    context = get_request_audit_context(request)
+    emit_document_audit_event(
+        DocumentAuditEvent(
+            action="module_access",
+            outcome="denied",
+            actor=user.email,
+            request_id=context.request_id,
+            metadata={
+                "module": module,
+                "permission": permission.value,
+                "method": request.method,
+                "path": request.url.path,
+                "role": user.role,
+            },
+        )
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            f"Role '{user.role}' lacks '{permission.value}' permission "
+            f"for module '{module}'."
+        ),
+    )
 
 
 def require_admin(user: CurrentUser) -> AuthenticatedUser:

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from app.api.dependencies.auth import require_authenticated_user
+from app.api.dependencies.auth import require_authenticated_user, require_module_access
 
 from app.api.v1.routes import (
     auth,
@@ -26,7 +26,9 @@ from app.api.v1.routes import (
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 
-protected_router = APIRouter(dependencies=[Depends(require_authenticated_user)])
+protected_router = APIRouter(
+    dependencies=[Depends(require_authenticated_user), Depends(require_module_access)]
+)
 protected_router.include_router(projects.router, prefix="/projects", tags=["projects"])
 protected_router.include_router(suppliers.router, prefix="/suppliers", tags=["suppliers"])
 protected_router.include_router(rfqs.router, prefix="/rfqs", tags=["rfqs"])

--- a/backend/app/api/v1/routes/auth.py
+++ b/backend/app/api/v1/routes/auth.py
@@ -8,7 +8,8 @@ from app.api.dependencies.auth import CurrentUser
 from app.core.config import get_settings
 from app.db.session import get_db
 from app.models.user import UserAccount
-from app.schemas.auth import AuthStatus, LoginRequest, UserAccountRead
+from app.schemas.auth import AuthStatus, LoginRequest, RoleAccessRead, UserAccountRead
+from app.services.access_control import describe_role_access
 from app.services.auth import authenticate, create_session_token
 
 router = APIRouter()
@@ -67,3 +68,8 @@ def current_account(user: CurrentUser, db: DBSession) -> AuthStatus:
     if account is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not found.")
     return AuthStatus(authentication="authenticated", user=UserAccountRead.model_validate(account))
+
+
+@router.get("/me/permissions", response_model=RoleAccessRead)
+def current_permissions(user: CurrentUser) -> RoleAccessRead:
+    return RoleAccessRead(role=user.role, modules=describe_role_access(user.role))

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -68,3 +68,8 @@ class PasswordResetRequest(BaseModel):
 class AuthStatus(BaseModel):
     authentication: str
     user: UserAccountRead
+
+
+class RoleAccessRead(BaseModel):
+    role: UserRole
+    modules: dict[str, list[str]]

--- a/backend/app/services/access_control.py
+++ b/backend/app/services/access_control.py
@@ -1,0 +1,92 @@
+from enum import StrEnum
+
+from app.services.document_audit_access import normalize_role
+
+
+class ModulePermission(StrEnum):
+    READ = "read"
+    WRITE = "write"
+    ADMINISTER = "administer"
+
+
+BUSINESS_MODULES = (
+    "projects",
+    "suppliers",
+    "rfqs",
+    "rfq-automation",
+    "bid-package",
+    "bid-readiness",
+    "bids",
+    "estimates",
+    "cost-codes",
+    "quotes",
+    "documents",
+    "drawing-intelligence",
+    "takeoff",
+    "municipality",
+    "tenders",
+    "equipment",
+)
+ALL_MODULES = (*BUSINESS_MODULES, "users")
+
+ESTIMATOR_WRITE_MODULES = frozenset(
+    {
+        "projects",
+        "suppliers",
+        "rfqs",
+        "rfq-automation",
+        "bid-package",
+        "bid-readiness",
+        "bids",
+        "estimates",
+        "cost-codes",
+        "quotes",
+        "documents",
+        "drawing-intelligence",
+        "takeoff",
+        "municipality",
+        "tenders",
+    }
+)
+
+
+def module_permissions_for_role(role: str | None, module: str) -> frozenset[ModulePermission]:
+    normalized_role = normalize_role(role)
+    if module not in ALL_MODULES:
+        return frozenset()
+    if normalized_role == "admin":
+        permissions = {ModulePermission.READ, ModulePermission.WRITE}
+        if module == "users":
+            permissions.add(ModulePermission.ADMINISTER)
+        return frozenset(permissions)
+    if module == "users":
+        return frozenset()
+    if normalized_role == "operations_manager":
+        return frozenset({ModulePermission.READ, ModulePermission.WRITE})
+    if normalized_role == "estimator":
+        permissions = {ModulePermission.READ}
+        if module in ESTIMATOR_WRITE_MODULES:
+            permissions.add(ModulePermission.WRITE)
+        return frozenset(permissions)
+    if normalized_role == "viewer":
+        return frozenset({ModulePermission.READ})
+    return frozenset()
+
+
+def required_permission(module: str, method: str) -> ModulePermission:
+    if module == "users":
+        return ModulePermission.ADMINISTER
+    if method.upper() in {"GET", "HEAD", "OPTIONS"}:
+        return ModulePermission.READ
+    return ModulePermission.WRITE
+
+
+def can_access_module(role: str | None, module: str, permission: ModulePermission) -> bool:
+    return permission in module_permissions_for_role(role, module)
+
+
+def describe_role_access(role: str | None) -> dict[str, list[str]]:
+    return {
+        module: sorted(permission.value for permission in module_permissions_for_role(role, module))
+        for module in ALL_MODULES
+    }

--- a/docs/builds/BUILD_210.md
+++ b/docs/builds/BUILD_210.md
@@ -1,0 +1,22 @@
+# Build 210 — module role permissions
+
+## Outcome
+
+Every protected API module now enforces one shared, fail-closed role matrix. Authentication alone no longer grants mutation access: viewers are read-only, estimators can operate estimating and bid workflows, operations managers can mutate every business module, and administrators additionally control user accounts.
+
+## Role matrix
+
+| Role | Business read | Estimating/project mutation | Equipment mutation | User administration |
+| --- | --- | --- | --- | --- |
+| `admin` | Yes | Yes | Yes | Yes |
+| `operations_manager` | Yes | Yes | Yes | No |
+| `estimator` | Yes | Yes | No | No |
+| `viewer` | Yes | No | No | No |
+
+User-account routes always require `administer`; all other `GET`, `HEAD`, and `OPTIONS` requests require `read`, while mutation methods require `write`. Unknown roles receive no permissions.
+
+## Audit boundary
+
+Every denied module action appends a `module_access` event to the configured durable audit stream with actor, role, module, method, path, requested permission, and request ID. Passwords, session cookies, request bodies, and other credentials are never recorded.
+
+The authenticated permission summary is available at `GET /api/v1/auth/me/permissions`. The API remains authoritative even when a client does not pre-hide an unavailable action.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -62,6 +62,8 @@ The public URL can then be shared from a phone or desktop browser as a QR code. 
 - Sign in with the bootstrap administrator email and password from `.env.production`.
 - Administrators can create, update, deactivate, and reset accounts through `/api/v1/users`.
 - Roles are `admin`, `operations_manager`, `estimator`, and `viewer`.
+- Viewers are read-only. Estimators can mutate estimating, procurement, project, document, tender, and bid workflows but not fleet data or users. Operations managers can mutate all business modules. Only administrators can manage user accounts.
+- Denied module actions are written to the durable audit stream without request bodies, credentials, or session tokens.
 - Role changes, deactivation, and password resets invalidate that user's existing sessions.
 - Remove `BOOTSTRAP_ADMIN_PASSWORD` from routine operator notes after the first successful start. The startup task never overwrites an existing account password.
 

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -8,6 +8,14 @@ import { useAuth } from "../contexts/AuthContext";
 export function AppLayout({ children }: PropsWithChildren) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { user, logout } = useAuth();
+  const accessLabel =
+    user?.role === "viewer"
+      ? "Read-only access"
+      : user?.role === "estimator"
+        ? "Estimating access"
+        : user?.role === "operations_manager"
+          ? "Operations access"
+          : "Administrator access";
 
   return (
     <div className="min-h-screen bg-iron-50 text-iron-950">
@@ -61,6 +69,7 @@ export function AppLayout({ children }: PropsWithChildren) {
             Signed in as {user?.display_name}
           </div>
           <div className="flex items-center gap-3">
+            <div className="hidden text-xs font-medium text-iron-500 sm:block">{accessLabel}</div>
             <div className="rounded-md bg-signal-green px-3 py-1 text-xs font-semibold capitalize text-white">
               {user?.role.replace("_", " ")}
             </div>

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -1,0 +1,104 @@
+from uuid import UUID
+
+from fastapi import Request
+from fastapi.testclient import TestClient
+import pytest
+
+from app.api.dependencies.auth import require_authenticated_user
+from app.main import app
+from app.services.access_control import (
+    ModulePermission,
+    can_access_module,
+    describe_role_access,
+)
+from app.services.auth import AuthenticatedUser
+from app.services.document_audit import (
+    clear_recent_document_audit_events,
+    list_recent_document_audit_events,
+)
+
+client = TestClient(app)
+
+
+def _authenticate_as(role: str) -> None:
+    def override(request: Request) -> AuthenticatedUser:
+        user = AuthenticatedUser(
+            id=UUID("00000000-0000-0000-0000-000000000001"),
+            email=f"{role}@ironhousecivil.com",
+            display_name=f"Test {role}",
+            role=role,
+            session_version=1,
+        )
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = override
+
+
+@pytest.mark.parametrize("role", ["admin", "operations_manager", "estimator", "viewer"])
+def test_every_supported_role_can_read_business_modules(role: str) -> None:
+    for module in ("projects", "suppliers", "estimates", "documents", "tenders", "equipment"):
+        assert can_access_module(role, module, ModulePermission.READ)
+
+
+def test_role_matrix_separates_administration_and_mutation() -> None:
+    assert can_access_module("admin", "users", ModulePermission.ADMINISTER)
+    assert not can_access_module("operations_manager", "users", ModulePermission.ADMINISTER)
+    assert can_access_module("operations_manager", "equipment", ModulePermission.WRITE)
+    assert not can_access_module("estimator", "equipment", ModulePermission.WRITE)
+    assert can_access_module("estimator", "estimates", ModulePermission.WRITE)
+    assert not can_access_module("viewer", "projects", ModulePermission.WRITE)
+
+
+def test_viewer_is_read_only_and_denial_is_audited() -> None:
+    clear_recent_document_audit_events()
+    _authenticate_as("viewer")
+
+    assert client.get("/api/v1/projects").status_code == 200
+    response = client.post(
+        "/api/v1/projects",
+        json={"name": "Viewer must not create this project"},
+        headers={"x-request-id": "build-210-viewer-denial"},
+    )
+
+    assert response.status_code == 403
+    assert "write" in response.json()["detail"]
+    event = list_recent_document_audit_events(action="module_access", outcome="denied")[0]
+    assert event["actor"] == "viewer@ironhousecivil.com"
+    assert event["request_id"] == "build-210-viewer-denial"
+    assert event["metadata"] == {
+        "module": "projects",
+        "permission": "write",
+        "method": "POST",
+        "path": "/api/v1/projects",
+        "role": "viewer",
+    }
+
+
+@pytest.mark.parametrize("role", ["operations_manager", "estimator"])
+def test_non_admin_roles_cannot_access_user_administration(role: str) -> None:
+    _authenticate_as(role)
+    response = client.get("/api/v1/users")
+    assert response.status_code == 403
+    assert "administer" in response.json()["detail"]
+
+
+@pytest.mark.parametrize("role", ["admin", "operations_manager", "estimator"])
+def test_authorized_business_roles_can_create_projects(role: str) -> None:
+    _authenticate_as(role)
+    response = client.post(
+        "/api/v1/projects",
+        json={"name": f"Build 210 {role} project", "project_number": f"B210-{role}"},
+    )
+    assert response.status_code == 201
+
+
+def test_permission_summary_is_available_for_the_current_session() -> None:
+    _authenticate_as("estimator")
+    response = client.get("/api/v1/auth/me/permissions")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "role": "estimator",
+        "modules": describe_role_access("estimator"),
+    }


### PR DESCRIPTION
## Outcome

Enforce one fail-closed role matrix across every protected Iron House OS API module and record denied actions in the durable audit stream.

## Included

- shared `read`, `write`, and `administer` module permissions
- read-only viewer access
- estimating/project/procurement mutation access for estimators
- full business-module mutation access for operations managers
- administrator-only user account management
- authenticated permission-summary endpoint
- denial audit records without request bodies, credentials, or session tokens
- role regression tests and operator documentation
- visible access-level label in the application shell

## Validation

- `ruff check . ../tests/backend ../scripts`
- `pytest -q` — 87 passed
- `npm run lint`
- `npm run test` — 14 passed
- `npm run build`
- `git diff --check`

## Merge gate

Do not merge until standard CI and production-stack release readiness are green.