### PR TITLE
Build 221: connect job workbook production tracking

### DIFF
--- a/automation/build-queue.json
+++ b/automation/build-queue.json
@@ -20,7 +20,7 @@
     {
       "id": "build-221-job-workbook-production",
       "priority": 221,
-      "status": "open",
+      "status": "done",
       "title": "Connect job workbook and production tracking",
       "summary": "Expose project materials, estimate quantities, installed-to-date quantities and remaining production inside the Foreman Portal.",
       "acceptance_criteria": ["Foreman selects a job workbook", "Estimated and installed quantities are compared", "Entries link to cost codes and project", "Tests pass"]

--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -216,6 +216,8 @@ class FieldOperationsBootstrap(BaseModel):
     suppliers: list[dict]
     equipment: list[dict]
     cost_codes: list[dict]
+    job_workbooks: list[dict]
+    production_items: list[dict]
     vehicles: list[VehicleRead]
     vehicle_logs: list[VehicleLogRead]
     time_entries: list[TimeEntryRead]

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.core.errors import AppError
 from app.models.equipment import Equipment
+from app.models.bid import Bid
 from app.models.field_operations import EmployeeCertification, FieldRecord, TimeEntry, Vehicle, VehicleLog
 from app.models.project import Project
 from app.models.supplier import Supplier
@@ -46,6 +47,7 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
     time_entries = list(db.scalars(select(TimeEntry).order_by(TimeEntry.work_date.desc()).limit(200)))
     records = list(db.scalars(select(FieldRecord).order_by(FieldRecord.work_date.desc(), FieldRecord.created_at.desc()).limit(200)))
     certifications = list(db.scalars(select(EmployeeCertification).order_by(EmployeeCertification.expiry_date)))
+    workbooks, production_items = build_job_workbooks(db)
     alerts = build_alerts(vehicles, records, certifications)
     return FieldOperationsBootstrap(
         employees=[EmployeeRead.model_validate(item) for item in employees],
@@ -53,6 +55,8 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
         suppliers=[{"id": str(item.id), "name": item.name, "category": item.category} for item in suppliers],
         equipment=[{"id": str(item.id), "name": item.name, "identifier": item.identifier, "status": item.status} for item in equipment],
         cost_codes=[item.model_dump(mode="json") for item in get_cost_code_library().items],
+        job_workbooks=workbooks,
+        production_items=production_items,
         vehicles=[vehicle_schema(item) for item in vehicles],
         vehicle_logs=[VehicleLogRead.model_validate(item) for item in vehicle_logs],
         time_entries=[TimeEntryRead.model_validate(item) for item in time_entries],
@@ -61,6 +65,58 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
         alerts=alerts,
         toolbox_talk=current_toolbox_talk(),
     )
+
+
+def build_job_workbooks(db: Session) -> tuple[list[dict], list[dict]]:
+    bids = list(db.scalars(select(Bid).order_by(Bid.project_id, Bid.created_at.desc())))
+    latest: dict[UUID, Bid] = {}
+    for bid in bids:
+        if bid.project_id not in latest and (bid.bid_json or {}).get("source") == "estimate_workspace":
+            latest[bid.project_id] = bid
+
+    production_records = db.scalars(
+        select(FieldRecord).where(FieldRecord.record_type == "material_quantity")
+    )
+    installed: dict[str, float] = {}
+    for record in production_records:
+        line_key = str((record.details or {}).get("line_key") or "")
+        try:
+            quantity = float((record.details or {}).get("installed_quantity") or 0)
+        except (TypeError, ValueError):
+            quantity = 0
+        if line_key:
+            installed[line_key] = installed.get(line_key, 0) + quantity
+
+    workbooks: list[dict] = []
+    production_items: list[dict] = []
+    for project_id, bid in latest.items():
+        estimate = (bid.bid_json or {}).get("estimate") or {}
+        lines = estimate.get("line_items") or []
+        workbooks.append({
+            "id": str(bid.id),
+            "project_id": str(project_id),
+            "status": bid.status,
+            "created_at": bid.created_at.isoformat(),
+            "line_count": len(lines),
+        })
+        for index, line in enumerate(lines):
+            line_key = f"{bid.id}:{index}"
+            estimated = float(line.get("quantity") or 0)
+            installed_quantity = installed.get(line_key, 0)
+            production_items.append({
+                "line_key": line_key,
+                "workbook_id": str(bid.id),
+                "project_id": str(project_id),
+                "cost_code": line.get("code"),
+                "description": line.get("description") or f"Line {index + 1}",
+                "unit": line.get("unit") or "lump_sum",
+                "estimated_quantity": estimated,
+                "installed_quantity": installed_quantity,
+                "remaining_quantity": max(estimated - installed_quantity, 0),
+                "percent_complete": round(min(installed_quantity / estimated * 100, 100), 1) if estimated else 0,
+                "materials": line.get("materials") or [],
+            })
+    return workbooks, production_items
 
 
 def create_employee(db: Session, payload: EmployeeCreate) -> EmployeeRead:

--- a/docs/builds/BUILD_221.md
+++ b/docs/builds/BUILD_221.md
@@ -1,0 +1,13 @@
+# Build 221 — Job Workbook Production Tracking
+
+## Outcome
+
+The Foreman Portal now reads the latest saved estimate workspace for each project and compares estimated quantities with installed-to-date field production.
+
+## Included
+
+- Project job-workbook selection in the Foreman Portal.
+- Estimate line descriptions, cost codes, units and material counts.
+- Estimated, installed-to-date, remaining and percent-complete calculations.
+- Installed-today entries linked to the project, workbook line and cost code.
+- No duplicate estimate database or migration; saved estimate workspaces remain the source of truth.

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -52,6 +52,20 @@ export type FieldOperationsBootstrap = {
   suppliers: SelectRecord[];
   equipment: SelectRecord[];
   cost_codes: Array<{ code: string; name: string }>;
+  job_workbooks: Array<{ id: string; project_id: string; status: string; created_at: string; line_count: number }>;
+  production_items: Array<{
+    line_key: string;
+    workbook_id: string;
+    project_id: string;
+    cost_code: string | null;
+    description: string;
+    unit: string;
+    estimated_quantity: number;
+    installed_quantity: number;
+    remaining_quantity: number;
+    percent_complete: number;
+    materials: Array<Record<string, unknown>>;
+  }>;
   vehicles: Vehicle[];
   vehicle_logs: Array<Record<string, unknown>>;
   time_entries: Array<Record<string, unknown>>;

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -136,6 +136,7 @@ export function ForemanPortalPage() {
       {state.data ? (
         <>
           <AlertStrip alerts={state.data.alerts} />
+          <JobWorkbookCard data={state.data} onSaved={state.refresh} onError={state.setError} />
           <TimeEntryForm data={state.data} mode="foreman_crew" onSaved={state.refresh} onError={state.setError} />
           <RecordForm data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} />
           <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} />
@@ -143,6 +144,49 @@ export function ForemanPortalPage() {
         </>
       ) : null}
     </PortalShell>
+  );
+}
+
+function JobWorkbookCard({ data, onSaved, onError }: { data: FieldOperationsBootstrap; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
+  const [projectId, setProjectId] = useState(data.job_workbooks[0]?.project_id ?? "");
+  const items = data.production_items.filter((item) => item.project_id === projectId);
+  const [lineKey, setLineKey] = useState(items[0]?.line_key ?? "");
+  const [quantity, setQuantity] = useState("");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const selected = data.production_items.find((item) => item.line_key === lineKey);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!selected || !quantity) return;
+    setSaving(true); onError(null);
+    try {
+      await fieldOperationsApi.createRecord({
+        record_type: "material_quantity",
+        project_id: selected.project_id,
+        cost_code: selected.cost_code,
+        work_date: today(),
+        title: selected.description,
+        details: { line_key: selected.line_key, workbook_id: selected.workbook_id, installed_quantity: Number(quantity), unit: selected.unit, notes },
+      });
+      setQuantity(""); setNotes(""); await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to save production quantity."); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<ClipboardCheck />} title="Job workbook production" subtitle="Compare estimated, installed-to-date and remaining quantities from the latest project estimate." />
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <Select label="Project / job workbook" value={projectId} onChange={(value) => { setProjectId(value); setLineKey(""); }} options={data.job_workbooks.map((book) => { const project = data.projects.find((item) => item.id === book.project_id); return [book.project_id, (project?.name ?? "Project") + " — " + book.line_count + " lines"]; })} />
+        <Select label="Production line" value={lineKey} onChange={setLineKey} options={items.map((item) => [item.line_key, (item.cost_code ? item.cost_code + " — " : "") + item.description])} />
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {items.map((item) => <div key={item.line_key} className="rounded-md border border-iron-100 p-3"><div className="text-sm font-semibold text-iron-950">{item.description}</div><div className="mt-1 text-xs text-iron-500">{item.cost_code ?? "No cost code"} · {item.unit}</div><div className="mt-3 grid grid-cols-3 gap-2"><Fact label="Estimate" value={String(item.estimated_quantity)} /><Fact label="Installed" value={String(item.installed_quantity)} /><Fact label="Remaining" value={String(item.remaining_quantity)} /></div><div className="mt-2 text-xs font-semibold text-brand-gold-dark">{item.percent_complete}% complete · {item.materials.length} material(s)</div></div>)}
+      </div>
+      {selected ? <form onSubmit={submit} className="mt-4 grid gap-3 rounded-md bg-iron-50 p-4 md:grid-cols-3"><Input label={"Installed today (" + selected.unit + ")"} value={quantity} onChange={setQuantity} type="number" required /><Input label="Production notes" value={notes} onChange={setNotes} /><div className="self-end"><PrimaryButton disabled={saving || !quantity}>{saving ? "Saving…" : "Add installed quantity"}</PrimaryButton></div></form> : null}
+      {!data.job_workbooks.length ? <div className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">Save a project estimate workspace to activate production tracking.</div> : null}
+    </section>
   );
 }
 

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -139,3 +139,48 @@ def test_course_ticket_expiry_creates_management_alert() -> None:
     assert response.json()["expiry_status"] == "expires_soon"
     alerts = client.get("/api/v1/field-operations/bootstrap").json()["alerts"]
     assert any(alert["type"] == "ticket_expiry" for alert in alerts)
+
+
+def test_job_workbook_compares_estimated_installed_and_remaining_quantities() -> None:
+    project = _project()
+    workspace = client.post(
+        "/api/v1/estimates/workspace",
+        json={
+            "project_id": project["id"],
+            "estimate": {
+                "project_name": project["name"],
+                "line_items": [{
+                    "code": "03-100",
+                    "description": "Storm main installation",
+                    "quantity": 100,
+                    "unit": "m",
+                    "materials": [{"name": "PVC pipe", "quantity": 100, "unit": "m", "unit_cost": 20}],
+                }],
+            },
+        },
+    )
+    assert workspace.status_code == 201
+
+    bootstrap = client.get("/api/v1/field-operations/bootstrap").json()
+    line = next(item for item in bootstrap["production_items"] if item["project_id"] == project["id"])
+    assert line["estimated_quantity"] == 100
+    assert line["installed_quantity"] == 0
+
+    record = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "material_quantity",
+            "project_id": project["id"],
+            "cost_code": "03-100",
+            "work_date": str(date.today()),
+            "title": "Storm main installation",
+            "details": {"line_key": line["line_key"], "installed_quantity": 35, "unit": "metre"},
+        },
+    )
+    assert record.status_code == 201
+
+    updated = client.get("/api/v1/field-operations/bootstrap").json()
+    line = next(item for item in updated["production_items"] if item["project_id"] == project["id"])
+    assert line["installed_quantity"] == 35
+    assert line["remaining_quantity"] == 65
+    assert line["percent_complete"] == 35


### PR DESCRIPTION
## Outcome
Connects the latest saved project estimate to a Foreman Portal job workbook, showing estimated, installed-to-date, remaining, completion percentage, materials, project, and cost-code context.

## Field workflow
- Select a project job workbook and estimate line
- Review estimate, installed, remaining, completion, and material count
- Submit today’s installed quantity and notes
- Refresh installed-to-date totals from all linked production records

## Validation
- 120 backend tests passed locally
- Job workbook integration test covers estimate → production entry → updated totals
- Visual design lock passed
- `git diff --check` passed
- Frontend lint/test/build delegated to GitHub CI because the restricted local npm environment cannot write its configured cache

## Safety
No migration, deletion, purchasing, external messaging, or permission expansion.