### PR TITLE
Build 214: browser, mobile, and accessibility release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,33 @@ jobs:
         run: npm run test
       - name: Build frontend
         run: npm run build
+
+  browser-release-gate:
+    name: Browser, mobile, and accessibility gate
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: npm ci
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Build production frontend
+        run: npm run build
+      - name: Run browser release gate
+        run: npm run test:e2e
+      - name: Upload browser failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ venv/
 node_modules/
 dist/
 coverage/
+playwright-report/
+test-results/
 
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ Frontend without Docker:
 cd frontend
 npm install
 npm run dev
+# After installing Chromium with Playwright:
+npm run build && npm run test:e2e
 ```
 
 ## Production Release
 
-Build 207 added the production Compose stack. Builds 208–211 add database-backed sessions, role permissions, login abuse safeguards, and administrator-assisted recovery. Build 209 adds the complete Alembic baseline and verified database-plus-upload recovery bundles. Build 212 adds private S3-compatible storage and verified scheduled-backup retention while preserving the controlled local-volume option.
+Build 207 added the production Compose stack. Builds 208–211 add database-backed sessions, role permissions, login abuse safeguards, and administrator-assisted recovery. Build 209 adds the complete Alembic baseline and verified database-plus-upload recovery bundles. Build 212 adds private S3-compatible storage and verified scheduled-backup retention while preserving the controlled local-volume option. Builds 213–214 add operational diagnostics, incident runbooks, and a desktop/mobile/accessibility browser release gate.
 
 ```bash
 cp .env.production.example .env.production

--- a/docs/builds/BUILD_214.md
+++ b/docs/builds/BUILD_214.md
@@ -1,0 +1,26 @@
+# Build 214 — Browser, mobile, and accessibility release gate
+
+Build 214 adds a required Chromium gate to pull-request and `main` CI.
+
+## Gate coverage
+
+- Builds and serves the production frontend bundle.
+- Exercises the sign-in transition into the authenticated dashboard shell.
+- Runs at desktop Chrome and Pixel 7 viewport/device settings.
+- Rejects horizontal viewport overflow and verifies the mobile navigation control.
+- Runs axe rules tagged WCAG 2.0/2.1 A and AA and rejects serious or critical violations.
+- Captures Playwright traces, screenshots, and an HTML report on failure; CI retains the report for 14 days.
+
+API responses are intercepted with deterministic, non-production fixtures. This makes the browser gate repeatable and prevents CI from needing credentials or paid infrastructure. Backend authentication, authorization, and production-stack smoke coverage remain separate required gates.
+
+## Local use
+
+```bash
+cd frontend
+npm ci
+npx playwright install chromium
+npm run build
+npm run test:e2e
+```
+
+The browser binaries are development/CI dependencies only and are not included in the production frontend image.

