### PR TITLE
Lock Iron House OS visual design

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# The current OS appearance is an owner-approved production baseline.
+/frontend/tailwind.config.ts @iron-house-os
+/frontend/src/styles.css @iron-house-os
+/frontend/src/components/AppLayout.tsx @iron-house-os
+/frontend/src/pages/LoginPage.tsx @iron-house-os
+/frontend/src/pages/DashboardPage.tsx @iron-house-os
+/frontend/public/ @iron-house-os
+/frontend/visual-design-lock.json @iron-house-os
+/scripts/check_visual_design_lock.py @iron-house-os
+/docs/visual-design-lock.md @iron-house-os
+/.github/CODEOWNERS @iron-house-os
+/.github/pull_request_template.md @iron-house-os

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What changed
+
+Describe the operational change and its user impact.
+
+## Validation
+
+List the checks used to validate the change.
+
+## Visual design lock
+
+- [ ] This change preserves the approved Iron House OS production appearance.
+- [ ] If a protected visual file changed, Jeremie Peters explicitly approved the appearance change and the visual-design manifest was intentionally updated.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - name: Verify OS visual design lock
+        run: python ../scripts/check_visual_design_lock.py
       - name: Install frontend dependencies
         run: npm ci
       - name: Lint frontend

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -60,6 +60,8 @@ jobs:
           node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - name: Verify OS visual design lock
+        run: python ../scripts/check_visual_design_lock.py
       - name: Install frontend dependencies
         run: npm ci
       - name: Lint frontend

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The smoke test expects `BOOTSTRAP_ADMIN_EMAIL` and `BOOTSTRAP_ADMIN_PASSWORD`. I
 
 See [the release runbook](docs/deployment.md) before exposing IHOS outside a trusted network. A public deployment must terminate HTTPS upstream, schedule off-host recovery bundles, and regularly confirm the automated restore drill remains green.
 
+The production appearance is protected by the [Iron House OS visual design lock](docs/visual-design-lock.md). New features must follow the existing gold, silver, black, and charcoal visual system; significant restyling requires explicit owner approval.
+
 The approved Build 216 DigitalOcean configuration and operator procedure are documented in [Build 216](docs/builds/BUILD_216.md). The live script requires the exact merged commit, the matching GitHub release-evidence artifact, protected provider credentials, matching DNS, and an explicit go flag.
 
 ## Core Application Areas

--- a/docs/visual-design-lock.md
+++ b/docs/visual-design-lock.md
@@ -1,0 +1,33 @@
+# Iron House OS visual design lock
+
+## Decision
+
+The production appearance released in commit `3c6cbe89c205f6db164b05df59e4df9aa865101b` on 2026-07-22 is the approved Iron House OS visual baseline.
+
+The OS may continue to gain workflows, data, controls, and responsive refinements, but it must not receive a significant visual redesign without explicit written approval from Jeremie Peters.
+
+## Protected visual system
+
+- Brand colours: CAT-inspired gold `#DDAE58`, charcoal `#34373A`, black `#0B0D11`, silver `#D9DCE0`, and the existing iron neutral scale.
+- Identity: the current Iron House logo, application icons, and the gold/silver/black presentation.
+- Application shell: fixed dark sidebar on desktop, drawer navigation on mobile, white sticky header, light workspace, and the existing content width and spacing.
+- Typography: Inter with the existing system-font fallback, current weights, compact uppercase brand labels, and current heading hierarchy.
+- Surfaces: white operational cards, restrained borders and shadows, medium corner radii, and dark branded hero panels using the existing gold glow and steel-grid treatment.
+- Interaction: gold active-navigation and primary-action states, current signal colours, and the established desktop/mobile behaviour.
+
+## Changes that remain allowed
+
+- New modules and workflow screens that use the protected visual system.
+- Content, data, forms, tables, validation, and operational controls.
+- Accessibility, responsive, performance, and browser-compatibility fixes that preserve the overall appearance.
+- Small spacing or legibility corrections that do not change the OS's visual identity or layout model.
+
+## Changes requiring owner approval
+
+Explicit written approval is required before changing the logo, application icons, core palette, typography family, sidebar/header structure, global density, primary corner-radius or shadow language, branded hero treatment, navigation behaviour, or introducing a new theme or broad restyle.
+
+## Enforcement
+
+`frontend/visual-design-lock.json` records SHA-256 hashes for the protected source and identity assets. Both CI and release readiness run `scripts/check_visual_design_lock.py`. A protected file change fails the build until the manifest is deliberately updated in the same approved pull request.
+
+`CODEOWNERS` requests Iron House owner review for protected files, the manifest, the checker, and this policy. Updating the manifest is an acknowledgement that the visual baseline is changing; it is not routine maintenance.

