### PR TITLE
Build 215: production-candidate cutover package

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -102,6 +102,22 @@ jobs:
           --email "$BOOTSTRAP_ADMIN_EMAIL"
           --password "$BOOTSTRAP_ADMIN_PASSWORD"
           --input /tmp/ihos-recovery-probe.json
+      - name: Build release-candidate evidence
+        run: >-
+          python scripts/release_candidate_evidence.py
+          --output release-candidate-evidence
+          --release-id "$GITHUB_SHA"
+          --gate ci=not_run
+          --gate browser_mobile_accessibility=not_run
+          --gate production_stack_smoke=passed
+          --gate backup_restore=passed
+      - name: Upload release-candidate evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate-evidence-${{ github.sha }}
+          path: release-candidate-evidence
+          if-no-files-found: error
+          retention-days: 30
       - name: Show production logs on failure
         if: failure()
         run: docker compose --env-file .env.production.example -f docker-compose.production.yml logs --no-color

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 coverage/
 playwright-report/
 test-results/
+release-candidate-evidence/
 
 .idea/
 .vscode/

--- a/docs/builds/BUILD_215.md
+++ b/docs/builds/BUILD_215.md
@@ -1,0 +1,10 @@
+# Build 215 — Production-candidate cutover package
+
+Build 215 completes the pre-infrastructure release package.
+
+- `scripts/release_candidate_evidence.py` produces JSON and Markdown evidence bound to the exact Git commit/tree and SHA-256 hashes of deployment, smoke, backup, restore, and operator-runbook inputs.
+- Release readiness generates and retains the evidence bundle only after its disposable production-stack smoke and recovery drill succeeds.
+- The cutover checklist defines prerequisites, execution order, verification, and abort conditions.
+- The operator acceptance record remains pending until a real, explicitly approved cutover.
+
+This build validates a production candidate. It does not select or provision a host, change DNS, buy services, configure external alert delivery, send communications, or authorize live traffic.

--- a/docs/operations/cutover-checklist.md
+++ b/docs/operations/cutover-checklist.md
@@ -1,0 +1,29 @@
+# Production cutover checklist
+
+No step in this checklist authorizes infrastructure spend, DNS changes, credential sharing, or external communication. Those actions require Jeremie’s explicit approval.
+
+## Go/no-go prerequisites
+
+- [ ] Approved host, region, budget, domain, TLS termination, backup destination, and monitoring destination are recorded.
+- [ ] Named cutover operator, approver, rollback owner, and maintenance window are recorded in UTC.
+- [ ] Immutable application image digests and the release-candidate commit match the evidence bundle.
+- [ ] CI, browser/mobile/accessibility, production-stack smoke, migration, backup, and restore gates passed for that commit.
+- [ ] Production secrets are supplied through the approved secret store and are absent from files, logs, shell history, and evidence.
+- [ ] A verified pre-cutover recovery point exists off host; its restore drill and expected recovery window are recorded.
+- [ ] Incident, rollback, and recovery runbooks are open and the last known-good release is deployable.
+
+Any unchecked prerequisite is a no-go.
+
+## Cutover sequence
+
+1. Announce the approved maintenance state through the separately approved communication plan.
+2. Freeze writes, record UTC time, and create/verify the final pre-cutover backup.
+3. Deploy the exact approved image/configuration and apply migrations once.
+4. Require green `/health` and `/readiness` before routing user traffic.
+5. Run authenticated smoke, representative read/write, document upload/download, diagnostics, and desktop/mobile browser checks.
+6. Complete the operator acceptance record. Route traffic only after explicit go approval.
+7. Create a verified post-cutover backup and begin the observation window.
+
+## Abort conditions
+
+Abort and follow the rollback runbook for migration uncertainty, failed readiness, authentication failure, data-integrity mismatch, failed upload/download, unapproved configuration drift, or missing evidence. Preserve logs and do not improvise destructive database changes.