--- a/frontend/e2e/release-gate.spec.ts
+++ b/frontend/e2e/release-gate.spec.ts
@@ -1,0 +1,75 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, Page, test } from "@playwright/test";
+
+const user = {
+  id: "00000000-0000-0000-0000-000000000214",
+  email: "release-gate@ironhousecivil.com",
+  display_name: "Release Gate Operator",
+  role: "admin",
+  is_active: true,
+  password_reset_required: false,
+  last_login_at: null,
+  created_at: "2026-07-14T00:00:00Z",
+  updated_at: "2026-07-14T00:00:00Z",
+};
+
+async function mockApi(page: Page) {
+  let authenticated = false;
+  await page.route("http://localhost:8000/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/auth/me")) {
+      await route.fulfill(
+        authenticated
+          ? { status: 200, json: { authentication: "authenticated", user } }
+          : { status: 401, json: { detail: "Sign in is required." } },
+      );
+      return;
+    }
+    if (path.endsWith("/auth/login") && request.method() === "POST") {
+      authenticated = true;
+      await route.fulfill({ status: 200, json: { authentication: "authenticated", user } });
+      return;
+    }
+    await route.fulfill({ status: 200, json: { items: [], total: 0 } });
+  });
+}
+
+async function expectNoSeriousAccessibilityViolations(page: Page) {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  const blocking = results.violations.filter(
+    ({ impact }) => impact === "critical" || impact === "serious",
+  );
+  expect(blocking, JSON.stringify(blocking, null, 2)).toEqual([]);
+}
+
+test("authenticated core shell is responsive and accessible", async ({ page }, testInfo) => {
+  await mockApi(page);
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "Iron House OS" })).toBeVisible();
+  await page.getByLabel("Email").fill("release-gate@ironhousecivil.com");
+  await page.getByLabel("Password").fill("Local-release-gate-only");
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await expect(page.getByRole("heading", { name: "Iron House Dashboard" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+
+  const hasHorizontalOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  );
+  expect(hasHorizontalOverflow).toBe(false);
+
+  if (testInfo.project.name === "mobile-chromium") {
+    const menu = page.getByRole("button", { name: "Open navigation" });
+    await expect(menu).toBeVisible();
+    await menu.click();
+    await expect(page.getByRole("navigation").getByText("Dashboard", { exact: true })).toBeVisible();
+  } else {
+    await expect(page.getByText("Administrator access")).toBeVisible();
+  }
+
+  await expectNoSeriousAccessibilityViolations(page);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,9 @@
         "react-router-dom": "latest"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@eslint/js": "latest",
+        "@playwright/test": "^1.55.0",
         "@testing-library/jest-dom": "latest",
         "@testing-library/react": "latest",
         "@testing-library/user-event": "latest",
@@ -105,6 +107,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -872,6 +887,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
@@ -965,9 +996,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -985,9 +1013,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1005,9 +1030,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1025,9 +1047,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1045,9 +1064,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1065,9 +1081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1869,6 +1882,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -3113,9 +3136,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3137,9 +3157,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3161,9 +3178,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3185,9 +3199,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3610,6 +3621,67 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright/node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "tsc --noEmit",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -17,24 +18,26 @@
     "react-router-dom": "latest"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "latest",
+    "@axe-core/playwright": "^4.10.2",
     "@eslint/js": "latest",
+    "@playwright/test": "^1.55.0",
     "@testing-library/jest-dom": "latest",
     "@testing-library/react": "latest",
     "@testing-library/user-event": "latest",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",
+    "@vitejs/plugin-react": "latest",
     "autoprefixer": "latest",
     "eslint": "latest",
     "eslint-plugin-react-hooks": "latest",
     "eslint-plugin-react-refresh": "latest",
+    "jsdom": "latest",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "latest",
     "typescript-eslint": "latest",
     "vite": "latest",
-    "vitest": "latest",
-    "jsdom": "latest"
+    "vitest": "latest"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "npm run preview -- --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    { name: "desktop-chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "mobile-chromium", use: { ...devices["Pixel 7"] } },
+  ],
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -70,7 +70,7 @@ export function AppLayout({ children }: PropsWithChildren) {
           </div>
           <div className="flex items-center gap-3">
             <div className="hidden text-xs font-medium text-iron-500 sm:block">{accessLabel}</div>
-            <div className="rounded-md bg-signal-green px-3 py-1 text-xs font-semibold capitalize text-white">
+            <div className="rounded-md bg-iron-950 px-3 py-1 text-xs font-semibold capitalize text-white">
               {user?.role.replace("_", " ")}
             </div>
             <button

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    include: ["src/**/*.test.{ts,tsx}"],
     setupFiles: "./src/test/setup.ts",
   },
 });


### PR DESCRIPTION
## Outcome

Add a required production-bundle Chromium gate for the authenticated shell across desktop and mobile, with automated accessibility checks.

## Included

- Playwright desktop Chrome and Pixel 7 projects
- deterministic login-to-dashboard browser regression
- horizontal overflow and mobile navigation assertions
- axe WCAG 2.0/2.1 A and AA checks blocking serious/critical violations
- CI browser job with Chromium installation and retained failure evidence
- corrected admin role-badge contrast discovered by the new gate
- Vitest include boundary separating unit and browser suites
- operator documentation and local commands

## Validation

- browser release gate — 2 passed
- frontend unit tests — 15 passed
- TypeScript lint — clean
- production build — clean
- workflow YAML — valid
- `git diff --check` — clean

## Merge gate

Do not merge until standard CI, the new browser gate, and production-stack release readiness are green.