### PR TITLE
Build 222A: track imported and exported materials

### DIFF
--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -18,6 +18,7 @@ RecordType = Literal[
     "time_off_request",
     "performance_review",
     "material_quantity",
+    "material_movement",
     "subcontractor",
     "rental_equipment",
     "weather",
@@ -184,6 +185,25 @@ class FieldRecordCreate(BaseModel):
     def default_management_alerts(cls, value: list[str]) -> list[str]:
         return list(dict.fromkeys(item.strip() for item in value if item.strip()))
 
+    @model_validator(mode="after")
+    def validate_material_movement(self) -> "FieldRecordCreate":
+        if self.record_type != "material_movement":
+            return self
+        direction = self.details.get("direction")
+        material_type = str(self.details.get("material_type") or "").strip()
+        try:
+            loads = float(self.details.get("loads") or 0)
+            total_tonnes = float(self.details.get("total_tonnes") or 0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Loads and total tonnes must be numbers.") from exc
+        if direction not in {"imported", "exported"}:
+            raise ValueError("Material direction must be imported or exported.")
+        if not material_type:
+            raise ValueError("Select a material type.")
+        if loads <= 0 or total_tonnes <= 0:
+            raise ValueError("Loads and total tonnes must be greater than zero.")
+        return self
+
 
 class FieldRecordRead(FieldRecordCreate):
     model_config = ConfigDict(from_attributes=True)
@@ -218,6 +238,8 @@ class FieldOperationsBootstrap(BaseModel):
     cost_codes: list[dict]
     job_workbooks: list[dict]
     production_items: list[dict]
+    material_types: list[dict]
+    material_movement_summary: list[dict]
     vehicles: list[VehicleRead]
     vehicle_logs: list[VehicleLogRead]
     time_entries: list[TimeEntryRead]

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -35,6 +35,25 @@ from app.services.cost_codes import get_cost_code_library
 
 
 MANAGEMENT_ALERT_RECIPIENTS = ["Jeremie Peters", "Mac Warren"]
+MATERIAL_TYPES = [
+    {"code": "pit_run", "name": "Pit run gravel"},
+    {"code": "75mm_minus", "name": "75 mm minus"},
+    {"code": "50mm_minus", "name": "50 mm minus"},
+    {"code": "25mm_minus", "name": "25 mm minus"},
+    {"code": "19mm_minus", "name": "19 mm minus / road base"},
+    {"code": "19mm_clear", "name": "19 mm clear crush"},
+    {"code": "13mm_clear", "name": "13 mm clear crush"},
+    {"code": "10mm_screenings", "name": "10 mm screenings"},
+    {"code": "pea_gravel", "name": "Pea gravel"},
+    {"code": "drain_rock", "name": "Drain rock"},
+    {"code": "bedding_sand", "name": "Bedding sand"},
+    {"code": "concrete_sand", "name": "Concrete sand"},
+    {"code": "riprap", "name": "Riprap"},
+    {"code": "structural_fill", "name": "Structural fill"},
+    {"code": "native_material", "name": "Native material"},
+    {"code": "topsoil", "name": "Topsoil"},
+    {"code": "other", "name": "Other material"},
+]
 
 
 def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
@@ -48,6 +67,7 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
     records = list(db.scalars(select(FieldRecord).order_by(FieldRecord.work_date.desc(), FieldRecord.created_at.desc()).limit(200)))
     certifications = list(db.scalars(select(EmployeeCertification).order_by(EmployeeCertification.expiry_date)))
     workbooks, production_items = build_job_workbooks(db)
+    material_movement_summary = build_material_movement_summary(db)
     alerts = build_alerts(vehicles, records, certifications)
     return FieldOperationsBootstrap(
         employees=[EmployeeRead.model_validate(item) for item in employees],
@@ -57,6 +77,8 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
         cost_codes=[item.model_dump(mode="json") for item in get_cost_code_library().items],
         job_workbooks=workbooks,
         production_items=production_items,
+        material_types=MATERIAL_TYPES,
+        material_movement_summary=material_movement_summary,
         vehicles=[vehicle_schema(item) for item in vehicles],
         vehicle_logs=[VehicleLogRead.model_validate(item) for item in vehicle_logs],
         time_entries=[TimeEntryRead.model_validate(item) for item in time_entries],
@@ -65,6 +87,33 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
         alerts=alerts,
         toolbox_talk=current_toolbox_talk(),
     )
+
+
+def build_material_movement_summary(db: Session) -> list[dict]:
+    records = db.scalars(
+        select(FieldRecord).where(FieldRecord.record_type == "material_movement")
+    )
+    totals: dict[tuple[str, str, str], dict] = {}
+    for record in records:
+        details = record.details or {}
+        direction = str(details.get("direction") or "")
+        material_code = str(details.get("material_code") or "other")
+        material_type = str(details.get("material_type") or "Other material")
+        key = (str(record.project_id or ""), direction, material_code)
+        item = totals.setdefault(key, {
+            "project_id": str(record.project_id) if record.project_id else None,
+            "direction": direction,
+            "material_code": material_code,
+            "material_type": material_type,
+            "loads": 0.0,
+            "total_tonnes": 0.0,
+        })
+        try:
+            item["loads"] += float(details.get("loads") or 0)
+            item["total_tonnes"] += float(details.get("total_tonnes") or 0)
+        except (TypeError, ValueError):
+            continue
+    return sorted(totals.values(), key=lambda item: (item["project_id"] or "", item["material_type"], item["direction"]))
 
 
 def build_job_workbooks(db: Session) -> tuple[list[dict], list[dict]]:

--- a/docs/builds/BUILD_222A.md
+++ b/docs/builds/BUILD_222A.md
@@ -1,0 +1,14 @@
+# Build 222A — Foreman material movement tracking
+
+## Outcome
+
+Foremen can record imported and exported gravel/material movements by project, cost code, supplier or disposal site, load count, tonnes per load, calculated total tonnes, scale-ticket reference, notes and attachments.
+
+## Included
+
+- Standard selectable gravel and civil material catalogue
+- Imported-to-job and exported-from-job directions
+- Load and tonne validation
+- Automatic total-tonne calculation
+- Running project/material/direction summaries
+- Multiple ticket and delivery-photo attachments

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -66,6 +66,15 @@ export type FieldOperationsBootstrap = {
     percent_complete: number;
     materials: Array<Record<string, unknown>>;
   }>;
+  material_types: Array<{ code: string; name: string }>;
+  material_movement_summary: Array<{
+    project_id: string | null;
+    direction: "imported" | "exported";
+    material_code: string;
+    material_type: string;
+    loads: number;
+    total_tonnes: number;
+  }>;
   vehicles: Vehicle[];
   vehicle_logs: Array<Record<string, unknown>>;
   time_entries: Array<Record<string, unknown>>;

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -1,5 +1,6 @@
 import {
   AlertTriangle,
+  ArrowDownUp,
   BookOpenCheck,
   Camera,
   CheckCircle2,
@@ -137,6 +138,7 @@ export function ForemanPortalPage() {
         <>
           <AlertStrip alerts={state.data.alerts} />
           <JobWorkbookCard data={state.data} onSaved={state.refresh} onError={state.setError} />
+          <MaterialMovementCard data={state.data} onSaved={state.refresh} onError={state.setError} />
           <TimeEntryForm data={state.data} mode="foreman_crew" onSaved={state.refresh} onError={state.setError} />
           <RecordForm data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} />
           <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} />
@@ -144,6 +146,64 @@ export function ForemanPortalPage() {
         </>
       ) : null}
     </PortalShell>
+  );
+}
+
+function MaterialMovementCard({ data, onSaved, onError }: { data: FieldOperationsBootstrap; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
+  const [projectId, setProjectId] = useState("");
+  const [costCode, setCostCode] = useState("");
+  const [supplierId, setSupplierId] = useState("");
+  const [direction, setDirection] = useState("imported");
+  const [materialCode, setMaterialCode] = useState("");
+  const [loads, setLoads] = useState("");
+  const [tonnesPerLoad, setTonnesPerLoad] = useState("");
+  const [ticketNumber, setTicketNumber] = useState("");
+  const [notes, setNotes] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [saving, setSaving] = useState(false);
+  const totalTonnes = Number(loads || 0) * Number(tonnesPerLoad || 0);
+  const material = data.material_types.find((item) => item.code === materialCode);
+  const summaries = data.material_movement_summary.filter((item) => !projectId || item.project_id === projectId);
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!projectId || !costCode || !material || totalTonnes <= 0) return;
+    setSaving(true); onError(null);
+    try {
+      const documentIds = await uploadPhotos(files, projectId, direction + " material ticket");
+      await fieldOperationsApi.createRecord({
+        record_type: "material_movement", project_id: projectId, supplier_id: supplierId || null,
+        cost_code: costCode, work_date: today(), title: direction + " — " + material.name,
+        document_ids: documentIds,
+        details: { direction, material_code: material.code, material_type: material.name, loads: Number(loads), tonnes_per_load: Number(tonnesPerLoad), total_tonnes: totalTonnes, ticket_number: ticketNumber, notes },
+      });
+      setLoads(""); setTonnesPerLoad(""); setTicketNumber(""); setNotes(""); setFiles([]); await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to save material movement."); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<ArrowDownUp />} title="Imported and exported materials" subtitle="Record gravel and other material by truck loads and tonnes, linked to the job and cost code." />
+      <form onSubmit={submit} className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <Select label="Project" value={projectId} onChange={setProjectId} required options={data.projects.map((item) => [item.id, item.name])} />
+        <Select label="Direction" value={direction} onChange={setDirection} options={[["imported", "Imported to job"], ["exported", "Exported from job"]]} />
+        <Select label="Material / gravel type" value={materialCode} onChange={setMaterialCode} required options={data.material_types.map((item) => [item.code, item.name])} />
+        <Select label="Cost code" value={costCode} onChange={setCostCode} required options={data.cost_codes.map((item) => [item.code, item.code + " — " + item.name])} />
+        <Select label="Supplier / disposal site" value={supplierId} onChange={setSupplierId} options={data.suppliers.map((item) => [item.id, item.name])} />
+        <Input label="Number of loads" value={loads} onChange={setLoads} type="number" required />
+        <Input label="Tonnes per load" value={tonnesPerLoad} onChange={setTonnesPerLoad} type="number" required />
+        <Input label="Scale ticket / reference" value={ticketNumber} onChange={setTicketNumber} />
+        <Input label="Notes" value={notes} onChange={setNotes} />
+        <FilePicker files={files} onChange={setFiles} />
+        <div className="rounded-md bg-iron-50 p-3"><div className="text-[10px] font-semibold uppercase tracking-wide text-iron-500">Calculated total</div><div className="mt-1 text-lg font-semibold text-iron-950">{totalTonnes.toLocaleString("en-CA")} tonnes</div></div>
+        <div className="self-end"><PrimaryButton disabled={saving || !projectId || !costCode || !materialCode || totalTonnes <= 0}>{saving ? "Saving…" : "Record material movement"}</PrimaryButton></div>
+      </form>
+      <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {summaries.map((item) => <div key={(item.project_id ?? "all") + item.direction + item.material_code} className="rounded-md border border-iron-100 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">{item.direction}</div><div className="mt-1 text-sm font-semibold text-iron-950">{item.material_type}</div><div className="mt-3 grid grid-cols-2 gap-2"><Fact label="Loads" value={item.loads.toLocaleString("en-CA")} /><Fact label="Tonnes" value={item.total_tonnes.toLocaleString("en-CA")} /></div></div>)}
+        {!summaries.length ? <div className="rounded-md bg-iron-50 p-4 text-sm text-iron-500">No imported or exported materials recorded for this selection.</div> : null}
+      </div>
+    </section>
   );
 }
 

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -184,3 +184,69 @@ def test_job_workbook_compares_estimated_installed_and_remaining_quantities() ->
     assert line["installed_quantity"] == 35
     assert line["remaining_quantity"] == 65
     assert line["percent_complete"] == 35