--- a/frontend/visual-design-lock.json
+++ b/frontend/visual-design-lock.json
@@ -1,0 +1,22 @@
+{
+  "approved_by": "Jeremie Peters",
+  "baseline_commit": "3c6cbe89c205f6db164b05df59e4df9aa865101b",
+  "baseline_date": "2026-07-22",
+  "files": {
+    "frontend/public/apple-touch-icon.png": "61238cf4edb72a94ae0bdb0c762db8aaf5bf0e022fc521db8edea033080951de",
+    "frontend/public/favicon-32x32.png": "c7c83909f9026f4910f05406fe7d9404904b3dedb81f09aa836b4a909e938423",
+    "frontend/public/favicon.ico": "d775bd589ed230333aeeb0acc829b643ce51b1eb9c07f9c54d01cb4a163f32aa",
+    "frontend/public/icon-192.png": "43c6aee8efb6463bcaf95e240511c583d4438ba0ed85b77b89e69479cbeec877",
+    "frontend/public/icon-512-maskable.png": "373b0ad14eb30677cab2fc0bd18fcb81b9a190b01c8bdbd8d79684c10c4ebf58",
+    "frontend/public/icon-512.png": "410c16b7f12ce56ff98c4bce34dbe234c53bde79726c1498abceac68ac06fc82",
+    "frontend/public/os-logo-256.png": "ee3d1cc318206fcce1e038fc97631f1bf09f56d7162c47ea8bbb7917cf8a74e3",
+    "frontend/public/site.webmanifest": "1de7d6a57ba4976412f4f3923862c9d7e8037a10b0d3bba9a636395ef06bdce3",
+    "frontend/src/components/AppLayout.tsx": "45a72b9de0847dfbb7c56027ddce3037bd6724904866b49caf654b8a3229dde6",
+    "frontend/src/pages/DashboardPage.tsx": "c8fb703a5c2014231c7934205d18cce247a15a805b73624fa21463225dd5649a",
+    "frontend/src/pages/LoginPage.tsx": "8cc96693579ea7e18e3fa34b456f259ad47b8479230df8c04bf7de50e3b510fe",
+    "frontend/src/styles.css": "d0ed7ee59b1690db07d4d70193cfbf1f3f80d6a5084edfedad786817de4ce58d",
+    "frontend/tailwind.config.ts": "3c9eae349df550797ad4590c8cfc905e031639f3eadf883844d4386d037be7e2"
+  },
+  "policy": "docs/visual-design-lock.md",
+  "schema_version": 1
+}

--- a/scripts/check_visual_design_lock.py
+++ b/scripts/check_visual_design_lock.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Fail CI when the approved Iron House visual baseline changes unexpectedly."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "frontend" / "visual-design-lock.json"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    try:
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        protected_files = manifest["files"]
+    except (OSError, json.JSONDecodeError, KeyError) as exc:
+        print(f"visual design lock is invalid: {exc}", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for relative_path, expected_hash in sorted(protected_files.items()):
+        path = ROOT / relative_path
+        if not path.is_file():
+            failures.append(f"missing protected file: {relative_path}")
+            continue
+        actual_hash = sha256(path)
+        if actual_hash != expected_hash:
+            failures.append(
+                f"protected appearance changed: {relative_path}\n"
+                f"  approved: {expected_hash}\n"
+                f"  current:  {actual_hash}"
+            )
+
+    if failures:
+        print("Iron House OS visual design lock failed.", file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
+        print(
+            "Significant appearance changes require Jeremie Peters' explicit written approval "
+            "and an intentional manifest update. See docs/visual-design-lock.md.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "Iron House OS visual design lock passed "
+        f"({len(protected_files)} protected files, baseline {manifest['baseline_commit'][:8]})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- Declared production release `3c6cbe89` as the approved Iron House OS visual baseline.
- Added a SHA-256 manifest for the palette, global styling, application shell, login/dashboard surfaces, logo, and application icons.
- Added CI and release-readiness enforcement that rejects unexpected protected-file changes.
- Added CODEOWNERS and pull-request review controls for any explicitly approved exception.

## Why

The current gold, silver, black, and charcoal OS appearance is approved and should remain stable while operational capabilities continue to grow.

## User impact

No visible production change. Future features must use the current design system; significant restyling requires Jeremie Peters' explicit written approval.

## Validation

- `python3 scripts/check_visual_design_lock.py` passed for all 13 protected files.
- `python3 -m py_compile scripts/check_visual_design_lock.py` passed.
- `git diff --check` passed.

## Visual design lock

- [x] This change preserves the approved Iron House OS production appearance.
- [x] The baseline and enforcement were explicitly requested by Jeremie Peters.