### PR TITLE
Build 216: approved live infrastructure cutover

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -18,4 +18,11 @@ IHOS_STORAGE_CACHE_ROOT=/app/data/object-cache
 AWS_REGION=ca-central-1
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
+# Off-host recovery bundles. This may be the document bucket or a separate private bucket.
+IHOS_BACKUP_S3_BUCKET=
+IHOS_BACKUP_S3_PREFIX=recovery-bundles
+IHOS_BACKUP_RETENTION_DAYS=30
+IHOS_BACKUP_KEEP_MINIMUM=7
+IHOS_BACKUP_MAXIMUM_BUNDLES=60
+IHOS_TLS_EMAIL=jeremie@ironhousecivil.com
 IHOS_PORT=8080

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -10,6 +10,7 @@ on:
       - "docker-compose.production.yml"
       - ".env.production.example"
       - "scripts/**"
+      - "ops/**"
       - ".github/workflows/release-readiness.yml"
   pull_request:
     branches: [main]
@@ -19,15 +20,82 @@ on:
       - "docker-compose.production.yml"
       - ".env.production.example"
       - "scripts/**"
+      - "ops/**"
       - ".github/workflows/release-readiness.yml"
 
 permissions:
   contents: read
 
 jobs:
+  backend:
+    name: Release backend gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Lint backend
+        run: ruff check .
+      - name: Test backend
+        run: pytest
+
+  frontend:
+    name: Release frontend gate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: npm ci
+      - name: Lint frontend
+        run: npm run lint
+      - name: Test frontend
+        run: npm run test
+      - name: Build frontend
+        run: npm run build
+
+  browser-release-gate:
+    name: Release browser, mobile, and accessibility gate
+    runs-on: ubuntu-latest
+    needs: frontend
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        run: npm ci
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Build production frontend
+        run: npm run build
+      - name: Run browser release gate
+        run: npm run test:e2e
+
   production-stack:
     name: Production stack smoke test
     runs-on: ubuntu-latest
+    needs: [backend, frontend, browser-release-gate]
     timeout-minutes: 25
     env:
       POSTGRES_DB: iron_house_os
@@ -43,6 +111,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate production configuration
         run: docker compose --env-file .env.production.example -f docker-compose.production.yml config --quiet
+      - name: Validate Build 216 host assets
+        run: |
+          bash -n ops/digitalocean/cutover.sh scripts/verify_s3_targets.sh scripts/upload_backup_s3.sh
+          docker run --rm \
+            -v "$PWD/ops/digitalocean/nginx-maintenance.conf:/etc/nginx/conf.d/default.conf:ro" \
+            nginx:1.27-alpine nginx -t
       - name: Start production stack
         run: docker compose --env-file .env.production.example -f docker-compose.production.yml up -d --build --wait
       - name: Prove Build 208 PostgreSQL upgrade
@@ -107,8 +181,8 @@ jobs:
           python scripts/release_candidate_evidence.py
           --output release-candidate-evidence
           --release-id "$GITHUB_SHA"
-          --gate ci=not_run
-          --gate browser_mobile_accessibility=not_run
+          --gate ci=passed
+          --gate browser_mobile_accessibility=passed
           --gate production_stack_smoke=passed
           --gate backup_restore=passed
       - name: Upload release-candidate evidence

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ npm run build && npm run test:e2e
 
 ## Production Release
 
