### PR TITLE
Build 223: add career milestones and company recognition

### DIFF
--- a/backend/app/api/v1/routes/field_operations.py
+++ b/backend/app/api/v1/routes/field_operations.py
@@ -14,6 +14,7 @@ from app.schemas.field_operations import (
     FieldOperationsBootstrap,
     FieldRecordCreate,
     FieldRecordRead,
+    MilestoneDecision,
     SignatureCreate,
     TimeEntryCreate,
     TimeEntryRead,
@@ -77,3 +78,13 @@ def sign_field_record(
     user: CurrentUser,
 ) -> FieldRecordRead:
     return field_operations.sign_field_record(db, record_id, payload, user)
+
+
+@router.post("/records/{record_id}/milestone-decision", response_model=FieldRecordRead)
+def decide_milestone(
+    record_id: UUID,
+    payload: MilestoneDecision,
+    db: DBSession,
+    user: CurrentUser,
+) -> FieldRecordRead:
+    return field_operations.decide_milestone(db, record_id, payload, user)

--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -19,6 +19,7 @@ RecordType = Literal[
     "performance_review",
     "material_quantity",
     "material_movement",
+    "milestone_review",
     "subcontractor",
     "rental_equipment",
     "weather",
@@ -221,6 +222,14 @@ class SignatureCreate(BaseModel):
     acknowledgement: str = Field(default="I acknowledge and understand this record.", min_length=10)
 
 
+class MilestoneDecision(BaseModel):
+    decision: Literal["approved", "declined"]
+    practical_passed: bool = False
+    practical_notes: str | None = None
+    reward_type: Literal["none", "bonus", "gift", "training", "paid_time", "other"] = "none"
+    reward_description: str | None = None
+
+
 class ToolboxTalk(BaseModel):
     week_of: date
     title: str
@@ -240,6 +249,9 @@ class FieldOperationsBootstrap(BaseModel):
     production_items: list[dict]
     material_types: list[dict]
     material_movement_summary: list[dict]
+    milestone_catalog: list[dict]
+    milestone_recognitions: list[dict]
+    paperwork_recognitions: list[dict]
     vehicles: list[VehicleRead]
     vehicle_logs: list[VehicleLogRead]
     time_entries: list[TimeEntryRead]

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -20,6 +20,7 @@ from app.schemas.field_operations import (
     FieldOperationsBootstrap,
     FieldRecordCreate,
     FieldRecordRead,
+    MilestoneDecision,
     SignatureCreate,
     TimeEntryCreate,
     TimeEntryRead,
@@ -54,6 +55,37 @@ MATERIAL_TYPES = [
     {"code": "topsoil", "name": "Topsoil"},
     {"code": "other", "name": "Other material"},
 ]
+MILESTONE_CATALOG = [
+    {"id": "civil_green_hat_rookie", "track": "civil", "name": "Green Hat Rookie", "minimum_months": 0, "practical": ["Completes site orientation", "Identifies basic hazards and controls", "Uses PPE and follows supervisor direction"]},
+    {"id": "civil_probation_complete", "track": "civil", "name": "3-Month Probation Complete", "minimum_months": 3, "practical": ["Completes assigned work safely", "Uses tools correctly", "Communicates hazards and progress"]},
+    {"id": "civil_labourer", "track": "civil", "name": "Labourer — Green Hat Removed", "minimum_months": 8, "practical": ["Works independently on routine tasks", "Supports excavation and backfill", "Maintains housekeeping and paperwork"]},
+    {"id": "civil_skilled_labourer", "track": "civil", "name": "Skilled Labourer", "minimum_months": 8, "practical": ["Reads grades and measurements", "Supports compaction and utility installation", "Anticipates crew needs safely"]},
+    {"id": "civil_rookie_pipe", "track": "civil", "name": "Rookie Pipe Layer", "minimum_months": 8, "practical": ["Identifies pipe and fittings", "Prepares bedding and joints", "Checks line, grade and cleanliness"]},
+    {"id": "civil_senior_pipe", "track": "civil", "name": "Senior Pipe Layer / Ditch Boss", "minimum_months": 8, "practical": ["Directs safe trench workflow", "Verifies line, grade and connections", "Coordinates operator and top person"]},
+    {"id": "civil_topman_grademan", "track": "civil", "name": "Top Man / Grademan", "minimum_months": 8, "practical": ["Sets and checks grade controls", "Calculates cuts and fills", "Documents quantities and changes"]},
+    {"id": "civil_junior_foreman", "track": "civil", "name": "Junior Foreman", "minimum_months": 8, "practical": ["Plans daily work and crew assignments", "Leads hazard assessments", "Completes cost-coded paperwork on time"]},
+    {"id": "civil_foreman", "track": "civil", "name": "Foreman", "minimum_months": 8, "practical": ["Leads production, safety and quality", "Coordinates vendors and management", "Coaches and assesses crew competency"]},
+    {"id": "operator_green_hat", "track": "operator", "name": "Green Hat Operator", "minimum_months": 0, "practical": ["Completes pre-use inspection", "Demonstrates safe start, travel and shutdown", "Maintains exclusion zones"]},
+    {"id": "operator_service_hoe", "track": "operator", "name": "Service Hoe Operator", "minimum_months": 3, "practical": ["Excavates safely around services", "Uses spotter communication", "Maintains depth and trench control"]},
+    {"id": "operator_mainline", "track": "operator", "name": "Mainline Operator", "minimum_months": 8, "practical": ["Maintains production line and grade", "Loads trucks efficiently with minimal spillage", "Coordinates safely with pipe crew"]},
+    {"id": "operator_fine_finish", "track": "operator", "name": "Fine Finish Operator", "minimum_months": 8, "practical": ["Finishes to design tolerance", "Reads grade stakes and instruments", "Protects completed work and adjacent assets"]},
+]
+MILESTONE_QUESTIONS = {
+    "civil": [
+        {"id": "hazard", "prompt": "What should happen before a task starts when a hazard is not controlled?", "options": ["Continue carefully", "Stop and establish controls", "Wait until lunch"], "answer": 1},
+        {"id": "grade", "prompt": "What confirms pipe or excavation elevation is being built correctly?", "options": ["Line and grade checks", "Truck count", "Fuel usage"], "answer": 0},
+        {"id": "paperwork", "prompt": "When should daily field paperwork be complete?", "options": ["Before the next workday", "At month end", "Only when requested"], "answer": 0},
+        {"id": "utility", "prompt": "Before excavating near a known utility, the crew must first:", "options": ["Increase bucket speed", "Confirm location and controls", "Remove the spotter"], "answer": 1},
+        {"id": "compaction", "prompt": "Compaction quality depends on using the specified material, lift thickness and:", "options": ["Moisture and compaction effort", "Paint colour", "Truck model"], "answer": 0},
+    ],
+    "operator": [
+        {"id": "inspection", "prompt": "What is required before operating equipment?", "options": ["Pre-use inspection", "Production photo only", "Fuel receipt"], "answer": 0},
+        {"id": "stability", "prompt": "The operator must continually assess machine stability, excavation edges and:", "options": ["Soil conditions", "Radio volume", "Paint condition"], "answer": 0},
+        {"id": "signals", "prompt": "If the operator loses sight of the designated spotter, the operator should:", "options": ["Continue slowly", "Stop movement", "Sound the horn and continue"], "answer": 1},
+        {"id": "loading", "prompt": "Efficient truck loading should minimize spillage and maintain:", "options": ["A level clean floor", "Maximum swing speed", "An unmarked exclusion zone"], "answer": 0},
+        {"id": "shutdown", "prompt": "When work pauses, implements should be:", "options": ["Left raised", "Lowered safely", "Held over the trench"], "answer": 1},
+    ],
+}
 
 
 def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
@@ -68,6 +100,8 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
     certifications = list(db.scalars(select(EmployeeCertification).order_by(EmployeeCertification.expiry_date)))
     workbooks, production_items = build_job_workbooks(db)
     material_movement_summary = build_material_movement_summary(db)
+    milestone_recognitions = build_milestone_recognitions(db)
+    paperwork_recognitions = build_paperwork_recognitions(db, employees)
     alerts = build_alerts(vehicles, records, certifications)
     return FieldOperationsBootstrap(
         employees=[EmployeeRead.model_validate(item) for item in employees],
@@ -79,6 +113,9 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
         production_items=production_items,
         material_types=MATERIAL_TYPES,
         material_movement_summary=material_movement_summary,
+        milestone_catalog=public_milestone_catalog(),
+        milestone_recognitions=milestone_recognitions,
+        paperwork_recognitions=paperwork_recognitions,
         vehicles=[vehicle_schema(item) for item in vehicles],
         vehicle_logs=[VehicleLogRead.model_validate(item) for item in vehicle_logs],
         time_entries=[TimeEntryRead.model_validate(item) for item in time_entries],
@@ -87,6 +124,41 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
         alerts=alerts,
         toolbox_talk=current_toolbox_talk(),
     )
+
+
+def public_milestone_catalog() -> list[dict]:
+    return [
+        {**item, "written_questions": [{"id": q["id"], "prompt": q["prompt"], "options": q["options"]} for q in MILESTONE_QUESTIONS[item["track"]]]}
+        for item in MILESTONE_CATALOG
+    ]
+
+
+def build_milestone_recognitions(db: Session) -> list[dict]:
+    records = db.scalars(select(FieldRecord).where(
+        FieldRecord.record_type == "milestone_review", FieldRecord.status == "approved"
+    ).order_by(FieldRecord.updated_at.desc()))
+    return [{
+        "record_id": str(item.id), "employee_id": str(item.employee_id),
+        "employee_name": (item.details or {}).get("employee_name"),
+        "milestone_name": (item.details or {}).get("milestone_name"),
+        "approved_at": (item.details or {}).get("approved_at"),
+        "reward_type": (item.details or {}).get("reward_type", "none"),
+        "reward_description": (item.details or {}).get("reward_description"),
+    } for item in records]
+
+
+def build_paperwork_recognitions(db: Session, employees: list[Employee]) -> list[dict]:
+    names = {item.id: f"{item.first_name} {item.last_name}" for item in employees}
+    entries = db.scalars(select(TimeEntry).order_by(TimeEntry.work_date))
+    days: dict[UUID, set[date]] = {}
+    for item in entries:
+        if item.created_at.date() <= item.work_date:
+            days.setdefault(item.employee_id, set()).add(item.work_date)
+    records = db.scalars(select(FieldRecord).where(FieldRecord.employee_id.is_not(None)).order_by(FieldRecord.work_date))
+    for item in records:
+        if item.employee_id and item.created_at.date() <= item.work_date:
+            days.setdefault(item.employee_id, set()).add(item.work_date)
+    return [{"employee_id": str(employee_id), "employee_name": names.get(employee_id, "Employee"), "on_time_days": len(work_days)} for employee_id, work_days in days.items() if work_days]
 
 
 def build_material_movement_summary(db: Session) -> list[dict]:
@@ -236,9 +308,69 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
     if payload.severity in {"medium", "high", "critical"} and not alerts:
         alerts = MANAGEMENT_ALERT_RECIPIENTS
     values = payload.model_dump()
+    if payload.record_type == "milestone_review":
+        employee = require_exists(db, Employee, payload.employee_id, "Employee") if payload.employee_id else db.scalar(
+            select(Employee).where(Employee.email.ilike(user.email))
+        )
+        if employee is None:
+            raise AppError("Your employee profile is not linked to this account.", status_code=400)
+        if user.role not in {"admin", "operations_manager"} and employee.email.lower() != user.email.lower():
+            raise AppError("You can only request your own milestone review.", status_code=403)
+        milestone_id = str(payload.details.get("milestone_id") or "")
+        milestone = next((item for item in MILESTONE_CATALOG if item["id"] == milestone_id), None)
+        if milestone is None:
+            raise AppError("Select a valid milestone.", status_code=400)
+        answers = payload.details.get("written_answers") or {}
+        questions = MILESTONE_QUESTIONS[milestone["track"]]
+        correct = sum(1 for question in questions if answers.get(question["id"]) == question["answer"])
+        score = round(correct / len(questions) * 100)
+        values["employee_id"] = employee.id
+        values["status"] = "practical_pending" if score >= 80 else "written_retry_required"
+        values["details"] = {
+            **payload.details,
+            "employee_name": f"{employee.first_name} {employee.last_name}",
+            "milestone_name": milestone["name"],
+            "track": milestone["track"],
+            "written_score": score,
+            "written_passed": score >= 80,
+            "practical_status": "pending",
+            "requested_at": datetime.now(UTC).isoformat(),
+        }
     values["document_ids"] = [str(document_id) for document_id in payload.document_ids]
     values["alert_recipients"] = alerts
     item = FieldRecord(**values, submitted_by=user.email)
+    db.add(item)
+    commit(db)
+    db.refresh(item)
+    return FieldRecordRead.model_validate(item)
+
+
+def decide_milestone(
+    db: Session,
+    record_id: UUID,
+    payload: MilestoneDecision,
+    user: AuthenticatedUser,
+) -> FieldRecordRead:
+    if user.role not in {"admin", "operations_manager"}:
+        raise AppError("Management access is required for milestone decisions.", status_code=403)
+    item = require_exists(db, FieldRecord, record_id, "Milestone review")
+    if item.record_type != "milestone_review":
+        raise AppError("That record is not a milestone review.", status_code=400)
+    details = dict(item.details or {})
+    if payload.decision == "approved" and (not details.get("written_passed") or not payload.practical_passed):
+        raise AppError("Written and practical assessments must both pass before approval.", status_code=400)
+    details.update({
+        "practical_status": "passed" if payload.practical_passed else "not_passed",
+        "practical_notes": payload.practical_notes,
+        "decision_by": user.display_name,
+        "decision_at": datetime.now(UTC).isoformat(),
+        "reward_type": payload.reward_type,
+        "reward_description": payload.reward_description,
+    })
+    if payload.decision == "approved":
+        details["approved_at"] = details["decision_at"]
+    item.details = details
+    item.status = payload.decision
     db.add(item)
     commit(db)
     db.refresh(item)

--- a/docs/builds/BUILD_223.md
+++ b/docs/builds/BUILD_223.md
@@ -1,0 +1,18 @@
+# Build 223 — Career milestones and recognition
+
+## Outcome
+
+Employee, Operator and Foreman portals include self-nominated career milestone reviews, original Iron House written assessments, management-observed practical checklists, controlled approval, optional rewards and company recognition.
+
+## Advancement rules
+
+- Written assessment requires at least 80 percent.
+- Practical competency must be observed and passed by management.
+- Only administrators and operations managers may approve or decline.
+- Bonus, gift, training, paid-time or other rewards are optional management decisions; the system never awards compensation automatically.
+- Approved milestones appear in the company recognition feed.
+- Time entries completed before the next workday contribute to paperwork recognition.
+
+## Source framework
+
+Original questions and practical checks are grounded in official SkilledTradesBC Heavy Equipment Operator and Construction Craft Worker competency areas and WorkSafeBC new-worker orientation, task instruction and supervision requirements. They are internal development assessments, not replacements for regulated certificates or external trade qualifications.

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -75,6 +75,24 @@ export type FieldOperationsBootstrap = {
     loads: number;
     total_tonnes: number;
   }>;
+  milestone_catalog: Array<{
+    id: string;
+    track: "civil" | "operator";
+    name: string;
+    minimum_months: number;
+    practical: string[];
+    written_questions: Array<{ id: string; prompt: string; options: string[] }>;
+  }>;
+  milestone_recognitions: Array<{
+    record_id: string;
+    employee_id: string;
+    employee_name: string;
+    milestone_name: string;
+    approved_at: string;
+    reward_type: string;
+    reward_description: string | null;
+  }>;
+  paperwork_recognitions: Array<{ employee_id: string; employee_name: string; on_time_days: number }>;
   vehicles: Vehicle[];
   vehicle_logs: Array<Record<string, unknown>>;
   time_entries: Array<Record<string, unknown>>;
@@ -117,6 +135,8 @@ export const fieldOperationsApi = {
     request<FieldRecord>("/field-operations/records", { method: "POST", body: JSON.stringify(payload) }),
   signRecord: (id: string, payload: Record<string, unknown>) =>
     request<FieldRecord>("/field-operations/records/" + id + "/sign", { method: "POST", body: JSON.stringify(payload) }),
+  decideMilestone: (id: string, payload: Record<string, unknown>) =>
+    request<FieldRecord>("/field-operations/records/" + id + "/milestone-decision", { method: "POST", body: JSON.stringify(payload) }),
   createEmployee: (payload: Record<string, unknown>) =>
     request("/field-operations/employees", { method: "POST", body: JSON.stringify(payload) }),
   createCertification: (payload: Record<string, unknown>) =>

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -1,6 +1,7 @@
 import {
   AlertTriangle,
   ArrowDownUp,
+  Award,
   BookOpenCheck,
   Camera,
   CheckCircle2,
@@ -19,6 +20,7 @@ import {
 import { FormEvent, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 
 import { documentsApi } from "../api/documents";
+import { useAuth } from "../contexts/AuthContext";
 import {
   Employee,
   FieldOperationsBootstrap,
@@ -139,6 +141,7 @@ export function ForemanPortalPage() {
           <AlertStrip alerts={state.data.alerts} />
           <JobWorkbookCard data={state.data} onSaved={state.refresh} onError={state.setError} />
           <MaterialMovementCard data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} />
+          <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} />
           <TimeEntryForm data={state.data} mode="foreman_crew" onSaved={state.refresh} onError={state.setError} />
           <RecordForm data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} />
           <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} />
@@ -269,6 +272,7 @@ export function OperatorPortalPage() {
         <>
           <AlertStrip alerts={state.data.alerts} />
           <MaterialMovementCard data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} />
+          <MilestoneCard data={state.data} track="operator" onSaved={state.refresh} onError={state.setError} />
           <TimeEntryForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} />
           <RecordForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} />
           <RecentRecords records={state.data.records.filter((item) => ["material_movement", "equipment_inspection", "job_photo", "time_off_request", "performance_review"].includes(item.record_type))} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} />
@@ -288,6 +292,7 @@ export function EmployeePortalPage() {
         <>
           <TimeEntryForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} />
           <RecordForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} />
+          <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} />
           <EmployeeDirectory data={state.data} />
           <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} />
           <RecentRecords records={state.data.records} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} />
