### PR TITLE
Fix project-aware estimating workspace

### DIFF
--- a/frontend/src/pages/EstimatingPage.test.tsx
+++ b/frontend/src/pages/EstimatingPage.test.tsx
@@ -7,6 +7,14 @@ import { EstimatingPage } from "./EstimatingPage";
 
 const summaryPayloads: Record<string, unknown>[] = [];
 
+const testProject = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "Test Project",
+  project_number: "TEST-001",
+  status: "tendering",
+  updated_at: "2026-07-21T12:00:00Z",
+};
+
 const rateLibrary = {
   production_rates: [
     {
@@ -81,6 +89,10 @@ describe("EstimatingPage", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = String(input);
+        if (url.endsWith("/projects")) return jsonResponse({ items: [testProject], total: 1 });
+        if (url.endsWith(`/estimates/workspace/project/${testProject.id}`)) {
+          return jsonResponse({ items: [], total: 0 });
+        }
         if (url.endsWith("/estimates/rate-library")) return jsonResponse(rateLibrary);
         if (url.endsWith("/estimates/summary")) {
           summaryPayloads.push(JSON.parse(String(init?.body)));
@@ -165,7 +177,7 @@ describe("EstimatingPage", () => {
       }),
     );
     expect(submitted.risks).toEqual([
-      expect.objectContaining({ amount: 500, probability: 1 }),
+      expect.objectContaining({ amount: 0, probability: 1 }),
     ]);
   });
 
@@ -249,6 +261,81 @@ describe("EstimatingPage", () => {
         is_selected: false,
       }),
     ]);