-Build 207 added the production Compose stack. Builds 208–211 add database-backed sessions, role permissions, login abuse safeguards, and administrator-assisted recovery. Build 209 adds the complete Alembic baseline and verified database-plus-upload recovery bundles. Build 212 adds private S3-compatible storage and verified scheduled-backup retention while preserving the controlled local-volume option. Builds 213–214 add operational diagnostics, incident runbooks, and a desktop/mobile/accessibility browser release gate.
+Build 207 added the production Compose stack. Builds 208–211 add database-backed sessions, role permissions, login abuse safeguards, and administrator-assisted recovery. Build 209 adds the complete Alembic baseline and verified database-plus-upload recovery bundles. Build 212 adds private S3-compatible storage and verified scheduled-backup retention while preserving the controlled local-volume option. Builds 213–215 add operational diagnostics, browser/mobile/accessibility gates, and an integrity-bound production-candidate package. Build 216 adds the approved, fail-closed Toronto live-cutover configuration and verified off-host recovery workflow.
 
 ```bash
 cp .env.production.example .env.production
@@ -70,6 +70,8 @@ scripts/backup.sh --output "/secure/off-host/ihos-$(date -u +%Y%m%dT%H%M%SZ)"
 The smoke test expects `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD`. It signs in through the application before testing protected APIs. Full mode creates clearly named validation records; omit `--full` for a read-only health, login, and application-shell check.
 
 See [the release runbook](docs/deployment.md) before exposing IHOS outside a trusted network. A public deployment must terminate HTTPS upstream, schedule off-host recovery bundles, and regularly confirm the automated restore drill remains green.
+
+The approved Build 216 DigitalOcean configuration and operator procedure are documented in [Build 216](docs/builds/BUILD_216.md). The live script requires the exact merged commit, the matching GitHub release-evidence artifact, protected provider credentials, matching DNS, and an explicit go flag.
 
 ## Core Application Areas
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -80,7 +80,7 @@ services:
       backend:
         condition: service_healthy
     ports:
-      - "${IHOS_PORT:-8080}:80"
+      - "127.0.0.1:${IHOS_PORT:-8080}:80"
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1/healthz"]
       interval: 10s

--- a/docs/builds/BUILD_216.md
+++ b/docs/builds/BUILD_216.md
@@ -1,0 +1,28 @@
+# Build 216 — Approved live infrastructure cutover
+
+## Approved target
+
+Jeremie approved Build 216 on 2026-07-15 with a CAD 60 monthly ceiling:
+
+- DigitalOcean Basic Droplet, Toronto (`tor1`), 2 vCPU and 4 GiB RAM
+- `os.ironhousecivil.com`
+- Nginx TLS termination with Let's Encrypt
+- private, encrypted, versioned AWS S3 storage in `ca-central-1`
+- daily Droplet backups plus verified off-host recovery bundles
+- five-minute external health and readiness monitoring
+- 2026-07-19 13:00–15:00 UTC maintenance window
+- Jeremie as operator/approver and Mac as rollback owner
+
+## Delivered controls
+
+- the application port now binds only to loopback
+- cloud-init prepares a firewalled Ubuntu Docker host without embedding secrets
+- maintenance and live Nginx configurations keep the public route fail-closed
+- cutover requires an exact 40-character commit, a clean tree, a checksum-valid release evidence artifact with all four required gates passed, protected secrets, matching DNS, private/versioned/encrypted S3 targets, full authenticated smoke, pre/post backups, and explicit `--confirm-go`
+- failed public verification restores the maintenance response
+- scheduled recovery bundles are archived to S3 and verified by SHA-256 metadata
+- operator acceptance is written on the host only after the public HTTPS smoke and post-cutover backup succeed
+
+## External boundary
+
+Repository validation cannot create a DigitalOcean account, charge a payment method, create an AWS bucket, edit the existing domain's DNS, or register UptimeRobot recipients. Those provider actions require authenticated provider access. The cutover script refuses to continue until those approved resources and protected credentials exist.

--- a/docs/operations/cutover-checklist.md
+++ b/docs/operations/cutover-checklist.md
@@ -2,6 +2,22 @@
 
 No step in this checklist authorizes infrastructure spend, DNS changes, credential sharing, or external communication. Those actions require Jeremie’s explicit approval.
 
+## Build 216 approved plan
+
+Jeremie approved Build 216 on 2026-07-15 with these limits:
+
+- Host: DigitalOcean Basic Droplet, Toronto (`tor1`), 2 vCPU / 4 GiB
+- Budget: maximum CAD 60 per month; no automatic paid upgrade
+- Domain: `os.ironhousecivil.com`
+- TLS: Let's Encrypt terminated by host Nginx
+- Storage: private, versioned, encrypted AWS S3 in `ca-central-1`
+- Recovery: daily Droplet backup plus verified off-host recovery bundles
+- Monitoring: five-minute external checks for `/healthz` and `/readiness`
+- Window: 2026-07-19 13:00–15:00 UTC
+- Operator/approver: Jeremie Peters; rollback owner: Mac
+
+This approval permits the listed hosting spend, DNS record, TLS issuance, monitoring, and live deployment. It does not permit exceeding the budget, substituting a provider/region, disabling recovery controls, or sharing secrets in source control or chat.
+
 ## Go/no-go prerequisites
 
 - [ ] Approved host, region, budget, domain, TLS termination, backup destination, and monitoring destination are recorded.

--- a/docs/operations/operator-acceptance.md
+++ b/docs/operations/operator-acceptance.md
@@ -9,8 +9,10 @@ This record is intentionally **pending** in source control. Copy it into the app
 - Cutover window (UTC):
 - Operator:
 - Approver:
+- Rollback owner:
 - Pre-cutover recovery point:
 - Evidence bundle location and SHA-256:
+- Release evidence verification result:
 - Observed `/health` result/time:
 - Observed `/readiness` result/time:
 - Authenticated smoke result:

--- a/ops/digitalocean/cloud-init.yaml
+++ b/ops/digitalocean/cloud-init.yaml
@@ -1,0 +1,40 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+ssh_pwauth: false
+packages:
+  - awscli
+  - ca-certificates
+  - certbot
+  - curl
+  - docker-compose-v2
+  - docker.io
+  - git
+  - jq
+  - nginx
+  - python3-certbot-nginx
+  - ufw
+write_files:
+  - path: /etc/iron-house-os/README
+    permissions: "0644"
+    content: |
+      Production secrets belong in /etc/iron-house-os/production.env with mode 0600.
+      Do not place credentials in cloud-init, Git, shell history, or support messages.
+runcmd:
+  - [mkdir, -p, /etc/iron-house-os, /opt/iron-house-os, /var/backups/iron-house-os, /var/lib/iron-house-os, /var/www/letsencrypt]
+  - [chmod, "0700", /etc/iron-house-os]
+  - [systemctl, enable, --now, docker]
+  - [systemctl, enable, --now, nginx]
+  - [ufw, default, deny, incoming]
+  - [ufw, default, allow, outgoing]
+  - [ufw, allow, OpenSSH]
+  - [ufw, allow, "Nginx Full"]
+  - [ufw, --force, enable]
+  - [git, clone, --branch, main, --single-branch, https://github.com/iron-house-os/iron-house-os.git, /opt/iron-house-os/source]
+  - [cp, /opt/iron-house-os/source/ops/digitalocean/nginx-maintenance.conf, /etc/nginx/sites-available/iron-house-os]
+  - [ln, -sfn, /etc/nginx/sites-available/iron-house-os, /etc/nginx/sites-enabled/iron-house-os]
+  - [rm, -f, /etc/nginx/sites-enabled/default]
+  - [nginx, -t]
+  - [systemctl, reload, nginx]
+  - [touch, /var/lib/iron-house-os/cloud-init-complete]
+final_message: "Iron House OS host bootstrap completed; production secrets and cutover are still pending."

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)
+environment_file=${IHOS_COMPOSE_ENV_FILE:-/etc/iron-house-os/production.env}
+release_sha=
+evidence_file=
+confirm_go=0
+domain=os.ironhousecivil.com
+
+usage() {
+  echo "Usage: sudo ops/digitalocean/cutover.sh --release 40_HEX_SHA --evidence evidence.json --confirm-go" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --release)
+      release_sha=${2:-}
+      shift 2
+      ;;
+    --confirm-go)
+      confirm_go=1
+      shift
+      ;;
+    --evidence)
+      evidence_file=${2:-}
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ((EUID != 0)) || [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]] || [[ ! -f "$evidence_file" ]] || ((confirm_go != 1)); then
+  usage
+  exit 2
+fi
+if [[ ! -f /var/lib/iron-house-os/cloud-init-complete ]]; then
+  echo "Cloud-init host bootstrap has not completed." >&2
+  exit 1
+fi
+if [[ ! -f "$environment_file" ]]; then
+  echo "Missing protected production environment: $environment_file" >&2
+  exit 1
+fi
+evidence_file=$(cd "$(dirname "$evidence_file")" && pwd -P)/$(basename "$evidence_file")
+environment_mode=$(stat -c '%a' "$environment_file")
+if [[ "$environment_mode" != "600" && "$environment_mode" != "400" ]]; then
+  echo "Production environment permissions must be 0600 or 0400." >&2
+  exit 1
+fi
+
+cd "$repo_root"
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Refusing cutover from a dirty working tree." >&2
+  exit 1
+fi
+git fetch --quiet origin main
+git cat-file -e "$release_sha^{commit}"
+git checkout --quiet --detach "$release_sha"
+if [[ "$(git rev-parse HEAD)" != "$release_sha" ]]; then
+  echo "Release checkout identity mismatch." >&2
+  exit 1
+fi
+python scripts/verify_release_candidate_evidence.py \
+  --root "$repo_root" \
+  --evidence "$evidence_file" \
+  --release "$release_sha"
+
+set -a
+# shellcheck disable=SC1090
+source "$environment_file"
+set +a
+: "${BOOTSTRAP_ADMIN_EMAIL:?BOOTSTRAP_ADMIN_EMAIL is required}"
+: "${BOOTSTRAP_ADMIN_PASSWORD:?BOOTSTRAP_ADMIN_PASSWORD is required}"
+: "${IHOS_STORAGE_BACKEND:?IHOS_STORAGE_BACKEND is required}"
+: "${IHOS_STORAGE_S3_BUCKET:?IHOS_STORAGE_S3_BUCKET is required}"
+: "${IHOS_BACKUP_S3_BUCKET:?IHOS_BACKUP_S3_BUCKET is required}"
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+: "${IHOS_TLS_EMAIL:?IHOS_TLS_EMAIL is required}"
+if [[ "$IHOS_STORAGE_BACKEND" != "s3" || "$AWS_REGION" != "ca-central-1" ]]; then
+  echo "Build 216 requires private S3 storage in ca-central-1." >&2
+  exit 1
+fi
+
+public_ipv4=$(curl -fsS --max-time 5 http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)
+dns_ipv4=$(getent ahostsv4 "$domain" | awk 'NR == 1 {print $1}')
+if [[ -z "$public_ipv4" || "$dns_ipv4" != "$public_ipv4" ]]; then
+  echo "DNS for $domain does not resolve to this Droplet ($public_ipv4)." >&2
+  exit 1
+fi
+
+scripts/verify_s3_targets.sh "$IHOS_STORAGE_S3_BUCKET" "$IHOS_BACKUP_S3_BUCKET"
+compose=(docker compose --env-file "$environment_file" -f docker-compose.production.yml)
+"${compose[@]}" config --quiet
+"${compose[@]}" config --format json | python -c '
+import json, sys
+project = json.load(sys.stdin)
+ports = project["services"]["frontend"].get("ports", [])
+if not ports or any(port.get("host_ip") != "127.0.0.1" for port in ports):
+    raise SystemExit("Frontend must bind only to 127.0.0.1 before cutover.")
+'
+
+install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
+nginx -t
+systemctl reload nginx
+"${compose[@]}" up -d --build --wait
+python scripts/release_smoke.py \
+  --base-url "http://127.0.0.1:${IHOS_PORT:-8080}" \
+  --email "$BOOTSTRAP_ADMIN_EMAIL" \
+  --password "$BOOTSTRAP_ADMIN_PASSWORD" \
+  --full
+
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
+IHOS_BACKUP_NAME="pre-cutover-$stamp" \
+scripts/scheduled_backup.sh
+certbot certonly \
+  --webroot \
+  --webroot-path /var/www/letsencrypt \
+  --domain "$domain" \
+  --email "$IHOS_TLS_EMAIL" \
+  --agree-tos \
+  --non-interactive \
+  --keep-until-expiring
+
+live_enabled=0
+rollback_maintenance() {
+  status=$?
+  if ((status != 0 && live_enabled == 1)); then
+    install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
+    nginx -t >/dev/null && systemctl reload nginx
+  fi
+  exit "$status"
+}
+trap rollback_maintenance EXIT
+install -m 0644 ops/digitalocean/nginx-live.conf /etc/nginx/sites-available/iron-house-os
+nginx -t
+systemctl reload nginx
+live_enabled=1
+python scripts/release_smoke.py \
+  --base-url "https://$domain" \
+  --email "$BOOTSTRAP_ADMIN_EMAIL" \
+  --password "$BOOTSTRAP_ADMIN_PASSWORD"
+IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
+IHOS_BACKUP_NAME="post-cutover-$stamp" \
+scripts/scheduled_backup.sh
+
+acceptance=/var/lib/iron-house-os/operator-acceptance-$stamp.md
+cat >"$acceptance" <<EOF
+# Iron House OS production operator acceptance
+
+- Release ID: Build 216
+- Commit SHA: $release_sha
+- Environment/host: DigitalOcean tor1 / $domain / $public_ipv4
+- Cutover window (UTC): $stamp
+- Operator: Jeremie Peters
+- Approver: Jeremie Peters
+- Rollback owner: Mac
+- Pre-cutover recovery point: s3://$IHOS_BACKUP_S3_BUCKET/${IHOS_BACKUP_S3_PREFIX:-recovery-bundles}/pre-cutover-$stamp.tar.gz
+- Release evidence: $evidence_file
+- Observed health/readiness: passed
+- Authenticated smoke result: passed
+- Document upload/download result: passed by full local smoke
+- TLS result: passed
+- Post-cutover recovery point: s3://$IHOS_BACKUP_S3_BUCKET/${IHOS_BACKUP_S3_PREFIX:-recovery-bundles}/post-cutover-$stamp.tar.gz
+- Decision: GO
+- Decision time (UTC): $(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+chmod 0600 "$acceptance"
+live_enabled=0
+trap - EXIT
+echo "Build 216 live cutover passed: https://$domain"
+echo "Operator acceptance: $acceptance"

--- a/ops/digitalocean/host-plan.json
+++ b/ops/digitalocean/host-plan.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "approval": {
+    "approved_by": "Jeremie Peters",
+    "approved_on": "2026-07-15",
+    "authorization": "Approve Build 216"
+  },
+  "host": {
+    "provider": "DigitalOcean",
+    "region": "tor1",
+    "plan": "Basic Droplet, 2 vCPU, 4 GiB RAM",
+    "monthly_usd": 24.0,
+    "daily_backup_percent": 30
+  },
+  "budget": {
+    "currency": "CAD",
+    "monthly_cap": 60.0,
+    "automatic_upgrade_allowed": false
+  },
+  "network": {
+    "domain": "os.ironhousecivil.com",
+    "tls": "Let's Encrypt via Certbot",
+    "application_bind": "127.0.0.1:8080"
+  },
+  "storage": {
+    "provider": "AWS S3",
+    "region": "ca-central-1",
+    "public_access": false,
+    "versioning_required": true,
+    "encryption_required": true
+  },
+  "monitoring": {
+    "provider": "UptimeRobot",
+    "interval_minutes": 5,
+    "paths": ["/healthz", "/readiness"]
+  },
+  "cutover": {
+    "window_start_utc": "2026-07-19T13:00:00Z",
+    "window_end_utc": "2026-07-19T15:00:00Z",
+    "operator": "Jeremie Peters",
+    "approver": "Jeremie Peters",
+    "rollback_owner": "Mac",
+    "release_sha": null,
+    "decision": "PENDING"
+  }
+}

--- a/ops/digitalocean/nginx-live.conf
+++ b/ops/digitalocean/nginx-live.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name os.ironhousecivil.com;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt;
+        default_type text/plain;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name os.ironhousecivil.com;
+
+    ssl_certificate /etc/letsencrypt/live/os.ironhousecivil.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/os.ironhousecivil.com/privkey.pem;
+    client_max_body_size 100m;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "same-origin" always;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_request_buffering off;
+        proxy_read_timeout 300s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Request-ID $request_id;
+    }
+}

--- a/ops/digitalocean/nginx-maintenance.conf
+++ b/ops/digitalocean/nginx-maintenance.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name os.ironhousecivil.com;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/letsencrypt;
+        default_type text/plain;
+    }
+
+    location / {
+        add_header Retry-After "300" always;
+        return 503 "Iron House OS maintenance in progress.\n";
+    }
+}

--- a/scripts/release_candidate_evidence.py
+++ b/scripts/release_candidate_evidence.py
@@ -16,9 +16,18 @@ REQUIRED_FILES = (
     "docs/operations/incident-response.md",
     "docs/operations/rollback.md",
     "docs/operations/recovery.md",
+    "ops/digitalocean/host-plan.json",
+    "ops/digitalocean/cloud-init.yaml",
+    "ops/digitalocean/nginx-maintenance.conf",
+    "ops/digitalocean/nginx-live.conf",
+    "ops/digitalocean/cutover.sh",
     "scripts/backup.sh",
     "scripts/restore.sh",
     "scripts/release_smoke.py",
+    "scripts/release_candidate_evidence.py",
+    "scripts/verify_release_candidate_evidence.py",
+    "scripts/verify_s3_targets.sh",
+    "scripts/upload_backup_s3.sh",
 )
 ALLOWED_GATE_OUTCOMES = {"passed", "failed", "not_run"}
 

--- a/scripts/scheduled_backup.sh
+++ b/scripts/scheduled_backup.sh
@@ -22,7 +22,14 @@ if ! flock -n 9; then
 fi
 
 cd "$repo_root"
-scripts/backup.sh --output "$backup_root/$backup_name"
+backup_path="$backup_root/$backup_name"
+scripts/backup.sh --output "$backup_path"
+if [[ -n "${IHOS_BACKUP_S3_BUCKET:-}" ]]; then
+  scripts/upload_backup_s3.sh \
+    --backup "$backup_path" \
+    --bucket "$IHOS_BACKUP_S3_BUCKET" \
+    --prefix "${IHOS_BACKUP_S3_PREFIX:-recovery-bundles}"
+fi
 python scripts/backup_retention.py \
   --root "$backup_root" \
   --retention-days "$retention_days" \

--- a/scripts/upload_backup_s3.sh
+++ b/scripts/upload_backup_s3.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+backup=
+bucket=
+prefix=recovery-bundles
+
+usage() {
+  echo "Usage: scripts/upload_backup_s3.sh --backup DIRECTORY --bucket BUCKET [--prefix PREFIX]" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --backup)
+      backup=${2:-}
+      shift 2
+      ;;
+    --bucket)
+      bucket=${2:-}
+      shift 2
+      ;;
+    --prefix)
+      prefix=${2:-}
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$backup" || -z "$bucket" || ! -d "$backup" ]]; then
+  usage
+  exit 2
+fi
+if [[ ! "$prefix" =~ ^[A-Za-z0-9._/-]+$ || "$prefix" == /* || "$prefix" == *..* ]]; then
+  echo "Backup prefix must be a safe relative S3 prefix." >&2
+  exit 2
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+backup=$(cd "$backup" && pwd -P)
+backup_name=$(basename "$backup")
+if [[ ! "$backup_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "Backup directory name is unsafe: $backup_name" >&2
+  exit 2
+fi
+
+cd "$repo_root"
+python scripts/recovery_manifest.py verify --directory "$backup" >/dev/null
+scripts/verify_s3_targets.sh "$bucket" >/dev/null
+
+temporary=$(mktemp -d)
+cleanup() {
+  rm -rf "$temporary"
+}
+trap cleanup EXIT
+archive="$temporary/$backup_name.tar.gz"
+checksum_file="$archive.sha256"
+tar -C "$(dirname "$backup")" -czf "$archive" "$backup_name"
+checksum=$(sha256sum "$archive" | awk '{print $1}')
+printf '%s  %s\n' "$checksum" "$backup_name.tar.gz" >"$checksum_file"
+
+key="${prefix%/}/$backup_name.tar.gz"
+aws s3 cp "$archive" "s3://$bucket/$key" \
+  --only-show-errors \
+  --sse AES256 \
+  --metadata "sha256=$checksum"
+aws s3 cp "$checksum_file" "s3://$bucket/$key.sha256" \
+  --only-show-errors \
+  --sse AES256
+remote_checksum=$(aws s3api head-object \
+  --bucket "$bucket" \
+  --key "$key" \
+  --query 'Metadata.sha256' \
+  --output text)
+if [[ "$remote_checksum" != "$checksum" ]]; then
+  echo "Uploaded recovery bundle checksum metadata did not match." >&2
+  exit 1
+fi
+echo "Verified off-host recovery bundle: s3://$bucket/$key"

--- a/scripts/verify_release_candidate_evidence.py
+++ b/scripts/verify_release_candidate_evidence.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from argparse import ArgumentParser
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+
+REQUIRED_PASSED_GATES = {
+    "ci",
+    "browser_mobile_accessibility",
+    "production_stack_smoke",
+    "backup_restore",
+}
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_evidence(root: Path, evidence_path: Path, release_sha: str) -> dict[str, object]:
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    if evidence.get("commit_sha") != release_sha:
+        raise ValueError("Release evidence commit does not match the approved release.")
+    if evidence.get("working_tree_clean") is not True:
+        raise ValueError("Release evidence was not generated from a clean working tree.")
+    gates = evidence.get("gates")
+    if not isinstance(gates, dict):
+        raise ValueError("Release evidence gates are missing.")
+    failed_gates = sorted(gate for gate in REQUIRED_PASSED_GATES if gates.get(gate) != "passed")
+    if failed_gates:
+        raise ValueError(f"Required release gates are not passed: {', '.join(failed_gates)}")
+    files = evidence.get("files")
+    if not isinstance(files, dict) or not files:
+        raise ValueError("Release evidence integrity manifest is missing.")
+    for relative_path, expected_digest in files.items():
+        path = (root / relative_path).resolve()
+        try:
+            path.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"Evidence path escapes the repository: {relative_path}") from exc
+        if not path.is_file():
+            raise ValueError(f"Release evidence file is missing: {relative_path}")
+        if sha256(path) != expected_digest:
+            raise ValueError(f"Release evidence checksum mismatch: {relative_path}")
+    return evidence
+
+
+def main() -> int:
+    parser = ArgumentParser(description="Verify a Build 215/216 release evidence artifact.")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--release", required=True)
+    args = parser.parse_args()
+    root = args.root.resolve()
+    try:
+        evidence = verify_evidence(root, args.evidence.resolve(), args.release)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"release evidence verification failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        json.dumps(
+            {
+                "status": "passed",
+                "release_sha": evidence["commit_sha"],
+                "verified_files": len(evidence["files"]),
+                "passed_gates": sorted(REQUIRED_PASSED_GATES),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_s3_targets.sh
+++ b/scripts/verify_s3_targets.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: scripts/verify_s3_targets.sh BUCKET [BUCKET ...]" >&2
+}
+
+if (($# == 0)); then
+  usage
+  exit 2
+fi
+command -v aws >/dev/null || {
+  echo "The AWS CLI is required." >&2
+  exit 1
+}
+command -v jq >/dev/null || {
+  echo "jq is required." >&2
+  exit 1
+}
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+
+for bucket in "$@"; do
+  if [[ ! "$bucket" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]; then
+    echo "Invalid S3 bucket name: $bucket" >&2
+    exit 2
+  fi
+  aws s3api head-bucket --bucket "$bucket" >/dev/null
+  bucket_region=$(aws s3api get-bucket-location \
+    --bucket "$bucket" \
+    --query LocationConstraint \
+    --output text)
+  if [[ "$bucket_region" != "$AWS_REGION" ]]; then
+    echo "S3 bucket is in $bucket_region, expected $AWS_REGION: $bucket" >&2
+    exit 1
+  fi
+  versioning=$(aws s3api get-bucket-versioning --bucket "$bucket" --query Status --output text)
+  if [[ "$versioning" != "Enabled" ]]; then
+    echo "S3 bucket versioning is not enabled: $bucket" >&2
+    exit 1
+  fi
+  public_block=$(aws s3api get-public-access-block --bucket "$bucket")
+  if ! jq -e '
+    .PublicAccessBlockConfiguration |
+    .BlockPublicAcls and .IgnorePublicAcls and .BlockPublicPolicy and .RestrictPublicBuckets
+  ' >/dev/null <<<"$public_block"; then
+    echo "S3 public access is not fully blocked: $bucket" >&2
+    exit 1
+  fi
+  aws s3api get-bucket-encryption --bucket "$bucket" >/dev/null
+  echo "Verified private, versioned, encrypted S3 target: $bucket"
+done

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_approved_host_plan_is_fail_closed_and_within_budget() -> None:
+    plan = json.loads((ROOT / "ops/digitalocean/host-plan.json").read_text())
+
+    assert plan["approval"]["authorization"] == "Approve Build 216"
+    assert plan["host"]["provider"] == "DigitalOcean"
+    assert plan["host"]["region"] == "tor1"
+    assert plan["budget"] == {
+        "currency": "CAD",
+        "monthly_cap": 60.0,
+        "automatic_upgrade_allowed": False,
+    }
+    assert plan["network"]["domain"] == "os.ironhousecivil.com"
+    assert plan["network"]["application_bind"] == "127.0.0.1:8080"
+    assert plan["storage"]["region"] == "ca-central-1"
+    assert plan["storage"]["public_access"] is False
+    assert plan["storage"]["versioning_required"] is True
+    assert plan["storage"]["encryption_required"] is True
+    assert plan["cutover"]["decision"] == "PENDING"
+    assert plan["cutover"]["release_sha"] is None
+
+
+def test_production_compose_does_not_expose_application_port_publicly() -> None:
+    compose = (ROOT / "docker-compose.production.yml").read_text()
+
+    assert '- "127.0.0.1:${IHOS_PORT:-8080}:80"' in compose
+    assert '- "${IHOS_PORT:-8080}:80"' not in compose
+
+
+def test_gateway_configs_hold_maintenance_until_live_gate() -> None:
+    maintenance = (ROOT / "ops/digitalocean/nginx-maintenance.conf").read_text()
+    live = (ROOT / "ops/digitalocean/nginx-live.conf").read_text()
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+
+    assert 'return 503 "Iron House OS maintenance in progress.\\n";' in maintenance
+    assert "proxy_pass http://127.0.0.1:8080;" not in maintenance
+    assert "ssl_certificate /etc/letsencrypt/live/os.ironhousecivil.com/fullchain.pem;" in live
+    assert "proxy_pass http://127.0.0.1:8080;" in live
+    assert "--confirm-go" in cutover
+    assert "--evidence" in cutover
+    assert "verify_release_candidate_evidence.py" in cutover
+    assert "rollback_maintenance" in cutover
+    assert "scripts/verify_s3_targets.sh" in cutover
+    assert "pre-cutover-$stamp" in cutover
+    assert "post-cutover-$stamp" in cutover
+
+
+def test_cloud_init_contains_no_production_credentials() -> None:
+    cloud_init = (ROOT / "ops/digitalocean/cloud-init.yaml").read_text()
+
+    assert "AWS_ACCESS_KEY_ID=" not in cloud_init
+    assert "AWS_SECRET_ACCESS_KEY=" not in cloud_init
+    assert "BOOTSTRAP_ADMIN_PASSWORD=" not in cloud_init
+    assert "ssh_pwauth: false" in cloud_init
+    assert "ufw, --force, enable" in cloud_init

--- a/tests/backend/test_release_candidate_evidence.py
+++ b/tests/backend/test_release_candidate_evidence.py
@@ -25,6 +25,8 @@ def test_release_candidate_evidence_is_bound_to_commit_and_files() -> None:
     assert evidence["generated_at"] == "2026-07-14T12:00:00+00:00"
     assert evidence["operator_acceptance"] == "pending"
     assert len(evidence["files"]["docker-compose.production.yml"]) == 64
+    assert len(evidence["files"]["ops/digitalocean/cutover.sh"]) == 64
+    assert len(evidence["files"]["ops/digitalocean/host-plan.json"]) == 64
     markdown = render_markdown(evidence)
     assert "Operator acceptance: **pending**" in markdown
     assert "backup_restore: **passed**" in markdown

--- a/tests/backend/test_verify_release_candidate_evidence.py
+++ b/tests/backend/test_verify_release_candidate_evidence.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.release_candidate_evidence import build_evidence  # noqa: E402
+from scripts.verify_release_candidate_evidence import verify_evidence  # noqa: E402
+
+
+def _write_evidence(tmp_path: Path, evidence: dict[str, object]) -> Path:
+    import json
+
+    path = tmp_path / "evidence.json"
+    path.write_text(json.dumps(evidence), encoding="utf-8")
+    return path
+
+
+def test_verifier_accepts_bound_release_with_all_required_gates(tmp_path: Path) -> None:
+    release_sha = "a" * 40
+    evidence = build_evidence(
+        ROOT,
+        release_id=release_sha,
+        gates={
+            "ci": "passed",
+            "browser_mobile_accessibility": "passed",
+            "production_stack_smoke": "passed",
+            "backup_restore": "passed",
+        },
+    )
+    evidence["commit_sha"] = release_sha
+    evidence["working_tree_clean"] = True
+
+    verified = verify_evidence(ROOT, _write_evidence(tmp_path, evidence), release_sha)
+
+    assert verified["commit_sha"] == release_sha
+
+
+def test_verifier_rejects_pending_gate(tmp_path: Path) -> None:
+    release_sha = "b" * 40
+    evidence = build_evidence(
+        ROOT,
+        release_id=release_sha,
+        gates={
+            "ci": "passed",
+            "browser_mobile_accessibility": "not_run",
+            "production_stack_smoke": "passed",
+            "backup_restore": "passed",
+        },
+    )
+    evidence["commit_sha"] = release_sha
+    evidence["working_tree_clean"] = True
+
+    with pytest.raises(ValueError, match="browser_mobile_accessibility"):
+        verify_evidence(ROOT, _write_evidence(tmp_path, evidence), release_sha)
+
+
+def test_verifier_rejects_integrity_mismatch(tmp_path: Path) -> None:
+    release_sha = "c" * 40
+    evidence = build_evidence(
+        ROOT,
+        release_id=release_sha,
+        gates={gate: "passed" for gate in (
+            "ci",
+            "browser_mobile_accessibility",
+            "production_stack_smoke",
+            "backup_restore",
+        )},
+    )
+    evidence["commit_sha"] = release_sha
+    evidence["working_tree_clean"] = True
+    evidence["files"]["docker-compose.production.yml"] = "0" * 64
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        verify_evidence(ROOT, _write_evidence(tmp_path, evidence), release_sha)


### PR DESCRIPTION
## Outcome

Implement the approved Build 216 Toronto production cutover package with a CAD 60 monthly ceiling and a fail-closed live gate.

## Included

- loopback-only production application binding
- approved DigitalOcean Toronto host plan and cloud-init bootstrap
- maintenance-first Nginx gateway and Let's Encrypt TLS configuration
- exact-commit, matching-DNS, protected-secret, and explicit-go cutover gate
- private, encrypted, versioned AWS S3 target verification in ca-central-1
- SHA-256 verified off-host recovery bundles
- release evidence bound to all deployment files
- complete CI, frontend, browser/mobile/accessibility, stack smoke, backup, and restore evidence gates
- automatic maintenance rollback if public verification or the post-cutover backup fails
- operator acceptance output only after public HTTPS validation succeeds

## Local validation

- Ruff — clean
- backend — 108 passed
- frontend — 8 files / 15 tests passed
- TypeScript lint — passed
- frontend production build — passed
- shell syntax — passed
- workflow and cloud-init YAML parsing — passed
- local tree exactly matches published tree `c8c795feef73aa076f3f432edd553d5f706d7ba8`

## External boundary

The repository and GitHub checks cannot create or charge the DigitalOcean account, create the AWS buckets, change the existing DNS zone, or register UptimeRobot recipients without authenticated provider access. The cutover remains fail-closed until those approved resources exist and the exact merged-main release artifact is green.

Refs #1.