@@ -295,6 +300,69 @@ export function EmployeePortalPage() {
       ) : null}
     </PortalShell>
   );
+}
+
+function MilestoneCard({ data, track, onSaved, onError }: { data: FieldOperationsBootstrap; track: "civil" | "operator"; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
+  const { user } = useAuth();
+  const employee = data.employees.find((item) => item.email.toLowerCase() === user?.email.toLowerCase());
+  const milestones = data.milestone_catalog.filter((item) => item.track === track);
+  const [milestoneId, setMilestoneId] = useState("");
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const selected = milestones.find((item) => item.id === milestoneId);
+  const requests = data.records.filter((item) => item.record_type === "milestone_review" && (!employee || item.employee_id === employee.id));
+  const pending = data.records.filter((item) => item.record_type === "milestone_review" && ["practical_pending", "written_retry_required"].includes(item.status));
+  const isManagement = ["admin", "operations_manager"].includes(user?.role ?? "");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!selected || !employee || selected.written_questions.some((question) => answers[question.id] === undefined)) return;
+    setSaving(true); onError(null);
+    try {
+      await fieldOperationsApi.createRecord({
+        record_type: "milestone_review", employee_id: employee.id, work_date: today(),
+        title: "Milestone review — " + selected.name,
+        details: { milestone_id: selected.id, written_answers: Object.fromEntries(Object.entries(answers).map(([key, value]) => [key, Number(value)])) },
+      });
+      setMilestoneId(""); setAnswers({}); await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to request milestone review."); }
+    finally { setSaving(false); }
+  }
+
+  return (
+    <section className="rounded-xl border border-brand-gold/40 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<Award />} title="Career milestones and recognition" subtitle="Request a written and practical review. Management approval is required before advancement or rewards are announced." />
+      {employee ? <form onSubmit={submit} className="mt-4 grid gap-4">
+        <Select label="Milestone I want to be reviewed for" value={milestoneId} onChange={(value) => { setMilestoneId(value); setAnswers({}); }} options={milestones.map((item) => [item.id, item.name + (item.minimum_months ? " — " + item.minimum_months + "+ months" : "")])} />
+        {selected ? <div className="grid gap-4 rounded-md bg-iron-50 p-4">
+          <div><div className="text-sm font-semibold text-iron-950">Written assessment</div><div className="mt-1 text-xs text-iron-500">80% is required before the practical assessment can be approved.</div></div>
+          {selected.written_questions.map((question, index) => <Select key={question.id} label={(index + 1) + ". " + question.prompt} value={answers[question.id] ?? ""} onChange={(value) => setAnswers((current) => ({ ...current, [question.id]: value }))} options={question.options.map((option, optionIndex) => [String(optionIndex), option])} required />)}
+          <div><div className="text-sm font-semibold text-iron-950">Practical assessment checklist</div><ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-iron-600">{selected.practical.map((item) => <li key={item}>{item}</li>)}</ul></div>
+          <PrimaryButton disabled={saving || selected.written_questions.some((question) => answers[question.id] === undefined)}>{saving ? "Submitting…" : "Submit written test and request practical review"}</PrimaryButton>
+        </div> : null}
+      </form> : <div className="mt-4 rounded-md bg-amber-50 p-4 text-sm text-amber-900">Your login must be linked to an employee profile before requesting a milestone review.</div>}
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
+        {requests.slice(0, 6).map((item) => <div key={item.id} className="rounded-md border border-iron-100 p-3"><div className="font-semibold text-iron-950">{String(item.details.milestone_name ?? item.title)}</div><div className="mt-1 text-sm text-iron-500">Written: {String(item.details.written_score ?? 0)}% · Practical: {String(item.details.practical_status ?? "pending")} · {item.status.replaceAll("_", " ")}</div></div>)}
+      </div>
+      <div className="mt-5 rounded-md bg-brand-gold/10 p-4"><div className="font-semibold text-iron-950">Company recognition</div><div className="mt-2 grid gap-2">{data.milestone_recognitions.slice(0, 8).map((item) => <div key={item.record_id} className="text-sm text-iron-700">Achievement: {item.employee_name} earned <strong>{item.milestone_name}</strong>{item.reward_description ? " — " + item.reward_description : ""}</div>)}{data.paperwork_recognitions.slice(0, 8).map((item) => <div key={item.employee_id} className="text-sm text-iron-700">Paperwork recognition: {item.employee_name} completed {item.on_time_days} workday(s) before the next day</div>)}{!data.milestone_recognitions.length && !data.paperwork_recognitions.length ? <div className="text-sm text-iron-500">Approved milestones and on-time paperwork recognition will appear here.</div> : null}</div></div>
+      {isManagement && pending.length ? <div className="mt-5"><div className="font-semibold text-iron-950">Management milestone reviews</div><div className="mt-3 grid gap-3">{pending.map((item) => <MilestoneDecisionControls key={item.id} record={item} onSaved={onSaved} onError={onError} />)}</div></div> : null}
+    </section>
+  );
+}
+
+function MilestoneDecisionControls({ record, onSaved, onError }: { record: FieldRecord; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
+  const [practicalPassed, setPracticalPassed] = useState(false);
+  const [practicalNotes, setPracticalNotes] = useState("");
+  const [rewardType, setRewardType] = useState("none");
+  const [rewardDescription, setRewardDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+  async function decide(decision: "approved" | "declined") {
+    setSaving(true); onError(null);
+    try { await fieldOperationsApi.decideMilestone(record.id, { decision, practical_passed: practicalPassed, practical_notes: practicalNotes, reward_type: rewardType, reward_description: rewardDescription || null }); await onSaved(); }
+    catch (current) { onError(current instanceof Error ? current.message : "Unable to save milestone decision."); }
+    finally { setSaving(false); }
+  }
+  return <div className="rounded-md border border-iron-100 p-4"><div className="font-semibold text-iron-950">{String(record.details.employee_name)} — {String(record.details.milestone_name)}</div><div className="mt-1 text-sm text-iron-500">Written score: {String(record.details.written_score)}%</div><label className="mt-3 flex items-center gap-2 text-sm"><input type="checkbox" checked={practicalPassed} onChange={(event) => setPracticalPassed(event.target.checked)} />Practical assessment observed and passed</label><div className="mt-3 grid gap-3 md:grid-cols-3"><Input label="Practical notes" value={practicalNotes} onChange={setPracticalNotes} /><Select label="Optional reward" value={rewardType} onChange={setRewardType} options={[["none", "No reward"], ["bonus", "Bonus"], ["gift", "Gift"], ["training", "Training opportunity"], ["paid_time", "Paid time"], ["other", "Other"]]} /><Input label="Reward description" value={rewardDescription} onChange={setRewardDescription} /></div><div className="mt-3 flex gap-2"><button type="button" disabled={saving || !practicalPassed || !record.details.written_passed} onClick={() => void decide("approved")} className="rounded-md bg-brand-gold px-3 py-2 text-sm font-semibold text-brand-black disabled:opacity-50">Approve and recognize</button><button type="button" disabled={saving} onClick={() => void decide("declined")} className="rounded-md border border-iron-100 px-3 py-2 text-sm font-semibold">Decline</button></div></div>;
 }
 
 function TimeEntryForm({ data, mode, onSaved, onError }: { data: FieldOperationsBootstrap; mode: "employee" | "operator" | "foreman_crew"; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -250,3 +250,84 @@ def test_material_movement_rejects_missing_or_zero_quantities() -> None:
         },
     )
     assert response.status_code == 422
+
+
+def test_milestone_requires_written_and_practical_pass_before_recognition() -> None:
+    employee = _employee()
+    review = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "milestone_review",
+            "employee_id": employee["id"],
+            "work_date": str(date.today()),
+            "title": "Milestone review — Green Hat Operator",
+            "details": {
+                "milestone_id": "operator_green_hat",
+                "written_answers": {"inspection": 0, "stability": 0, "signals": 1, "loading": 0, "shutdown": 1},
+            },
+        },
+    )
+    assert review.status_code == 201
+    assert review.json()["status"] == "practical_pending"
+    assert review.json()["details"]["written_score"] == 100
+
+    blocked = client.post(
+        f"/api/v1/field-operations/records/{review.json()['id']}/milestone-decision",
+        json={"decision": "approved", "practical_passed": False},
+    )
+    assert blocked.status_code == 400
+
+    approved = client.post(
+        f"/api/v1/field-operations/records/{review.json()['id']}/milestone-decision",
+        json={
+            "decision": "approved",
+            "practical_passed": True,
+            "practical_notes": "Safely completed the observed operating checklist.",
+            "reward_type": "training",
+            "reward_description": "Advanced excavator training day",
+        },
+    )
+    assert approved.status_code == 200
+    assert approved.json()["status"] == "approved"
+    recognitions = client.get("/api/v1/field-operations/bootstrap").json()["milestone_recognitions"]
+    assert recognitions[0]["employee_name"] == "Crew Member"
+    assert recognitions[0]["milestone_name"] == "Green Hat Operator"
+
+
+def test_failed_written_milestone_test_requires_retry() -> None:
+    employee = _employee()
+    review = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "milestone_review",
+            "employee_id": employee["id"],
+            "work_date": str(date.today()),
+            "title": "Milestone review — Skilled Labourer",
+            "details": {
+                "milestone_id": "civil_skilled_labourer",
+                "written_answers": {"hazard": 0, "grade": 1, "paperwork": 2, "utility": 0, "compaction": 2},
+            },
+        },
+    )
+    assert review.status_code == 201
+    assert review.json()["status"] == "written_retry_required"
+    assert review.json()["details"]["written_passed"] is False
+
+
+def test_bootstrap_exposes_milestone_ladders_and_on_time_paperwork_recognition() -> None:
+    employee = _employee()
+    project = _project()
+    entry = client.post(
+        "/api/v1/field-operations/time-entries",
+        json={
+            "employee_id": employee["id"], "project_id": project["id"], "cost_code": "02-200",
+            "work_date": str(date.today()), "regular_hours": 8, "entry_type": "employee",
+        },
+    )
+    assert entry.status_code == 201
+    bootstrap = client.get("/api/v1/field-operations/bootstrap").json()
+    names = {item["name"] for item in bootstrap["milestone_catalog"]}
+    assert "Foreman" in names
+    assert "Fine Finish Operator" in names
+    paperwork = next(item for item in bootstrap["paperwork_recognitions"] if item["employee_id"] == employee["id"])
+    assert paperwork["on_time_days"] == 1


### PR DESCRIPTION
## Outcome
Adds career milestone review and recognition sections to the Employee, Operator, and Foreman portals.

## Career ladders
- Civil: Green Hat Rookie through Foreman
- Operator: Green Hat Operator through Fine Finish Operator

## Controls
- Employees self-nominate for a milestone
- Original Iron House written assessment requires 80%
- Practical checklist requires management observation
- Only administrators and operations managers can approve or decline
- Optional bonus, gift, training, paid-time, or other reward remains a management decision
- Approval creates company recognition
- On-time time entries and employee-linked field forms create paperwork recognition

## Source framework
Original assessment content is grounded in official SkilledTradesBC Heavy Equipment Operator and Construction Craft Worker competency areas and WorkSafeBC new-worker training and supervision requirements. It does not copy or replace regulated certification exams.

## Validation
- 125 backend tests passed
- Written pass/fail, practical gate, approval, recognition, ladders, and paperwork tests added
- Visual design lock passed
- Clean diff check passed

No migration or automatic financial award is included.