### PR TITLE
Separate civil utility cost codes

### DIFF
--- a/backend/app/schemas/cost_code.py
+++ b/backend/app/schemas/cost_code.py
@@ -9,6 +9,7 @@ class CostCodeGroup(StrEnum):
     general = "general"
     earthworks = "earthworks"
     utilities = "utilities"
+    shallows = "shallows"
     structures = "structures"
     concrete = "concrete"
     asphalt = "asphalt"
@@ -50,3 +51,4 @@ class CostCodeResolveResponse(BaseModel):
     match: CostCode | None
     confidence: float = Field(ge=0, le=1)
     alternatives: list[CostCode] = Field(default_factory=list)
+

--- a/backend/app/services/cost_codes.py
+++ b/backend/app/services/cost_codes.py
@@ -10,7 +10,7 @@ from app.schemas.cost_code import (
 from app.schemas.estimate import EstimateItemType, EstimateUnit
 
 
-LIBRARY_VERSION = "2026.07"
+LIBRARY_VERSION = "2026.08"
 
 COST_CODES: tuple[CostCode, ...] = (
     CostCode(code="01-100", name="Mobilization", group=CostCodeGroup.general, default_item_type=EstimateItemType.indirect, default_unit=EstimateUnit.lump_sum, tags=["mobilization", "startup", "demobilization"]),
@@ -19,10 +19,15 @@ COST_CODES: tuple[CostCode, ...] = (
     CostCode(code="02-200", name="Common excavation", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.cubic_metre, tags=["excavation", "dig", "soil"]),
     CostCode(code="02-300", name="Trench backfill and compaction", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.cubic_metre, tags=["backfill", "compaction", "trench"]),
     CostCode(code="02-400", name="Granular base and subbase", group=CostCodeGroup.earthworks, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.tonne, tags=["aggregate", "road base", "subbase", "granular"]),
-    CostCode(code="03-100", name="PVC sewer and drain pipe", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.metre, tags=["pvc", "storm", "sanitary", "pipe"]),
-    CostCode(code="03-200", name="Watermain pipe", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.metre, tags=["watermain", "ductile iron", "pvc", "pipe"]),
+    CostCode(code="03-100", name="Storm main installation", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["storm", "storm main", "storm sewer", "drainage main", "pvc", "pipe"]),
+    CostCode(code="03-110", name="Storm service installation", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["storm", "storm service", "service connection", "lateral", "pvc", "pipe"]),
+    CostCode(code="03-200", name="Water main installation", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["watermain", "water main", "ductile iron", "pvc", "pipe"]),
+    CostCode(code="03-210", name="Water service installation", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["water service", "service connection", "curb stop", "meter", "pipe"]),
     CostCode(code="03-300", name="Manholes", group=CostCodeGroup.structures, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.each, tags=["manhole", "precast", "structure"]),
     CostCode(code="03-400", name="Catch basins", group=CostCodeGroup.structures, default_item_type=EstimateItemType.material, default_unit=EstimateUnit.each, tags=["catch basin", "cb", "drainage"]),
+    CostCode(code="03-500", name="Sanitary main installation", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["sanitary", "sanitary main", "sanitary sewer", "sewer main", "pvc", "pipe"]),
+    CostCode(code="03-510", name="Sanitary service installation", group=CostCodeGroup.utilities, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["sanitary", "sanitary service", "sewer service", "service connection", "lateral", "pvc", "pipe"]),
+    CostCode(code="03-520", name="Sanitary manholes", group=CostCodeGroup.structures, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.each, tags=["sanitary manhole", "sewer manhole", "precast", "structure"]),
     CostCode(code="04-100", name="Concrete curb", group=CostCodeGroup.concrete, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.metre, tags=["curb", "concrete"]),
     CostCode(code="04-200", name="Concrete sidewalk", group=CostCodeGroup.concrete, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.square_metre, tags=["sidewalk", "concrete", "flatwork"]),
     CostCode(code="05-100", name="Asphalt paving", group=CostCodeGroup.asphalt, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.tonne, tags=["asphalt", "paving", "blacktop"]),
@@ -33,6 +38,8 @@ COST_CODES: tuple[CostCode, ...] = (
     CostCode(code="08-100", name="Material and compaction testing", group=CostCodeGroup.testing, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.lump_sum, tags=["testing", "density", "compaction", "concrete"]),
     CostCode(code="09-100", name="Coring", group=CostCodeGroup.closeout, default_item_type=EstimateItemType.subcontract, default_unit=EstimateUnit.each, tags=["coring", "core drilling"]),
     CostCode(code="09-200", name="Cleanup and closeout", group=CostCodeGroup.closeout, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.lump_sum, tags=["cleanup", "closeout", "deficiency"]),
+    CostCode(code="10-100", name="Shallows - Hydro and communications installation", group=CostCodeGroup.shallows, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["shallows", "hydro", "power", "electrical", "communications", "communication", "telecom", "fibre", "fiber", "duct", "conduit"]),
+    CostCode(code="10-200", name="Shallows - Streetlight installation", group=CostCodeGroup.shallows, default_item_type=EstimateItemType.self_perform, default_unit=EstimateUnit.metre, tags=["shallows", "streetlight", "street light", "lighting", "duct", "conduit"]),
 )
 
 
@@ -70,3 +77,4 @@ def resolve_cost_code(payload: CostCodeResolveRequest) -> CostCodeResolveRespons
         confidence=round(best_score, 2),
         alternatives=[item for _, item in scored[1:4]],
     )
+

--- a/backend/tests/test_cost_codes.py
+++ b/backend/tests/test_cost_codes.py
@@ -9,12 +9,48 @@ def test_cost_code_library_contains_core_civil_scopes() -> None:
     library = get_cost_code_library()
     by_code = {item.code: item for item in library.items}
 
-    assert library.version == "2026.07"
+    assert library.version == "2026.08"
     assert by_code["02-200"].name == "Common excavation"
     assert by_code["03-100"].default_unit == EstimateUnit.metre
     assert by_code["05-100"].default_item_type == EstimateItemType.subcontract
     assert by_code["06-100"].group == CostCodeGroup.traffic
     assert len(library.items) == len(by_code)
+
+
+def test_cost_code_library_separates_storm_sanitary_and_shallows() -> None:
+    library = get_cost_code_library()
+    by_code = {item.code: item for item in library.items}
+
+    assert by_code["03-100"].name == "Storm main installation"
+    assert by_code["03-110"].name == "Storm service installation"
+    assert by_code["03-500"].name == "Sanitary main installation"
+    assert by_code["03-510"].name == "Sanitary service installation"
+    assert by_code["03-200"].name == "Water main installation"
+    assert by_code["03-210"].name == "Water service installation"
+    assert by_code["10-100"].name == "Shallows - Hydro and communications installation"
+    assert by_code["10-100"].group == CostCodeGroup.shallows
+    assert by_code["10-200"].name == "Shallows - Streetlight installation"
+    assert by_code["10-200"].group == CostCodeGroup.shallows
+    assert "10-300" not in by_code
+
+
+def test_cost_code_resolver_distinguishes_utility_mains_and_services() -> None:
+    cases = {
+        "install storm main": "03-100",
+        "install storm service": "03-110",
+        "install sanitary main": "03-500",
+        "install sanitary service": "03-510",
+        "install water main": "03-200",
+        "install water service": "03-210",
+        "install hydro conduit": "10-100",
+        "install communications duct": "10-100",
+        "install streetlight conduit": "10-200",
+    }
+
+    for description, expected_code in cases.items():
+        result = resolve_cost_code(CostCodeResolveRequest(description=description))
+        assert result.match is not None
+        assert result.match.code == expected_code
 
 
 def test_cost_code_resolver_matches_exact_code() -> None:


### PR DESCRIPTION
## What changed

- separates storm, sanitary, and water into distinct main and service cost codes
- adds a Shallows group with combined hydro/communications and separate streetlight installation
- updates cost-code resolution tags so descriptions map to the correct field code
- preserves existing watermain, manhole, and catch-basin code meanings

## Impact

The new codes flow through estimating, time entry, production records, and field-portal selectors from the shared cost-code library.

## Validation

- 117 backend tests passed
- focused cost-code, quote-estimate, estimate-validation, and field-operations suite passed
- git diff whitespace check passed