### PR TITLE
Build 222B: include company trucks in Operator load tracker

### DIFF
--- a/docs/builds/BUILD_222B.md
+++ b/docs/builds/BUILD_222B.md
@@ -4,6 +4,8 @@
 
 Operators can record imported and exported material loads directly from the Operator Portal. Entries share the Foreman material ledger and are linked to the selected truck/equipment, project, cost code, supplier or disposal site, material type, scale-ticket reference and attachments.
 
+Company vehicles (including Trucks 001 and 002) and equipment records are combined into one haul-unit selector so the tracker works before separate equipment records are added.
+
 ## Tracking
 
 - Number of loads

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -153,7 +153,7 @@ function MaterialMovementCard({ data, mode, onSaved, onError }: { data: FieldOpe
   const [projectId, setProjectId] = useState("");
   const [costCode, setCostCode] = useState("");
   const [supplierId, setSupplierId] = useState("");
-  const [equipmentId, setEquipmentId] = useState("");
+  const [haulUnit, setHaulUnit] = useState("");
   const [direction, setDirection] = useState("imported");
   const [materialCode, setMaterialCode] = useState("");
   const [loads, setLoads] = useState("");
@@ -164,19 +164,24 @@ function MaterialMovementCard({ data, mode, onSaved, onError }: { data: FieldOpe
   const [saving, setSaving] = useState(false);
   const totalTonnes = Number(loads || 0) * Number(tonnesPerLoad || 0);
   const material = data.material_types.find((item) => item.code === materialCode);
+  const selectedHaulUnit = [
+    ...data.vehicles.map((item) => ({ value: "vehicle:" + item.id, id: item.id, type: "vehicle", name: "Truck " + item.unit_number + " — " + (item.assigned_driver_name ?? item.name) })),
+    ...data.equipment.map((item) => ({ value: "equipment:" + item.id, id: item.id, type: "equipment", name: item.name })),
+  ].find((item) => item.value === haulUnit);
   const summaries = data.material_movement_summary.filter((item) => !projectId || item.project_id === projectId);
 
   async function submit(event: FormEvent) {
     event.preventDefault();
-    if (!projectId || !costCode || !material || totalTonnes <= 0 || (mode === "operator" && !equipmentId)) return;
+    if (!projectId || !costCode || !material || totalTonnes <= 0 || (mode === "operator" && !selectedHaulUnit)) return;
     setSaving(true); onError(null);
     try {
       const documentIds = await uploadPhotos(files, projectId, direction + " material ticket");
       await fieldOperationsApi.createRecord({
-        record_type: "material_movement", project_id: projectId, supplier_id: supplierId || null, equipment_id: equipmentId || null,
+        record_type: "material_movement", project_id: projectId, supplier_id: supplierId || null,
+        equipment_id: selectedHaulUnit?.type === "equipment" ? selectedHaulUnit.id : null,
         cost_code: costCode, work_date: today(), title: direction + " — " + material.name,
         document_ids: documentIds,
-        details: { direction, material_code: material.code, material_type: material.name, loads: Number(loads), tonnes_per_load: Number(tonnesPerLoad), total_tonnes: totalTonnes, ticket_number: ticketNumber, notes },
+        details: { direction, material_code: material.code, material_type: material.name, loads: Number(loads), tonnes_per_load: Number(tonnesPerLoad), total_tonnes: totalTonnes, ticket_number: ticketNumber, notes, haul_unit_id: selectedHaulUnit?.id, haul_unit_type: selectedHaulUnit?.type, haul_unit_name: selectedHaulUnit?.name },
       });
       setLoads(""); setTonnesPerLoad(""); setTicketNumber(""); setNotes(""); setFiles([]); await onSaved();
     } catch (current) { onError(current instanceof Error ? current.message : "Unable to save material movement."); }
@@ -192,14 +197,17 @@ function MaterialMovementCard({ data, mode, onSaved, onError }: { data: FieldOpe
         <Select label="Material / gravel type" value={materialCode} onChange={setMaterialCode} required options={data.material_types.map((item) => [item.code, item.name])} />
         <Select label="Cost code" value={costCode} onChange={setCostCode} required options={data.cost_codes.map((item) => [item.code, item.code + " — " + item.name])} />
         <Select label="Supplier / disposal site" value={supplierId} onChange={setSupplierId} options={data.suppliers.map((item) => [item.id, item.name])} />
-        {mode === "operator" ? <Select label="Truck / equipment" value={equipmentId} onChange={setEquipmentId} required options={data.equipment.map((item) => [item.id, item.name])} /> : null}
+        {mode === "operator" ? <Select label="Truck / equipment" value={haulUnit} onChange={setHaulUnit} required options={[
+          ...data.vehicles.map((item) => ["vehicle:" + item.id, "Truck " + item.unit_number + " — " + (item.assigned_driver_name ?? item.name)]),
+          ...data.equipment.map((item) => ["equipment:" + item.id, item.name]),
+        ]} /> : null}
         <Input label="Number of loads" value={loads} onChange={setLoads} type="number" required />
         <Input label="Tonnes per load" value={tonnesPerLoad} onChange={setTonnesPerLoad} type="number" required />
         <Input label="Scale ticket / reference" value={ticketNumber} onChange={setTicketNumber} />
         <Input label="Notes" value={notes} onChange={setNotes} />
         <FilePicker files={files} onChange={setFiles} />
         <div className="rounded-md bg-iron-50 p-3"><div className="text-[10px] font-semibold uppercase tracking-wide text-iron-500">Calculated total</div><div className="mt-1 text-lg font-semibold text-iron-950">{totalTonnes.toLocaleString("en-CA")} tonnes</div></div>
-        <div className="self-end"><PrimaryButton disabled={saving || !projectId || !costCode || !materialCode || totalTonnes <= 0 || (mode === "operator" && !equipmentId)}>{saving ? "Saving…" : mode === "operator" ? "Record loads" : "Record material movement"}</PrimaryButton></div>
+        <div className="self-end"><PrimaryButton disabled={saving || !projectId || !costCode || !materialCode || totalTonnes <= 0 || (mode === "operator" && !selectedHaulUnit)}>{saving ? "Saving…" : mode === "operator" ? "Record loads" : "Record material movement"}</PrimaryButton></div>
       </form>
       <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
         {summaries.map((item) => <div key={(item.project_id ?? "all") + item.direction + item.material_code} className="rounded-md border border-iron-100 p-3"><div className="text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">{item.direction}</div><div className="mt-1 text-sm font-semibold text-iron-950">{item.material_type}</div><div className="mt-3 grid grid-cols-2 gap-2"><Fact label="Loads" value={item.loads.toLocaleString("en-CA")} /><Fact label="Tonnes" value={item.total_tonnes.toLocaleString("en-CA")} /></div></div>)}


### PR DESCRIPTION
## Production usability correction
Authenticated production verification found that the equipment table is currently empty. The Operator load tracker required an equipment selection, which would block submissions.

## Fix
- Combine company vehicles and equipment in one haul-unit selector
- Make Trucks 001 and 002 immediately selectable
- Preserve future equipment support
- Store haul-unit ID, type, and display name with the material movement
- Populate `equipment_id` only for actual equipment records

Visual design lock and clean diff checks pass.