--- a/docs/operations/operator-acceptance.md
+++ b/docs/operations/operator-acceptance.md
@@ -1,0 +1,26 @@
+# Production operator acceptance
+
+This record is intentionally **pending** in source control. Copy it into the approved change record and complete it during an authorized cutover.
+
+- Release ID:
+- Commit SHA:
+- Image digests:
+- Environment/host:
+- Cutover window (UTC):
+- Operator:
+- Approver:
+- Pre-cutover recovery point:
+- Evidence bundle location and SHA-256:
+- Observed `/health` result/time:
+- Observed `/readiness` result/time:
+- Authenticated smoke result:
+- Document upload/download result:
+- Browser/mobile/accessibility gate run:
+- Post-cutover recovery point:
+- Known limitations accepted:
+- Decision: `GO` / `ROLLBACK`
+- Decision time (UTC):
+- Operator signature/reference:
+- Approver signature/reference:
+
+Acceptance is invalid if any field is omitted, the release identity differs from the evidence bundle, or approval occurred before verification completed.

--- a/scripts/release_candidate_evidence.py
+++ b/scripts/release_candidate_evidence.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+from datetime import UTC, datetime
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Iterable
+
+REQUIRED_FILES = (
+    ".env.production.example",
+    "docker-compose.production.yml",
+    "docs/operations/cutover-checklist.md",
+    "docs/operations/operator-acceptance.md",
+    "docs/operations/incident-response.md",
+    "docs/operations/rollback.md",
+    "docs/operations/recovery.md",
+    "scripts/backup.sh",
+    "scripts/restore.sh",
+    "scripts/release_smoke.py",
+)
+ALLOWED_GATE_OUTCOMES = {"passed", "failed", "not_run"}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git_value(root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def parse_gates(values: Iterable[str]) -> dict[str, str]:
+    gates: dict[str, str] = {}
+    for value in values:
+        try:
+            name, outcome = value.split("=", 1)
+        except ValueError as exc:
+            raise ValueError(f"Invalid gate '{value}'; expected name=outcome.") from exc
+        if not name or outcome not in ALLOWED_GATE_OUTCOMES:
+            raise ValueError(
+                f"Invalid gate '{value}'; outcomes are {sorted(ALLOWED_GATE_OUTCOMES)}."
+            )
+        gates[name] = outcome
+    return dict(sorted(gates.items()))
+
+
+def build_evidence(
+    root: Path,
+    *,
+    release_id: str | None,
+    gates: dict[str, str],
+    generated_at: datetime | None = None,
+) -> dict[str, object]:
+    missing = [path for path in REQUIRED_FILES if not (root / path).is_file()]
+    if missing:
+        raise ValueError(f"Release package is incomplete; missing: {', '.join(missing)}")
+    commit_sha = git_value(root, "rev-parse", "HEAD")
+    resolved_release_id = release_id or commit_sha
+    timestamp = generated_at or datetime.now(UTC)
+    return {
+        "schema_version": 1,
+        "release_id": resolved_release_id,
+        "commit_sha": commit_sha,
+        "commit_tree": git_value(root, "rev-parse", "HEAD^{tree}"),
+        "generated_at": timestamp.astimezone(UTC).isoformat(),
+        "working_tree_clean": not bool(git_value(root, "status", "--porcelain")),
+        "gates": gates,
+        "files": {path: sha256(root / path) for path in REQUIRED_FILES},
+        "operator_acceptance": "pending",
+        "limitations": [
+            "No live host, DNS, TLS, monitoring destination, or paid service was provisioned.",
+            "Operator acceptance must be completed at the approved cutover window.",
+        ],
+    }
+
+
+def render_markdown(evidence: dict[str, object]) -> str:
+    gates = evidence["gates"]
+    files = evidence["files"]
+    lines = [
+        "# Iron House OS release-candidate evidence",
+        "",
+        f"- Release ID: `{evidence['release_id']}`",
+        f"- Commit: `{evidence['commit_sha']}`",
+        f"- Tree: `{evidence['commit_tree']}`",
+        f"- Generated: {evidence['generated_at']}",
+        f"- Working tree clean: {str(evidence['working_tree_clean']).lower()}",
+        f"- Operator acceptance: **{evidence['operator_acceptance']}**",
+        "",
+        "## Gates",
+        "",
+        *[f"- {name}: **{outcome}**" for name, outcome in gates.items()],
+        "",
+        "## Integrity manifest",
+        "",
+        *[f"- `{path}` — `{digest}`" for path, digest in files.items()],
+        "",
+        "## Limitations",
+        "",
+        *[f"- {item}" for item in evidence["limitations"]],
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = ArgumentParser(description="Build an integrity-checked IHOS release evidence bundle.")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--output", type=Path, default=Path("release-candidate-evidence"))
+    parser.add_argument("--release-id")
+    parser.add_argument("--gate", action="append", default=[], metavar="NAME=OUTCOME")
+    args = parser.parse_args()
+    try:
+        gates = parse_gates(args.gate)
+        evidence = build_evidence(args.root.resolve(), release_id=args.release_id, gates=gates)
+    except (OSError, subprocess.CalledProcessError, ValueError) as exc:
+        print(f"release evidence failed: {exc}", file=sys.stderr)
+        return 1
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "evidence.json").write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (args.output / "evidence.md").write_text(render_markdown(evidence), encoding="utf-8")
+    print(f"release evidence written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/backend/test_release_candidate_evidence.py
+++ b/tests/backend/test_release_candidate_evidence.py
@@ -1,0 +1,44 @@
+from datetime import UTC, datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.release_candidate_evidence import build_evidence, parse_gates, render_markdown  # noqa: E402
+
+
+def test_release_candidate_evidence_is_bound_to_commit_and_files() -> None:
+    generated_at = datetime(2026, 7, 14, 12, 0, tzinfo=UTC)
+    evidence = build_evidence(
+        ROOT,
+        release_id="build-215-test",
+        gates={"backup_restore": "passed", "ci": "not_run"},
+        generated_at=generated_at,
+    )
+
+    assert evidence["release_id"] == "build-215-test"
+    assert len(str(evidence["commit_sha"])) == 40
+    assert len(str(evidence["commit_tree"])) == 40
+    assert evidence["generated_at"] == "2026-07-14T12:00:00+00:00"
+    assert evidence["operator_acceptance"] == "pending"
+    assert len(evidence["files"]["docker-compose.production.yml"]) == 64
+    markdown = render_markdown(evidence)
+    assert "Operator acceptance: **pending**" in markdown
+    assert "backup_restore: **passed**" in markdown
+
+
+def test_incomplete_release_package_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Release package is incomplete"):
+        build_evidence(tmp_path, release_id=None, gates={})
+
+
+def test_gate_parser_rejects_unknown_outcomes() -> None:
+    assert parse_gates(["ci=passed", "browser=not_run"]) == {
+        "browser": "not_run",
+        "ci": "passed",
+    }
+    with pytest.raises(ValueError, match="Invalid gate"):
+        parse_gates(["ci=probably"])


### PR DESCRIPTION
## Outcome

Produce a reproducible production-candidate evidence bundle and the controlled cutover, abort, rollback, recovery, and operator-acceptance package without provisioning infrastructure or sending external communications.

## Included

- fail-closed release evidence generator
- exact commit/tree identity and SHA-256 integrity manifest
- JSON and Markdown evidence outputs
- truthful gate outcomes and explicit limitations
- cutover go/no-go prerequisites and abort conditions
- pending operator acceptance template
- release-readiness artifact generation after smoke and recovery verification
- 30-day GitHub artifact retention
- tests for integrity binding, missing inputs, and gate validation

## Validation

- backend CI command — 101 passed
- focused evidence tests — 3 passed
- Ruff — clean
- local evidence generation — clean
- workflow YAML — valid
- `git diff --check` — clean

## Scope boundary

No host, domain, DNS, TLS, monitoring destination, paid service, live traffic, credential distribution, or external message is created by this PR.

## Merge gate

Do not merge until CI, browser/mobile/accessibility, and production-stack release readiness are green and the evidence artifact is generated.