### PR TITLE
Build 213: operational observability and incident readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ docker compose up --build
 - API docs: http://localhost:8000/docs
 - Health: http://localhost:8000/health
 - Readiness: http://localhost:8000/readiness
+- Administrator diagnostics: http://localhost:8000/api/v1/operations/diagnostics
 
 Backend without Docker:
 

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -13,6 +13,7 @@ from app.api.v1.routes import (
     equipment,
     estimates,
     municipality,
+    operations,
     projects,
     quotes,
     rfq_automation,
@@ -50,4 +51,5 @@ protected_router.include_router(municipality.router, prefix="/municipality", tag
 protected_router.include_router(tenders.router, prefix="/tenders", tags=["tenders"])
 protected_router.include_router(equipment.router, prefix="/equipment", tags=["equipment"])
 protected_router.include_router(users.router, prefix="/users", tags=["users"])
+protected_router.include_router(operations.router, prefix="/operations", tags=["operations"])
 api_router.include_router(protected_router)

--- a/backend/app/api/v1/routes/operations.py
+++ b/backend/app/api/v1/routes/operations.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from fastapi import APIRouter
+
+from app.api.dependencies.auth import AdminUser
+from app.services.document_audit import list_recent_document_audit_events, summarize_document_audit_events
+from app.services.operational_metrics import operational_snapshot
+from app.services.system_readiness import get_system_readiness
+
+router = APIRouter()
+SECURITY_ACTIONS = {
+    "account_recovery",
+    "login",
+    "module_access",
+    "password_change",
+}
+
+
+@router.get("/diagnostics")
+def operational_diagnostics(_: AdminUser) -> dict[str, Any]:
+    return {
+        "readiness": get_system_readiness(probe_runtime=True),
+        "traffic": operational_snapshot(),
+        "audit": summarize_document_audit_events(),
+    }
+
+
+@router.get("/security-events")
+def security_events(_: AdminUser, limit: int = 50) -> dict[str, Any]:
+    events = list_recent_document_audit_events(limit=200)
+    selected = [event for event in events if event.get("action") in SECURITY_ACTIONS]
+    bounded_limit = max(1, min(limit, 100))
+    return {"items": selected[:bounded_limit], "total": len(selected)}

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -22,7 +22,12 @@ def register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(Exception)
     async def unhandled_error_handler(request: Request, exc: Exception) -> JSONResponse:
-        logger.exception("unhandled_error", path=request.url.path, error=str(exc))
+        logger.exception(
+            "unhandled_error",
+            path=request.url.path,
+            request_id=getattr(request.state, "request_id", None),
+            error=str(exc),
+        )
         return JSONResponse(
             status_code=500,
             content={"error": {"message": "Internal server error"}},

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from app.api.v1.router import api_router
 from app.core.config import get_settings
 from app.core.errors import register_exception_handlers
 from app.core.logging import configure_logging
+from app.middleware.observability import RequestObservabilityMiddleware
 from app.services.document_audit import configure_document_audit_store
 from app.services.document_audit_store import create_document_audit_store_from_environment
 from app.services.system_readiness import get_system_readiness
@@ -31,6 +32,7 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_middleware(RequestObservabilityMiddleware)
 
     register_exception_handlers(app)
     app.include_router(api_router, prefix=settings.api_v1_prefix)

--- a/backend/app/middleware/observability.py
+++ b/backend/app/middleware/observability.py
@@ -1,0 +1,41 @@
+from time import perf_counter
+import structlog
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+from app.services.operational_metrics import observe_request
+from app.services.request_context import normalize_request_id
+
+logger = structlog.get_logger("ihos.request")
+
+
+class RequestObservabilityMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request_id = normalize_request_id(request.headers.get("x-request-id"))
+        request.state.request_id = request_id
+        started = perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            duration_ms = (perf_counter() - started) * 1000
+            observe_request(
+                method=request.method,
+                path=request.url.path,
+                status_code=status_code,
+                duration_ms=duration_ms,
+                request_id=request_id,
+            )
+            logger.info(
+                "request_completed",
+                request_id=request_id,
+                method=request.method,
+                path=request.url.path,
+                status_code=status_code,
+                duration_ms=round(duration_ms, 2),
+            )
+            if "response" in locals():
+                response.headers["x-request-id"] = request_id

--- a/backend/app/services/access_control.py
+++ b/backend/app/services/access_control.py
@@ -27,7 +27,7 @@ BUSINESS_MODULES = (
     "tenders",
     "equipment",
 )
-ALL_MODULES = (*BUSINESS_MODULES, "users")
+ALL_MODULES = (*BUSINESS_MODULES, "users", "operations")
 
 ESTIMATOR_WRITE_MODULES = frozenset(
     {
@@ -56,10 +56,10 @@ def module_permissions_for_role(role: str | None, module: str) -> frozenset[Modu
         return frozenset()
     if normalized_role == "admin":
         permissions = {ModulePermission.READ, ModulePermission.WRITE}
-        if module == "users":
+        if module in {"users", "operations"}:
             permissions.add(ModulePermission.ADMINISTER)
         return frozenset(permissions)
-    if module == "users":
+    if module in {"users", "operations"}:
         return frozenset()
     if normalized_role == "operations_manager":
         return frozenset({ModulePermission.READ, ModulePermission.WRITE})
@@ -74,7 +74,7 @@ def module_permissions_for_role(role: str | None, module: str) -> frozenset[Modu
 
 
 def required_permission(module: str, method: str) -> ModulePermission:
-    if module == "users":
+    if module in {"users", "operations"}:
         return ModulePermission.ADMINISTER
     if method.upper() in {"GET", "HEAD", "OPTIONS"}:
         return ModulePermission.READ

--- a/backend/app/services/operational_metrics.py
+++ b/backend/app/services/operational_metrics.py
@@ -1,0 +1,55 @@
+from collections import Counter, deque
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from threading import Lock
+
+
+@dataclass(frozen=True)
+class RequestObservation:
+    method: str
+    path: str
+    status_code: int
+    duration_ms: float
+    request_id: str
+    occurred_at: str
+
+
+_lock = Lock()
+_recent: deque[RequestObservation] = deque(maxlen=100)
+_started_at = datetime.now(UTC)
+
+
+def observe_request(
+    *, method: str, path: str, status_code: int, duration_ms: float, request_id: str
+) -> None:
+    observation = RequestObservation(
+        method=method,
+        path=path,
+        status_code=status_code,
+        duration_ms=round(duration_ms, 2),
+        request_id=request_id,
+        occurred_at=datetime.now(UTC).isoformat(),
+    )
+    with _lock:
+        _recent.appendleft(observation)
+
+
+def operational_snapshot(*, recent_limit: int = 20) -> dict[str, object]:
+    with _lock:
+        observations = list(_recent)
+    status_classes = Counter(f"{item.status_code // 100}xx" for item in observations)
+    failures = [item for item in observations if item.status_code >= 500]
+    durations = [item.duration_ms for item in observations]
+    return {
+        "started_at": _started_at.isoformat(),
+        "observed_requests": len(observations),
+        "status_classes": dict(status_classes),
+        "server_error_count": len(failures),
+        "max_duration_ms": max(durations, default=0.0),
+        "recent": [asdict(item) for item in observations[: max(1, min(recent_limit, 100))]],
+    }
+
+
+def clear_operational_metrics() -> None:
+    with _lock:
+        _recent.clear()

--- a/backend/app/services/request_context.py
+++ b/backend/app/services/request_context.py
@@ -5,11 +5,21 @@ from fastapi import Request
 
 from app.services.auth import AuthenticatedUser
 
+MAX_REQUEST_ID_LENGTH = 128
+
 
 @dataclass(frozen=True)
 class RequestAuditContext:
     actor: str | None
     request_id: str
+
+
+def normalize_request_id(value: str | None) -> str:
+    if value and len(value) <= MAX_REQUEST_ID_LENGTH and all(
+        character.isalnum() or character in "-_.:" for character in value
+    ):
+        return value
+    return f"req-{uuid4().hex}"
 
 
 def get_request_audit_context(request: Request) -> RequestAuditContext:
@@ -19,5 +29,8 @@ def get_request_audit_context(request: Request) -> RequestAuditContext:
         None,
     )
     actor = authenticated_user.email if authenticated_user is not None else None
-    request_id = request.headers.get("x-request-id") or f"req-{uuid4().hex}"
+    request_id = getattr(request.state, "request_id", None)
+    if request_id is None:
+        request_id = normalize_request_id(request.headers.get("x-request-id"))
+        request.state.request_id = request_id
     return RequestAuditContext(actor=actor, request_id=request_id)

--- a/docs/api-inventory-mvp.md
+++ b/docs/api-inventory-mvp.md
@@ -4,6 +4,8 @@
 
 - `GET /health`
 - `GET /readiness`
+- `GET /api/v1/operations/diagnostics` (administrator only)
+- `GET /api/v1/operations/security-events` (administrator only)
 
 ## Projects
 

--- a/docs/builds/BUILD_213.md
+++ b/docs/builds/BUILD_213.md
@@ -1,0 +1,18 @@
+# Build 213 — Operational observability and incident readiness
+
+Build 213 adds an administrator-only operational view and a practical incident-response contract without sending events to an external service.
+
+## Runtime visibility
+
+- Every HTTP response carries an `x-request-id`; a caller-supplied ID is preserved for trace correlation.
+- Every completed request emits one structured JSON log event with method, path, status, duration, and request ID. Query strings, bodies, cookies, and authorization material are excluded.
+- The process retains a bounded 100-request diagnostic window. It reports status-class counts, server errors, maximum duration, and recent request metadata.
+- `GET /api/v1/operations/diagnostics` combines live database/storage readiness, bounded traffic observations, and durable audit totals.
+- `GET /api/v1/operations/security-events` exposes recent authentication, recovery, password, and access-denial events.
+- Both operations endpoints are fail-closed to the administrator role. Denied access is written to the security audit stream.
+
+The in-process traffic window resets on process restart and is diagnostic context, not durable monitoring. Durable security events remain in the configured audit store. External alert delivery is intentionally deferred until an approved monitoring destination exists.
+
+## Operator response
+
+Use [incident response](../operations/incident-response.md), [rollback](../operations/rollback.md), and [recovery](../operations/recovery.md) for the supported decision and verification paths.

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -1,0 +1,21 @@
+# Incident response
+
+## Detect and classify
+
+1. Record UTC time, operator, environment, symptom, and the response `x-request-id`.
+2. Check `/health`. A failure means the API process or route is unavailable.
+3. Check `/readiness`. A `503` identifies database or document-storage unavailability without disclosing credentials.
+4. As an administrator, capture `/api/v1/operations/diagnostics` and relevant `/api/v1/operations/security-events` output.
+5. Classify the incident as availability, data integrity, security, or performance. Treat suspected credential exposure or unauthorized access as security-critical.
+
+## Contain
+
+- Stop destructive user activity before changing data or configuration.
+- Preserve application, proxy, database, and scheduled-backup logs with UTC timestamps.
+- Do not paste cookies, passwords, tokens, connection strings, or uploaded document contents into the incident record.
+- Disable a compromised user and rotate affected secrets through the approved operator channel.
+- If the current release caused the incident, follow the rollback runbook.
+
+## Recover and close
+
+Use the recovery runbook for database or uploaded-file loss. Before reopening access, require `/health`, `/readiness`, authenticated smoke coverage, and a recorded operator decision. Record cause, impact, evidence, actions, and follow-ups. External notifications require explicit approval and an approved recipient list.

--- a/docs/operations/recovery.md
+++ b/docs/operations/recovery.md
@@ -1,0 +1,11 @@
+# Data recovery
+
+1. Isolate the affected deployment and preserve logs and damaged storage for analysis.
+2. Inventory backup bundles newest-first. Run `scripts/restore_production.sh --verify-only <bundle>` before choosing a recovery point.
+3. Confirm the manifest, checksums, database dump, upload archive, release identifier, and schema revision. Reject incomplete or corrupt bundles.
+4. Restore into a disposable environment first. Verify database connectivity, current migrations, user login, representative records, and uploaded-file checksum/download.
+5. Record the expected data-loss window between the recovery point and incident time.
+6. With operator approval, restore the verified bundle to the isolated target using the documented restore command.
+7. Require `/health`, `/readiness`, authenticated release smoke, and a fresh post-recovery backup before reopening access.
+
+For S3-compatible storage, bucket version recovery is performed through the storage provider’s approved operator tooling. The application never makes buckets public and never deletes object versions during this procedure.

--- a/docs/operations/rollback.md
+++ b/docs/operations/rollback.md
@@ -1,0 +1,11 @@
+# Release rollback
+
+1. Freeze writes and record the current release identifier, database revision, incident time, and last known-good release.
+2. Take and verify a fresh backup when the database and object store are readable. Never overwrite the last verified recovery point.
+3. Review the target release migration notes. Do not run a destructive downgrade unless its data-loss behavior has been reviewed and accepted.
+4. Redeploy the last known-good immutable image and its matching configuration. Keep secrets out of shell history and evidence files.
+5. If schema compatibility prevents startup, restore the verified pre-release backup using the recovery runbook instead of improvising SQL changes.
+6. Require green `/health`, `/readiness`, authenticated smoke, document download, and a representative write before reopening access.
+7. Record the final image digest, schema revision, verification evidence, and operator acceptance.
+
+Rollback does not provision infrastructure or notify external parties.

--- a/tests/backend/test_operational_observability.py
+++ b/tests/backend/test_operational_observability.py
@@ -1,0 +1,72 @@
+from uuid import UUID
+
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from app.api.dependencies.auth import require_authenticated_user
+from app.main import app
+from app.services.auth import AuthenticatedUser
+from app.services.document_audit import (
+    DocumentAuditEvent,
+    clear_recent_document_audit_events,
+    emit_document_audit_event,
+)
+from app.services.operational_metrics import clear_operational_metrics
+
+client = TestClient(app)
+
+
+def _authenticate_as(role: str) -> None:
+    def override(request: Request) -> AuthenticatedUser:
+        user = AuthenticatedUser(
+            id=UUID("00000000-0000-0000-0000-000000000213"),
+            email=f"{role}@ironhousecivil.com",
+            display_name=f"Build 213 {role}",
+            role=role,
+            session_version=1,
+        )
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = override
+
+
+def test_request_id_and_operational_snapshot() -> None:
+    clear_operational_metrics()
+    response = client.get("/health", headers={"x-request-id": "build-213-health"})
+
+    assert response.status_code == 200
+    assert response.headers["x-request-id"] == "build-213-health"
+
+    _authenticate_as("admin")
+    diagnostics = client.get("/api/v1/operations/diagnostics")
+    assert diagnostics.status_code == 200
+    payload = diagnostics.json()
+    assert payload["readiness"]["service"] == "Iron House OS API"
+    assert payload["traffic"]["observed_requests"] >= 1
+    assert payload["traffic"]["recent"][0]["request_id"] == "build-213-health"
+
+
+def test_unsafe_request_id_is_replaced() -> None:
+    response = client.get("/health", headers={"x-request-id": "bad\nlog-line"})
+
+    assert response.status_code == 200
+    assert response.headers["x-request-id"].startswith("req-")
+
+
+def test_security_visibility_is_admin_only_and_excludes_business_events() -> None:
+    clear_recent_document_audit_events()
+    emit_document_audit_event(DocumentAuditEvent(action="login", outcome="denied"))
+    emit_document_audit_event(DocumentAuditEvent(action="upload"))
+
+    _authenticate_as("operations_manager")
+    assert client.get("/api/v1/operations/security-events").status_code == 403
+
+    _authenticate_as("admin")
+    response = client.get("/api/v1/operations/security-events")
+    assert response.status_code == 200
+    assert response.json()["total"] == 2
+    assert {item["action"] for item in response.json()["items"]} == {
+        "login",
+        "module_access",
+    }

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -43,7 +43,9 @@ def test_every_supported_role_can_read_business_modules(role: str) -> None:
 
 def test_role_matrix_separates_administration_and_mutation() -> None:
     assert can_access_module("admin", "users", ModulePermission.ADMINISTER)
+    assert can_access_module("admin", "operations", ModulePermission.ADMINISTER)
     assert not can_access_module("operations_manager", "users", ModulePermission.ADMINISTER)
+    assert not can_access_module("operations_manager", "operations", ModulePermission.ADMINISTER)
     assert can_access_module("operations_manager", "equipment", ModulePermission.WRITE)
     assert not can_access_module("estimator", "equipment", ModulePermission.WRITE)
     assert can_access_module("estimator", "estimates", ModulePermission.WRITE)


### PR DESCRIPTION
## Outcome

Add administrator-only operational and security visibility, correlated request logging, and incident/rollback/recovery runbooks without configuring external alert delivery.

## Included

- validated request IDs returned on every HTTP response
- structured request-completion logs without bodies, cookies, or credentials
- bounded in-process traffic diagnostics with status classes, errors, and durations
- live readiness, traffic, and audit diagnostic endpoint
- filtered security-event endpoint
- fail-closed administrator-only operations permission
- incident response, rollback, and data recovery runbooks
- tests for correlation, unsafe request-ID replacement, security filtering, and access denial

## Validation

- Ruff — clean
- backend — 98 passed
- frontend TypeScript lint — clean
- frontend — 15 passed
- frontend production build — clean
- `git diff --check` — clean

## Merge gate

Do not merge until standard CI and production-stack release readiness are green.