+  });
+
+  it("loads the selected project's latest saved estimate instead of the Marine Drive sample", async () => {
+    const tfnProject = {
+      ...testProject,
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "TFN Path",
+      project_number: "TFN-2026-003",
+    };
+    const savedEstimate = {
+      project_name: "TFN Path",
+      project_code: "TFN-2026-003",
+      line_items: [
+        {
+          code: "32-1216",
+          description: "Hot mix asphalt paving",
+          item_type: "subcontract",
+          quantity: 3235,
+          unit: "m2",
+          default_activity: null,
+          labour: [],
+          equipment: [],
+          materials: [],
+          disposal: [],
+          vendor_quotes: [],
+          direct_unit_cost: 75,
+        },
+      ],
+      indirects: [{ description: "Mobilization", amount: 75000, category: "mobilization" }],
+      risks: [{ description: "Schedule escalation", amount: 100000, probability: 0.5 }],
+      markup: {
+        contingency_percent: 3,
+        overhead_percent: 10,
+        profit_percent: 12.5,
+        bonding_percent: 1.5,
+        insurance_percent: 1,
+      },
+      assumptions: ["Firm pricing through May 2027"],
+      exclusions: ["Unidentified hazardous materials"],
+    };
+
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/projects")) return jsonResponse({ items: [tfnProject], total: 1 });
+      if (url.endsWith(`/estimates/workspace/project/${tfnProject.id}`)) {
+        return jsonResponse({
+          items: [
+            {
+              id: "33333333-3333-4333-8333-333333333333",
+              project_id: tfnProject.id,
+              status: "draft",
+              estimate: { source: "tfn_bid_loader_v1", estimate: savedEstimate, summary: null },
+              created_at: "2026-07-21T12:00:00Z",
+              updated_at: "2026-07-21T12:00:00Z",
+            },
+          ],
+          total: 1,
+        });
+      }
+      if (url.endsWith("/estimates/rate-library")) return jsonResponse(rateLibrary);
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    render(
+      <MemoryRouter initialEntries={[`/estimating?projectId=${tfnProject.id}&projectName=TFN%20Path`]}>
+        <EstimatingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByDisplayValue("TFN Path")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("TFN-2026-003")).toBeInTheDocument();
+    expect(screen.getByLabelText("Line item 1 description")).toHaveValue("Hot mix asphalt paving");
+    expect(screen.getByLabelText("Line item 1 quantity")).toHaveValue(3235);
+    expect(screen.getByLabelText("Profit %")).toHaveValue(12.5);
+    expect(screen.queryByDisplayValue("Marine Drive Parking Lot")).not.toBeInTheDocument();
   });
 
   it("blocks calculation and workbook export until a project name is entered", async () => {

--- a/frontend/src/pages/EstimatingPage.tsx
+++ b/frontend/src/pages/EstimatingPage.tsx
@@ -1,6 +1,6 @@
 import { Calculator, Download, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { FormEvent, useEffect, useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { apiFetch } from "../api/client";
 
@@ -16,16 +16,18 @@ import {
   VendorQuoteInput,
   estimatesApi,
 } from "../api/estimates";
+import { EstimateWorkspaceRead, estimateWorkspaceApi } from "../api/estimateWorkspace";
+import { Project, projectsApi } from "../api/projects";
 import { ProjectScopeNotice } from "../components/ProjectScopeNotice";
-import { readProjectContext } from "../utils/projectContext";
+import { buildProjectContextParams, readProjectContext } from "../utils/projectContext";
 
-const defaultLineItem: EstimateLineItem = {
-  code: "31-001",
-  description: "Excavation",
+const blankLineItem: EstimateLineItem = {
+  code: "",
+  description: "",
   item_type: "self_perform",
-  quantity: 100,
-  unit: "m3",
-  default_activity: "excavation",
+  quantity: 0,
+  unit: "LS",
+  default_activity: null,
   labour: [],
   equipment: [],
   materials: [],
@@ -61,26 +63,32 @@ type EstimatingLocationState = {
 
 export function EstimatingPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const projectContext = readProjectContext(location.search);
   const locationState = location.state as EstimatingLocationState | null;
-  const importedQuoteLineItems = locationState?.quoteLineItems ?? [];
-  const [projectName, setProjectName] = useState(projectContext.projectName ?? "Marine Drive Parking Lot");
-  const [projectCode, setProjectCode] = useState(projectContext.projectId ?? "WR26-012");
+  const importedQuoteLineItems = useMemo(() => locationState?.quoteLineItems ?? [], [locationState?.quoteLineItems]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState(projectContext.projectId ?? "");
+  const [projectName, setProjectName] = useState(projectContext.projectName ?? "");
+  const [projectCode, setProjectCode] = useState("");
   const [lineItems, setLineItems] = useState<EstimateLineItem[]>(
-    () => importedQuoteLineItems.length ? importedQuoteLineItems : [defaultLineItem],
+    () => importedQuoteLineItems.length ? importedQuoteLineItems : [{ ...blankLineItem }],
   );
   const [contingency, setContingency] = useState(10);
   const [overhead, setOverhead] = useState(5);
   const [profit, setProfit] = useState(10);
   const [bonding, setBonding] = useState(0);
   const [insurance, setInsurance] = useState(0);
-  const [mobilization, setMobilization] = useState(1000);
+  const [mobilization, setMobilization] = useState(0);
   const [disposal, setDisposal] = useState(0);
-  const [riskAmount, setRiskAmount] = useState(500);
+  const [riskAmount, setRiskAmount] = useState(0);
   const [riskProbability, setRiskProbability] = useState(100);
+  const [assumptions, setAssumptions] = useState(["Normal working hours", "No contaminated soils unless noted"]);
+  const [exclusions, setExclusions] = useState(["Permits, bonds, and design fees unless listed"]);
   const [rateLibrary, setRateLibrary] = useState<ProductionRate[]>([]);
   const [summary, setSummary] = useState<EstimateSummary | null>(null);
   const [isLoadingRates, setIsLoadingRates] = useState(true);
+  const [isLoadingProject, setIsLoadingProject] = useState(true);
   const [isCalculating, setIsCalculating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -107,10 +115,10 @@ export function EstimatingPage() {
         bonding_percent: bonding,
         insurance_percent: insurance,
       },
-      assumptions: ["Normal working hours", "No contaminated soils unless noted"],
-      exclusions: ["Permits, bonds, and design fees unless listed"],
+      assumptions,
+      exclusions,
     }),
-    [bonding, contingency, disposal, insurance, lineItems, mobilization, overhead, profit, projectCode, projectName, riskAmount, riskProbability],
+    [assumptions, bonding, contingency, disposal, exclusions, insurance, lineItems, mobilization, overhead, profit, projectCode, projectName, riskAmount, riskProbability],
   );
 
   useEffect(() => {
@@ -128,6 +136,112 @@ export function EstimatingPage() {
     }
     void loadRates();
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadProject() {
+      setIsLoadingProject(true);
+      setError(null);
+      try {
+        const result = await projectsApi.list();
+        if (cancelled) return;
+
+        const ordered = [...result.items].sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+        const active = ordered.filter((project) => project.status !== "archived");
+        setProjects(active);
+
+        const requested = projectContext.projectId
+          ? ordered.find((project) => project.id === projectContext.projectId)
+          : null;
+        const selected = requested ?? active[0] ?? null;
+
+        if (!selected) {
+          resetEstimate();
+          return;
+        }
+
+        setSelectedProjectId(selected.id);
+        setProjectName(selected.name);
+        setProjectCode(selected.project_number ?? selected.tender_number ?? "");
+
+        if (importedQuoteLineItems.length) {
+          setLineItems(importedQuoteLineItems);
+          setSummary(null);
+          return;
+        }
+
+        const workspaces = await estimateWorkspaceApi.listForProject(selected.id);
+        if (cancelled) return;
+        const latest = workspaces.items[0];
+        if (latest) {
+          hydrateEstimate(latest, selected);
+        } else {
+          resetEstimate(selected);
+        }
+      } catch (currentError) {
+        if (!cancelled) {
+          setError(currentError instanceof Error ? currentError.message : "Unable to load the selected project estimate");
+        }
+      } finally {
+        if (!cancelled) setIsLoadingProject(false);
+      }
+    }
+
+    function resetEstimate(project?: Project) {
+      setSelectedProjectId(project?.id ?? "");
+      setProjectName(project?.name ?? "");
+      setProjectCode(project?.project_number ?? project?.tender_number ?? "");
+      setLineItems(importedQuoteLineItems.length ? importedQuoteLineItems : [{ ...blankLineItem }]);
+      setContingency(10);
+      setOverhead(5);
+      setProfit(10);
+      setBonding(0);
+      setInsurance(0);
+      setMobilization(0);
+      setDisposal(0);
+      setRiskAmount(0);
+      setRiskProbability(100);
+      setAssumptions(["Normal working hours", "No contaminated soils unless noted"]);
+      setExclusions(["Permits, bonds, and design fees unless listed"]);
+      setSummary(null);
+    }
+
+    function hydrateEstimate(workspace: EstimateWorkspaceRead, project: Project) {
+      const estimate = readSavedEstimate(workspace);
+      if (!estimate) {
+        resetEstimate(project);
+        return;
+      }
+
+      setProjectName(estimate.project_name || project.name);
+      setProjectCode(estimate.project_code ?? project.project_number ?? project.tender_number ?? "");
+      setLineItems(estimate.line_items.length ? estimate.line_items : [{ ...blankLineItem }]);
+      setContingency(estimate.markup.contingency_percent);
+      setOverhead(estimate.markup.overhead_percent);
+      setProfit(estimate.markup.profit_percent);
+      setBonding(estimate.markup.bonding_percent);
+      setInsurance(estimate.markup.insurance_percent);
+      setMobilization(indirectAmount(estimate, "mobilization"));
+      setDisposal(indirectAmount(estimate, "disposal"));
+      setRiskAmount(estimate.risks[0]?.amount ?? 0);
+      setRiskProbability((estimate.risks[0]?.probability ?? 1) * 100);
+      setAssumptions(estimate.assumptions);
+      setExclusions(estimate.exclusions);
+      setSummary(readSavedSummary(workspace));
+    }
+
+    void loadProject();
+    return () => {
+      cancelled = true;
+    };
+  }, [importedQuoteLineItems, location.search]);
+
+  function selectProject(projectId: string) {
+    const project = projects.find((candidate) => candidate.id === projectId);
+    if (!project) return;
+    navigate(`/estimating?${buildProjectContextParams(project)}`, { replace: true });
+  }
 
   function hasValidProjectName() {
     if (projectName.trim()) return true;
@@ -166,7 +280,7 @@ export function EstimatingPage() {
     setLineItems((items) => [
       ...items,
       {
-        ...defaultLineItem,
+        ...blankLineItem,
         code: `31-${String(items.length + 1).padStart(3, "0")}`,
         description: "New estimate item",
         quantity: 1,
@@ -212,16 +326,35 @@ export function EstimatingPage() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <button type="button" onClick={() => void calculateEstimate()} className="inline-flex items-center gap-2 rounded-md bg-iron-950 px-3 py-2 text-sm font-medium text-white">
+          <button type="button" disabled={isLoadingProject} onClick={() => void calculateEstimate()} className="inline-flex items-center gap-2 rounded-md bg-iron-950 px-3 py-2 text-sm font-medium text-white disabled:bg-iron-300">
             <Calculator className="h-4 w-4" /> Calculate
           </button>
-          <button type="button" onClick={() => void downloadWorkbook()} className="inline-flex items-center gap-2 rounded-md border border-iron-100 bg-white px-3 py-2 text-sm font-medium text-iron-800">
+          <button type="button" disabled={isLoadingProject} onClick={() => void downloadWorkbook()} className="inline-flex items-center gap-2 rounded-md border border-iron-100 bg-white px-3 py-2 text-sm font-medium text-iron-800 disabled:text-iron-300">
             <Download className="h-4 w-4" /> Workbook
           </button>
         </div>
       </div>
 
-      <ProjectScopeNotice name={projectContext.projectName} />
+      <ProjectScopeNotice name={projectName || null} />
+      <div className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+        <label className="block space-y-1 text-sm font-medium text-iron-700">
+          Active project
+          <select
+            aria-label="Active project"
+            value={selectedProjectId}
+            onChange={(event) => selectProject(event.target.value)}
+            disabled={isLoadingProject}
+            className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+          >
+            <option value="">{isLoadingProject ? "Loading projects..." : "Select a project"}</option>
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.name}{project.project_number ? ` — ${project.project_number}` : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       {importedQuoteLineItems.length ? (
         <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800">
           Loaded {importedQuoteLineItems.length} estimate line item{importedQuoteLineItems.length === 1 ? "" : "s"} from qualified supplier selections.
@@ -474,4 +607,27 @@ function NumberField({ label, value, onChange }: { label: string; value: number;
 
 function SummaryRow({ label, value, strong = false }: { label: string; value: number; strong?: boolean }) {
   return <div className={`flex justify-between ${strong ? "text-base font-semibold text-iron-950" : "text-iron-700"}`}><dt>{label}</dt><dd>{moneyFormatter.format(value)}</dd></div>;
+}
+
+function readSavedEstimate(workspace: EstimateWorkspaceRead): EstimateCreate | null {
+  const wrapped = workspace.estimate.estimate;
+  const candidate = isRecord(wrapped) ? wrapped : workspace.estimate;
+  if (!Array.isArray(candidate.line_items) || !isRecord(candidate.markup)) return null;
+  return candidate as unknown as EstimateCreate;
+}
+
+function readSavedSummary(workspace: EstimateWorkspaceRead): EstimateSummary | null {
+  const candidate = workspace.estimate.summary;
+  if (!isRecord(candidate) || typeof candidate.final_price !== "number" || !Array.isArray(candidate.line_items)) return null;
+  return candidate as unknown as EstimateSummary;
+}
+
+function indirectAmount(estimate: EstimateCreate, category: string): number {
+  return estimate.indirects
+    .filter((item) => item.category === category)
+    .reduce((total, item) => total + item.amount, 0);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -82,6 +82,20 @@ describe("ProjectWorkspacePage", () => {
     expect(within(detailPanel as HTMLElement).getAllByText("80%").length).toBeGreaterThan(0);
     expect(screen.getByText("Draft")).toBeInTheDocument();
   });
+
+  it("keeps project context on estimating links", async () => {
+    mockProjectApi();
+
+    renderWorkspace(`/projects/${project.id}`);
+
+    await screen.findByRole("heading", { name: project.name });
+    const estimatingLinks = screen.getAllByRole("link").filter((link) => link.getAttribute("href")?.startsWith("/estimating?"));
+    expect(estimatingLinks.length).toBeGreaterThan(0);
+    for (const link of estimatingLinks) {
+      expect(link).toHaveAttribute("href", expect.stringContaining(`projectId=${project.id}`));
+      expect(link).toHaveAttribute("href", expect.stringContaining("projectName=King+George+Utility+Upgrade"));
+    }
+  });
 });
 
 function renderWorkspace(path: string) {

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -10,6 +10,7 @@ import {
   projectStatuses,
   projectsApi,
 } from "../api/projects";
+import { withProjectContext } from "../utils/projectContext";
 
 const tabs = [
   "Overview",
@@ -382,14 +383,14 @@ function CommandCenter({ project, dashboard }: { project: Project; dashboard: Pr
         <div className="text-sm font-semibold text-iron-950">Readiness {dashboard.readiness_percentage}%</div>
       </div>
       <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-        <ActionCard icon={<FileStack className="h-4 w-4" />} label="RFQs" description="Create packages and draft supplier requests." href="/rfq-builder" />
-        <ActionCard icon={<BookOpen className="h-4 w-4" />} label="Documents" description="Register drawings, specs, addenda, and RFQ files." href="/documents" />
-        <ActionCard icon={<Users className="h-4 w-4" />} label="Suppliers" description="Find or add suppliers for the project scope." href="/suppliers" />
-        <ActionCard icon={<Table2 className="h-4 w-4" />} label="Quotes" description="Compare supplier pricing and selection reasons." href="/quotes" />
-        <ActionCard icon={<Calculator className="h-4 w-4" />} label="Estimate" description="Build price, markups, risk, and workbook export." href="/estimating" />
-        <ActionCard icon={<ShieldCheck className="h-4 w-4" />} label="Municipality" description="Track standards, permits, inspections, and risks." href="/documents" />
-        <ActionCard icon={<CalendarDays className="h-4 w-4" />} label="Schedule" description="Track bid due date, quote deadlines, and work windows." href="/projects" />
-        <ActionCard icon={<FolderKanban className="h-4 w-4" />} label="Bid Package" description="Assemble final scope, estimate, assumptions, and exclusions." href="/estimating" />
+        <ActionCard icon={<FileStack className="h-4 w-4" />} label="RFQs" description="Create packages and draft supplier requests." href={withProjectContext("/rfq-builder", project)} />
+        <ActionCard icon={<BookOpen className="h-4 w-4" />} label="Documents" description="Register drawings, specs, addenda, and RFQ files." href={withProjectContext("/documents", project)} />
+        <ActionCard icon={<Users className="h-4 w-4" />} label="Suppliers" description="Find or add suppliers for the project scope." href={withProjectContext("/suppliers", project)} />
+        <ActionCard icon={<Table2 className="h-4 w-4" />} label="Quotes" description="Compare supplier pricing and selection reasons." href={withProjectContext("/quotes", project)} />
+        <ActionCard icon={<Calculator className="h-4 w-4" />} label="Estimate" description="Build price, markups, risk, and workbook export." href={withProjectContext("/estimating", project)} />
+        <ActionCard icon={<ShieldCheck className="h-4 w-4" />} label="Municipality" description="Track standards, permits, inspections, and risks." href={withProjectContext("/documents", project)} />
+        <ActionCard icon={<CalendarDays className="h-4 w-4" />} label="Schedule" description="Track bid due date, quote deadlines, and work windows." href={withProjectContext("/projects", project)} />
+        <ActionCard icon={<FolderKanban className="h-4 w-4" />} label="Bid Package" description="Assemble final scope, estimate, assumptions, and exclusions." href={withProjectContext("/estimating", project)} />
       </div>
     </div>
   );
@@ -483,7 +484,7 @@ function TabBody({ tab, project, dashboard }: { tab: string; project: Project; d
       {content.actions.length ? (
         <div className="flex flex-wrap gap-2">
           {content.actions.map((action) => (
-            <Link key={action.label} to={action.href} className="rounded-md border border-iron-100 px-3 py-2 text-sm font-semibold text-iron-800">
+            <Link key={action.label} to={withProjectContext(action.href, project)} className="rounded-md border border-iron-100 px-3 py-2 text-sm font-semibold text-iron-800">
               {action.label}
             </Link>
           ))}


### PR DESCRIPTION
## What changed

- remove the hard-coded Marine Drive fallback from Estimating
- load the selected project's saved estimate and 12.5% settings
- preserve project context from the project workspace
- add an active-project selector for direct Estimating navigation

## Why

The production Estimating page always populated the Marine Drive sample, even when TFN or another project was selected.

## Validation

- TypeScript validation passed
- 17 frontend tests passed
- production frontend bundle built successfully
- regression coverage verifies a TFN-style saved estimate opens in the correct project context