+
+
+def test_material_imports_and_exports_are_tracked_by_loads_and_tonnes() -> None:
+    project = _project()
+    imported = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "material_movement",
+            "project_id": project["id"],
+            "cost_code": "02-200",
+            "work_date": str(date.today()),
+            "title": "Imported — 19 mm minus / road base",
+            "details": {
+                "direction": "imported",
+                "material_code": "19mm_minus",
+                "material_type": "19 mm minus / road base",
+                "loads": 4,
+                "tonnes_per_load": 18.5,
+                "total_tonnes": 74,
+            },
+        },
+    )
+    assert imported.status_code == 201
+    exported = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "material_movement",
+            "project_id": project["id"],
+            "cost_code": "01-300",
+            "work_date": str(date.today()),
+            "title": "Exported — Native material",
+            "details": {
+                "direction": "exported",
+                "material_code": "native_material",
+                "material_type": "Native material",
+                "loads": 3,
+                "tonnes_per_load": 16,
+                "total_tonnes": 48,
+            },
+        },
+    )
+    assert exported.status_code == 201
+
+    bootstrap = client.get("/api/v1/field-operations/bootstrap").json()
+    assert any(item["code"] == "19mm_minus" for item in bootstrap["material_types"])
+    imported_total = next(item for item in bootstrap["material_movement_summary"] if item["direction"] == "imported")
+    exported_total = next(item for item in bootstrap["material_movement_summary"] if item["direction"] == "exported")
+    assert imported_total["loads"] == 4
+    assert imported_total["total_tonnes"] == 74
+    assert exported_total["loads"] == 3
+    assert exported_total["total_tonnes"] == 48
+
+
+def test_material_movement_rejects_missing_or_zero_quantities() -> None:
+    project = _project()
+    response = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "material_movement",
+            "project_id": project["id"],
+            "work_date": str(date.today()),
+            "title": "Invalid gravel movement",
+            "details": {"direction": "imported", "material_type": "Pit run gravel", "loads": 0, "total_tonnes": 0},
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Outcome
Adds a dedicated Foreman Portal workflow for imported and exported gravel/material movements.

## Included
- Imported-to-job and exported-from-job direction
- 17 selectable gravel and civil material types
- Project, cost code, supplier/disposal-site linkage
- Loads, tonnes per load, and calculated total tonnes
- Scale ticket/reference, notes, and multiple photos
- Running totals by project, direction, and material
- Server validation for material type, direction, loads, and tonnes

## Validation
- 122 backend tests passed
- Material import/export integration and invalid-quantity tests added
- Visual design lock passed
- Clean diff check passed

No migration or destructive operation is required.