### PR TITLE
Build 224: role-scoped portal dashboards

### DIFF
--- a/backend/app/api/v1/routes/field_operations.py
+++ b/backend/app/api/v1/routes/field_operations.py
@@ -31,13 +31,13 @@ DBSession = Annotated[Session, Depends(get_db)]
 
 
 @router.get("/bootstrap", response_model=FieldOperationsBootstrap)
-def bootstrap(db: DBSession) -> FieldOperationsBootstrap:
-    return field_operations.get_bootstrap(db)
+def bootstrap(db: DBSession, user: CurrentUser) -> FieldOperationsBootstrap:
+    return field_operations.get_bootstrap(db, user)
 
 
 @router.post("/employees", response_model=EmployeeRead, status_code=status.HTTP_201_CREATED)
-def create_employee(payload: EmployeeCreate, db: DBSession) -> EmployeeRead:
-    return field_operations.create_employee(db, payload)
+def create_employee(payload: EmployeeCreate, db: DBSession, user: CurrentUser) -> EmployeeRead:
+    return field_operations.create_employee(db, payload, user)
 
 
 @router.post("/certifications", response_model=CertificationRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -20,6 +20,7 @@ RecordType = Literal[
     "material_quantity",
     "material_movement",
     "milestone_review",
+    "small_equipment_inspection",
     "subcontractor",
     "rental_equipment",
     "weather",
@@ -39,6 +40,8 @@ class EmployeeCreate(BaseModel):
     hire_date: date | None = None
     portal_role: PortalRole = "employee"
     notes: str | None = None
+    provision_portal_access: bool = Field(default=True, exclude=True)
+    temporary_password: str | None = Field(default=None, min_length=12, max_length=512, exclude=True)
 
 
 class EmployeeRead(EmployeeCreate):
@@ -48,6 +51,8 @@ class EmployeeRead(EmployeeCreate):
     status: str
     created_at: datetime
     updated_at: datetime
+    portal_access_created: bool = False
+    temporary_password: str | None = None
 
 
 class CertificationCreate(BaseModel):

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date, datetime, timedelta
+import secrets
 from uuid import UUID
 
 from sqlalchemy import select
@@ -11,7 +12,7 @@ from app.models.bid import Bid
 from app.models.field_operations import EmployeeCertification, FieldRecord, TimeEntry, Vehicle, VehicleLog
 from app.models.project import Project
 from app.models.supplier import Supplier
-from app.models.user import Employee
+from app.models.user import Employee, UserAccount
 from app.schemas.field_operations import (
     CertificationCreate,
     CertificationRead,
@@ -31,7 +32,7 @@ from app.schemas.field_operations import (
     VehicleRead,
     VehicleUpdate,
 )
-from app.services.auth import AuthenticatedUser
+from app.services.auth import AuthenticatedUser, hash_password
 from app.services.cost_codes import get_cost_code_library
 
 
@@ -88,8 +89,10 @@ MILESTONE_QUESTIONS = {
 }
 
 
-def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
+def get_bootstrap(db: Session, user: AuthenticatedUser) -> FieldOperationsBootstrap:
     employees = list(db.scalars(select(Employee).order_by(Employee.last_name, Employee.first_name)))
+    profile = next((item for item in employees if item.email.lower() == user.email.lower()), None)
+    field_role = profile.portal_role if profile else None
     projects = list(db.scalars(select(Project).order_by(Project.name)))
     suppliers = list(db.scalars(select(Supplier).order_by(Supplier.name)))
     equipment = list(db.scalars(select(Equipment).order_by(Equipment.name)))
@@ -102,6 +105,14 @@ def get_bootstrap(db: Session) -> FieldOperationsBootstrap:
     material_movement_summary = build_material_movement_summary(db)
     milestone_recognitions = build_milestone_recognitions(db)
     paperwork_recognitions = build_paperwork_recognitions(db, employees)
+    if user.role == "viewer" and field_role in {"employee", "operator"}:
+        employee_id = profile.id if profile else None
+        employees = [profile] if profile else []
+        time_entries = [item for item in time_entries if item.employee_id == employee_id]
+        records = [item for item in records if item.employee_id == employee_id or item.record_type == "toolbox_talk"]
+        certifications = [item for item in certifications if item.employee_id == employee_id]
+        milestone_recognitions = [item for item in milestone_recognitions if item["employee_id"] == str(employee_id)]
+        paperwork_recognitions = [item for item in paperwork_recognitions if item["employee_id"] == str(employee_id)]
     alerts = build_alerts(vehicles, records, certifications)
     return FieldOperationsBootstrap(
         employees=[EmployeeRead.model_validate(item) for item in employees],
@@ -240,12 +251,20 @@ def build_job_workbooks(db: Session) -> tuple[list[dict], list[dict]]:
     return workbooks, production_items
 
 
-def create_employee(db: Session, payload: EmployeeCreate) -> EmployeeRead:
+def create_employee(db: Session, payload: EmployeeCreate, user: AuthenticatedUser) -> EmployeeRead:
+    if user.role not in {"admin", "operations_manager"}:
+        raise AppError("Management access is required to create employees.", status_code=403)
     item = Employee(**payload.model_dump(), status="active")
     db.add(item)
     commit(db, "An employee with that email already exists.")
     db.refresh(item)
-    return EmployeeRead.model_validate(item)
+    temporary_password = payload.temporary_password or secrets.token_urlsafe(14)
+    access_created = False
+    if payload.provision_portal_access and db.scalar(select(UserAccount).where(UserAccount.email.ilike(item.email))) is None:
+        db.add(UserAccount(email=item.email.lower(), display_name=f"{item.first_name} {item.last_name}", role="viewer", password_hash=hash_password(temporary_password), is_active=True, password_reset_required=True))
+        commit(db)
+        access_created = True
+    return EmployeeRead.model_validate(item).model_copy(update={"portal_access_created": access_created, "temporary_password": temporary_password if access_created else None})
 
 
 def create_certification(db: Session, payload: CertificationCreate) -> CertificationRead:

--- a/docs/builds/BUILD_224.md
+++ b/docs/builds/BUILD_224.md
@@ -1,0 +1,14 @@
+# Build 224 — Role-scoped portal dashboards
+
+## Outcome
+
+Employee, Operator and Foreman accounts see only their assigned portal. Each portal opens as a dashboard of linked workspaces instead of one long page. Direct company-module URLs redirect field users back to their own portal.
+
+## Included
+
+- Employee data and record scoping for employee/operator viewer accounts
+- Automatic linked portal-account provisioning when management creates an employee
+- Mandatory first-login password change for new portal accounts
+- Dedicated time, journal/forms, safety, milestones, loads, production, profile and records pages by role
+- Small equipment inspections for saws, compactors, pumps, generators, lasers and power tools
+- Unsafe equipment severity routing to Jeremie and Mac

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useParams } from "react-router-dom";
 
 import { AppLayout } from "./components/AppLayout";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
@@ -31,8 +31,12 @@ import { SettingsPage } from "./pages/SettingsPage";
 import { SupplierDatabasePage } from "./pages/SupplierDatabasePage";
 import { TenderIntakePage } from "./pages/TenderIntakePage";
 
+function EmployeePortalRoute() { return <EmployeePortalPage section={useParams().section} />; }
+function ForemanPortalRoute() { return <ForemanPortalPage section={useParams().section} />; }
+function OperatorPortalRoute() { return <OperatorPortalPage section={useParams().section} />; }
+
 function AuthenticatedApp() {
-  const { user, isLoading } = useAuth();
+  const { user, portalRole, isLoading } = useAuth();
   if (isLoading) {
     return (
       <main className="grid min-h-screen place-items-center bg-iron-950 text-sm font-medium text-white">
@@ -43,14 +47,24 @@ function AuthenticatedApp() {
   if (!user) return <LoginPage />;
   if (user.password_reset_required) return <PasswordRecoveryPage />;
 
+  if (user.role === "viewer") {
+    const root = `/${portalRole ?? "employee"}-portal`;
+    const sections = portalRole === "foreman" ? ["time", "production", "loads", "forms", "safety", "milestones", "small-equipment", "records"] : portalRole === "operator" ? ["time", "loads", "inspections", "small-equipment", "photos", "milestones", "records"] : ["time", "journal", "schedule", "safety", "milestones", "small-equipment", "profile", "records"];
+    const Page = portalRole === "foreman" ? ForemanPortalPage : portalRole === "operator" ? OperatorPortalPage : EmployeePortalPage;
+    return <AppLayout><Routes><Route path={root} element={<Page />} />{sections.map((section) => <Route key={section} path={`${root}/${section}`} element={<Page section={section} />} />)}<Route path="*" element={<Navigate to={root} replace />} /></Routes></AppLayout>;
+  }
+
   return (
     <AppLayout>
       <Routes>
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/employee-portal" element={<EmployeePortalPage />} />
+        <Route path="/employee-portal/:section" element={<EmployeePortalRoute />} />
         <Route path="/foreman-portal" element={<ForemanPortalPage />} />
+        <Route path="/foreman-portal/:section" element={<ForemanPortalRoute />} />
         <Route path="/operator-portal" element={<OperatorPortalPage />} />
+        <Route path="/operator-portal/:section" element={<OperatorPortalRoute />} />
         <Route path="/vehicle-tracking" element={<VehicleTrackingPage />} />
         <Route path="/mvp-workflow" element={<MVPWorkflowPage />} />
         <Route path="/project-operations" element={<ProjectOperationsPage />} />

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -8,7 +8,7 @@ import { modulePathWithProjectContext, readEffectiveProjectContext } from "../ut
 
 export function AppLayout({ children }: PropsWithChildren) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const { user, logout } = useAuth();
+  const { user, portalRole, logout } = useAuth();
   const location = useLocation();
   const activeProject = readEffectiveProjectContext(location.search);
   const accessLabel =
@@ -35,7 +35,10 @@ export function AppLayout({ children }: PropsWithChildren) {
           </div>
         </div>
         <nav className="flex-1 space-y-1 overflow-y-auto p-3" aria-label="Primary navigation">
-          {modules.map((module) => {
+          {modules.filter((module) => {
+            if (user?.role !== "viewer") return true;
+            return module.path === `/${portalRole ?? "employee"}-portal`;
+          }).map((module) => {
             const Icon = module.icon;
             return (
               <NavLink

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -2,10 +2,14 @@ import { PropsWithChildren, createContext, useCallback, useContext, useEffect, u
 
 import { AuthUser, authApi } from "../api/auth";
 import { AUTH_SESSION_EXPIRED_EVENT } from "../api/client";
+import { fieldOperationsApi } from "../api/fieldOperations";
+
+export type PortalRole = "employee" | "operator" | "foreman" | "management" | null;
 
 type AuthContextValue = {
   user: AuthUser | null;
   isLoading: boolean;
+  portalRole: PortalRole;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
@@ -16,13 +20,23 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: PropsWithChildren) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [portalRole, setPortalRole] = useState<PortalRole>(null);
+
+  const resolvePortalRole = useCallback(async (account: AuthUser | null) => {
+    if (!account) { setPortalRole(null); return; }
+    if (account.role !== "viewer") { setPortalRole("management"); return; }
+    try {
+      const field = await fieldOperationsApi.bootstrap();
+      setPortalRole(field.employees.find((item) => item.email.toLowerCase() === account.email.toLowerCase())?.portal_role ?? "employee");
+    } catch { setPortalRole("employee"); }
+  }, []);
 
   useEffect(() => {
     let active = true;
     authApi
       .me()
       .then((account) => {
-        if (active) setUser(account);
+        if (active) { setUser(account); return resolvePortalRole(account); }
       })
       .catch(() => {
         if (active) setUser(null);
@@ -33,7 +47,7 @@ export function AuthProvider({ children }: PropsWithChildren) {
     return () => {
       active = false;
     };
-  }, []);
+  }, [resolvePortalRole]);
 
   useEffect(() => {
     const expireSession = () => setUser(null);
@@ -42,14 +56,15 @@ export function AuthProvider({ children }: PropsWithChildren) {
   }, []);
 
   const login = useCallback(async (email: string, password: string) => {
-    setUser(await authApi.login(email, password));
-  }, []);
+    const account = await authApi.login(email, password); setUser(account); await resolvePortalRole(account);
+  }, [resolvePortalRole]);
 
   const logout = useCallback(async () => {
     try {
       await authApi.logout();
     } finally {
       setUser(null);
+      setPortalRole(null);
     }
   }, []);
 
@@ -58,8 +73,8 @@ export function AuthProvider({ children }: PropsWithChildren) {
   }, []);
 
   const value = useMemo(
-    () => ({ user, isLoading, login, logout, changePassword }),
-    [changePassword, isLoading, login, logout, user],
+    () => ({ user, isLoading, portalRole, login, logout, changePassword }),
+    [changePassword, isLoading, login, logout, portalRole, user],
   );
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/frontend/src/pages/EmployeePortalPage.test.tsx
+++ b/frontend/src/pages/EmployeePortalPage.test.tsx
@@ -1,19 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 
 import { EmployeePortalPage } from "./EmployeePortalPage";
 
 describe("EmployeePortalPage", () => {
-  it("gives employees access to the controlled safety program", () => {
-    render(<EmployeePortalPage />);
+  it("presents separate linked workspaces instead of one long employee page", () => {
+    render(<MemoryRouter><EmployeePortalPage /></MemoryRouter>);
 
     expect(screen.getByRole("heading", { name: "Employee Portal" })).toBeInTheDocument();
-    const safetyLink = screen.getByRole("link", { name: /open safety program/i });
-    expect(safetyLink).toHaveAttribute(
-      "href",
-      "https://docs.google.com/document/d/1ApKQs4xIR8axW0lIaeqqATDVaZWs1jvSzaZwYK6wUNw/edit?usp=drivesdk",
-    );
-    expect(safetyLink).toHaveAttribute("target", "_blank");
-    expect(screen.getByText(/revision 1.1 incorporates current british columbia/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /my time/i })).toHaveAttribute("href", "/employee-portal/time");
+    expect(screen.getByRole("link", { name: /safety and toolbox talks/i })).toHaveAttribute("href", "/employee-portal/safety");
+    expect(screen.getByRole("link", { name: /small equipment inspections/i })).toHaveAttribute("href", "/employee-portal/small-equipment");
   });
 });

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -18,6 +18,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { FormEvent, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { documentsApi } from "../api/documents";
 import { useAuth } from "../contexts/AuthContext";
@@ -131,21 +132,23 @@ export function VehicleTrackingPage() {
   );
 }
 
-export function ForemanPortalPage() {
+export function ForemanPortalPage({ section = "dashboard" }: { section?: string }) {
   const state = useFieldOperations();
   return (
     <PortalShell title="Foreman Portal" eyebrow="Field command centre" description="Crew time, daily records, vendors, quantities, weather, safety and production evidence." icon={<HardHat />}>
       <Status state={state} />
+      {section === "dashboard" ? <PortalSectionDashboard root="foreman-portal" items={[["time", "Crew timesheet"], ["production", "Job production"], ["loads", "Materials and loads"], ["forms", "Field forms and photos"], ["safety", "Safety and toolbox talks"], ["milestones", "Milestones and recognition"], ["small-equipment", "Small equipment inspections"], ["records", "Recent records"]]} /> : null}
       {state.data ? (
         <>
           <AlertStrip alerts={state.data.alerts} />
-          <JobWorkbookCard data={state.data} onSaved={state.refresh} onError={state.setError} />
-          <MaterialMovementCard data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} />
-          <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} />
-          <TimeEntryForm data={state.data} mode="foreman_crew" onSaved={state.refresh} onError={state.setError} />
-          <RecordForm data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} />
-          <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} />
-          <RecentRecords records={state.data.records} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} />
+          {section === "production" ? <JobWorkbookCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "loads" ? <MaterialMovementCard data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "milestones" ? <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "time" ? <TimeEntryForm data={state.data} mode="foreman_crew" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "forms" ? <RecordForm data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "safety" ? <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "small-equipment" ? <SmallEquipmentInspectionCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "records" ? <RecentRecords records={state.data.records} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} /> : null}
         </>
       ) : null}
     </PortalShell>
@@ -263,39 +266,43 @@ function JobWorkbookCard({ data, onSaved, onError }: { data: FieldOperationsBoot
   );
 }
 
-export function OperatorPortalPage() {
+export function OperatorPortalPage({ section = "dashboard" }: { section?: string }) {
   const state = useFieldOperations();
   return (
     <PortalShell title="Operator Portal" eyebrow="Equipment and time" description="Cost-coded time, machine inspections, service alerts, job photos and employee requests." icon={<Wrench />}>
       <Status state={state} />
+      {section === "dashboard" ? <PortalSectionDashboard root="operator-portal" items={[["time", "Time tracking"], ["loads", "Load tracker"], ["inspections", "Machine inspections"], ["small-equipment", "Small equipment inspections"], ["photos", "Job photos and requests"], ["milestones", "Milestones and recognition"], ["records", "Recent records"]]} /> : null}
       {state.data ? (
         <>
           <AlertStrip alerts={state.data.alerts} />
-          <MaterialMovementCard data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} />
-          <MilestoneCard data={state.data} track="operator" onSaved={state.refresh} onError={state.setError} />
-          <TimeEntryForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} />
-          <RecordForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} />
-          <RecentRecords records={state.data.records.filter((item) => ["material_movement", "equipment_inspection", "job_photo", "time_off_request", "performance_review"].includes(item.record_type))} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} />
+          {section === "loads" ? <MaterialMovementCard data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "milestones" ? <MilestoneCard data={state.data} track="operator" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "time" ? <TimeEntryForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} /> : null}
+          {["inspections", "photos"].includes(section) ? <RecordForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "small-equipment" ? <SmallEquipmentInspectionCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "records" ? <RecentRecords records={state.data.records.filter((item) => ["material_movement", "equipment_inspection", "small_equipment_inspection", "job_photo", "time_off_request", "performance_review"].includes(item.record_type))} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} /> : null}
         </>
       ) : null}
     </PortalShell>
   );
 }
 
-export function EmployeePortalPage() {
+export function EmployeePortalPage({ section = "dashboard" }: { section?: string }) {
   const state = useFieldOperations();
   return (
     <PortalShell title="Employee Portal" eyebrow="Iron House Contracting" description="Time, daily journal, safety, job photos, requests, contact information and course tickets." icon={<HardHat />}>
       <Status state={state} />
-      <SafetyProgramCard />
+      {section === "dashboard" ? <PortalSectionDashboard root="employee-portal" items={[["time", "My time"], ["journal", "Journal and photos"], ["schedule", "Schedule and requests"], ["safety", "Safety and toolbox talks"], ["milestones", "Milestones and recognition"], ["small-equipment", "Small equipment inspections"], ["profile", "My profile and tickets"], ["records", "My records"]]} /> : null}
+      {section === "safety" ? <SafetyProgramCard /> : null}
       {state.data ? (
         <>
-          <TimeEntryForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} />
-          <RecordForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} />
-          <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} />
-          <EmployeeDirectory data={state.data} />
-          <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} />
-          <RecentRecords records={state.data.records} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} />
+          {section === "time" ? <TimeEntryForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} /> : null}
+          {["journal", "schedule"].includes(section) ? <RecordForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "milestones" ? <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "profile" ? <EmployeeDirectory data={state.data} /> : null}
+          {section === "safety" ? <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "small-equipment" ? <SmallEquipmentInspectionCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "records" ? <RecentRecords records={state.data.records} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} /> : null}
         </>
       ) : null}
     </PortalShell>
@@ -348,6 +355,32 @@ function MilestoneCard({ data, track, onSaved, onError }: { data: FieldOperation
       {isManagement && pending.length ? <div className="mt-5"><div className="font-semibold text-iron-950">Management milestone reviews</div><div className="mt-3 grid gap-3">{pending.map((item) => <MilestoneDecisionControls key={item.id} record={item} onSaved={onSaved} onError={onError} />)}</div></div> : null}
     </section>
   );
+}
+
+function PortalSectionDashboard({ root, items }: { root: string; items: string[][] }) {
+  return <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm"><SectionTitle icon={<ClipboardCheck />} title="Portal dashboard" subtitle="Open one workspace at a time for more room to enter notes, comments, photos and details." /><div className="mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{items.map(([path, label]) => <Link key={path} to={`/${root}/${path}`} className="rounded-xl border border-brand-gold/30 bg-iron-50 p-5 transition hover:border-brand-gold hover:bg-brand-gold/10"><div className="font-semibold text-iron-950">{label}</div><div className="mt-2 text-sm text-iron-500">Open workspace</div></Link>)}</div></section>;
+}
+
+function SmallEquipmentInspectionCard({ data, onSaved, onError }: { data: FieldOperationsBootstrap; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
+  const [employeeId, setEmployeeId] = useState(data.employees.length === 1 ? data.employees[0].id : "");
+  const [projectId, setProjectId] = useState("");
+  const [equipmentType, setEquipmentType] = useState("");
+  const [identifier, setIdentifier] = useState("");
+  const [condition, setCondition] = useState("serviceable");
+  const [notes, setNotes] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [saving, setSaving] = useState(false);
+  async function submit(event: FormEvent) {
+    event.preventDefault(); if (!employeeId || !equipmentType) return;
+    setSaving(true); onError(null);
+    try {
+      const documentIds = await uploadPhotos(files, projectId || undefined, "Small equipment inspection");
+      await fieldOperationsApi.createRecord({ record_type: "small_equipment_inspection", employee_id: employeeId, project_id: projectId || null, work_date: today(), title: equipmentType + (identifier ? " — " + identifier : ""), severity: condition === "serviceable" ? "none" : condition === "remove_from_service" ? "high" : "medium", details: { equipment_type: equipmentType, identifier, condition, notes, checks: ["guards", "controls", "cords_or_hoses", "fuel_or_battery", "general_condition"] }, document_ids: documentIds });
+      setIdentifier(""); setNotes(""); setFiles([]); setCondition("serviceable"); await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to save small equipment inspection."); }
+    finally { setSaving(false); }
+  }
+  return <form onSubmit={submit} className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm"><SectionTitle icon={<Wrench />} title="Small equipment inspection" subtitle="Inspect saws, compactors, pumps, generators, lasers and power tools before use. Flagged items alert management." /><div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3"><Select label="Employee" value={employeeId} onChange={setEmployeeId} required options={employeeOptions(data.employees)} /><Select label="Project" value={projectId} onChange={setProjectId} options={data.projects.map((item) => [item.id, item.name])} /><Select label="Equipment type" value={equipmentType} onChange={setEquipmentType} required options={[["Cut-off saw", "Cut-off saw"], ["Chainsaw", "Chainsaw"], ["Plate compactor", "Plate compactor"], ["Jumping jack", "Jumping jack"], ["Pump", "Pump"], ["Generator", "Generator"], ["Laser / level", "Laser / level"], ["Power tool", "Power tool"], ["Other", "Other"]]} /><Input label="Asset number / description" value={identifier} onChange={setIdentifier} /><Select label="Condition" value={condition} onChange={setCondition} options={[["serviceable", "Serviceable"], ["monitor", "Monitor / repair soon"], ["remove_from_service", "Remove from service"]]} /><Input label="Inspection comments" value={notes} onChange={setNotes} /><FilePicker files={files} onChange={setFiles} /></div><div className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-600">Check guards, controls, cords or hoses, fuel or battery condition, leaks, damage and overall safe operation.</div><PrimaryButton disabled={saving || !employeeId || !equipmentType}>{saving ? "Saving…" : "Submit inspection"}</PrimaryButton></form>;
 }
 
 function MilestoneDecisionControls({ record, onSaved, onError }: { record: FieldRecord; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {

--- a/frontend/visual-design-lock.json
+++ b/frontend/visual-design-lock.json
@@ -11,7 +11,7 @@
     "frontend/public/icon-512.png": "410c16b7f12ce56ff98c4bce34dbe234c53bde79726c1498abceac68ac06fc82",
     "frontend/public/os-logo-256.png": "ee3d1cc318206fcce1e038fc97631f1bf09f56d7162c47ea8bbb7917cf8a74e3",
     "frontend/public/site.webmanifest": "1de7d6a57ba4976412f4f3923862c9d7e8037a10b0d3bba9a636395ef06bdce3",
-    "frontend/src/components/AppLayout.tsx": "45a72b9de0847dfbb7c56027ddce3037bd6724904866b49caf654b8a3229dde6",
+    "frontend/src/components/AppLayout.tsx": "bdd21fc104dfff16369d5de7d677ea423772bbd7045fe1b3dc2f1e7f4b011482",
     "frontend/src/pages/DashboardPage.tsx": "c8fb703a5c2014231c7934205d18cce247a15a805b73624fa21463225dd5649a",
     "frontend/src/pages/LoginPage.tsx": "8cc96693579ea7e18e3fa34b456f259ad47b8479230df8c04bf7de50e3b510fe",
     "frontend/src/styles.css": "d0ed7ee59b1690db07d4d70193cfbf1f3f80d6a5084edfedad786817de4ce58d",

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -1,8 +1,12 @@
 from datetime import date, timedelta
 
 from fastapi.testclient import TestClient
+from fastapi import Request
+from uuid import UUID
 
 from app.main import app
+from app.api.dependencies.auth import require_authenticated_user
+from app.services.auth import AuthenticatedUser
 
 
 client = TestClient(app)
@@ -331,3 +335,46 @@ def test_bootstrap_exposes_milestone_ladders_and_on_time_paperwork_recognition()
     assert "Fine Finish Operator" in names
     paperwork = next(item for item in bootstrap["paperwork_recognitions"] if item["employee_id"] == employee["id"])
     assert paperwork["on_time_days"] == 1
+
+
+def test_employee_creation_provisions_a_password_change_required_portal_account() -> None:
+    response = client.post(
+        "/api/v1/field-operations/employees",
+        json={"first_name": "New", "last_name": "Worker", "email": "new.worker@ironhousecivil.com", "portal_role": "employee"},
+    )
+    assert response.status_code == 201
+    assert response.json()["portal_access_created"] is True
+    temporary_password = response.json()["temporary_password"]
+    assert len(temporary_password) >= 12
+    login = client.post("/api/v1/auth/login", json={"email": "new.worker@ironhousecivil.com", "password": temporary_password})
+    assert login.status_code == 200
+    assert login.json()["user"]["password_reset_required"] is True
+
+
+def test_employee_bootstrap_is_limited_to_own_records() -> None:
+    own = _employee()
+    other = client.post(
+        "/api/v1/field-operations/employees",
+        json={"first_name": "Other", "last_name": "Worker", "email": "other.worker@ironhousecivil.com", "portal_role": "employee"},
+    ).json()
+
+    def employee_user(request: Request) -> AuthenticatedUser:
+        user = AuthenticatedUser(id=UUID("00000000-0000-0000-0000-000000000009"), email=own["email"], display_name="Crew Member", role="viewer", session_version=1)
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = employee_user
+    bootstrap = client.get("/api/v1/field-operations/bootstrap")
+    assert bootstrap.status_code == 200
+    assert [item["id"] for item in bootstrap.json()["employees"]] == [own["id"]]
+    assert other["id"] not in {item["id"] for item in bootstrap.json()["employees"]}
+
+
+def test_small_equipment_inspection_flags_unsafe_saw_for_management() -> None:
+    employee = _employee()
+    record = client.post(
+        "/api/v1/field-operations/records",
+        json={"record_type": "small_equipment_inspection", "employee_id": employee["id"], "work_date": str(date.today()), "title": "Cut-off saw — SAW-01", "severity": "high", "details": {"equipment_type": "Cut-off saw", "condition": "remove_from_service", "notes": "Guard damaged"}},
+    )
+    assert record.status_code == 201
+    assert record.json()["alert_recipients"] == ["Jeremie Peters", "Mac Warren"]


### PR DESCRIPTION
## Summary
- give each employee, operator, and foreman a dedicated role-scoped portal and block company module navigation for viewer accounts
- split portal tools into linked dashboard workspaces with room for notes, photos, and records
- automatically provision a private viewer login when management creates an employee
- limit employee/operator bootstrap records to the signed-in worker
- add small-equipment inspections for saws, compactors, pumps, generators, lasers, and power tools with management alerts for unsafe conditions

## Validation
- 128 backend tests passed
- 21 frontend tests passed
- TypeScript/Vite production build passed
- visual design lock passed
- git diff check passed