### PR TITLE
Build 225: crew scheduling and time-off workflow

### DIFF
--- a/backend/app/api/v1/routes/field_operations.py
+++ b/backend/app/api/v1/routes/field_operations.py
@@ -18,6 +18,7 @@ from app.schemas.field_operations import (
     SignatureCreate,
     TimeEntryCreate,
     TimeEntryRead,
+    TimeOffDecision,
     VehicleCreate,
     VehicleLogCreate,
     VehicleLogRead,
@@ -88,3 +89,13 @@ def decide_milestone(
     user: CurrentUser,
 ) -> FieldRecordRead:
     return field_operations.decide_milestone(db, record_id, payload, user)
+
+
+@router.post("/records/{record_id}/time-off-decision", response_model=FieldRecordRead)
+def decide_time_off(
+    record_id: UUID,
+    payload: TimeOffDecision,
+    db: DBSession,
+    user: CurrentUser,
+) -> FieldRecordRead:
+    return field_operations.decide_time_off(db, record_id, payload, user)

--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -16,6 +16,7 @@ RecordType = Literal[
     "daily_hazard_assessment",
     "toolbox_talk",
     "time_off_request",
+    "crew_shift",
     "performance_review",
     "material_quantity",
     "material_movement",
@@ -193,21 +194,33 @@ class FieldRecordCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_material_movement(self) -> "FieldRecordCreate":
-        if self.record_type != "material_movement":
-            return self
-        direction = self.details.get("direction")
-        material_type = str(self.details.get("material_type") or "").strip()
-        try:
-            loads = float(self.details.get("loads") or 0)
-            total_tonnes = float(self.details.get("total_tonnes") or 0)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("Loads and total tonnes must be numbers.") from exc
-        if direction not in {"imported", "exported"}:
-            raise ValueError("Material direction must be imported or exported.")
-        if not material_type:
-            raise ValueError("Select a material type.")
-        if loads <= 0 or total_tonnes <= 0:
-            raise ValueError("Loads and total tonnes must be greater than zero.")
+        if self.record_type == "material_movement":
+            direction = self.details.get("direction")
+            material_type = str(self.details.get("material_type") or "").strip()
+            try:
+                loads = float(self.details.get("loads") or 0)
+                total_tonnes = float(self.details.get("total_tonnes") or 0)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("Loads and total tonnes must be numbers.") from exc
+            if direction not in {"imported", "exported"}:
+                raise ValueError("Material direction must be imported or exported.")
+            if not material_type:
+                raise ValueError("Select a material type.")
+            if loads <= 0 or total_tonnes <= 0:
+                raise ValueError("Loads and total tonnes must be greater than zero.")
+        if self.record_type == "crew_shift":
+            if not self.employee_id or not self.project_id:
+                raise ValueError("Crew shifts require an employee and project.")
+            if not self.details.get("start_time") or not self.details.get("end_time"):
+                raise ValueError("Crew shifts require start and end times.")
+        if self.record_type == "time_off_request":
+            try:
+                start = date.fromisoformat(str(self.details.get("start_date") or ""))
+                end = date.fromisoformat(str(self.details.get("end_date") or ""))
+            except ValueError as exc:
+                raise ValueError("Time-off requests require valid start and end dates.") from exc
+            if end < start:
+                raise ValueError("Time-off end date cannot be before the start date.")
         return self
 
 
@@ -233,6 +246,11 @@ class MilestoneDecision(BaseModel):
     practical_notes: str | None = None
     reward_type: Literal["none", "bonus", "gift", "training", "paid_time", "other"] = "none"
     reward_description: str | None = None
+
+
+class TimeOffDecision(BaseModel):
+    decision: Literal["approved", "declined"]
+    management_notes: str | None = Field(default=None, max_length=2000)
 
 
 class ToolboxTalk(BaseModel):

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -23,6 +23,7 @@ from app.schemas.field_operations import (
     FieldRecordRead,
     MilestoneDecision,
     SignatureCreate,
+    TimeOffDecision,
     TimeEntryCreate,
     TimeEntryRead,
     ToolboxTalk,
@@ -309,7 +310,10 @@ def create_vehicle_log(db: Session, payload: VehicleLogCreate) -> VehicleLogRead
 
 
 def create_time_entry(db: Session, payload: TimeEntryCreate, user: AuthenticatedUser) -> TimeEntryRead:
-    require_exists(db, Employee, payload.employee_id, "Employee")
+    employee = require_exists(db, Employee, payload.employee_id, "Employee")
+    profile = db.scalar(select(Employee).where(Employee.email.ilike(user.email)))
+    if user.role == "viewer" and (profile is None or (profile.portal_role != "foreman" and employee.id != profile.id)):
+        raise AppError("You can only submit time for your own employee profile.", status_code=403)
     require_exists(db, Project, payload.project_id, "Project")
     item = TimeEntry(**payload.model_dump(), status="submitted", submitted_by=user.email)
     db.add(item)
@@ -327,6 +331,25 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
     if payload.severity in {"medium", "high", "critical"} and not alerts:
         alerts = MANAGEMENT_ALERT_RECIPIENTS
     values = payload.model_dump()
+    profile = db.scalar(select(Employee).where(Employee.email.ilike(user.email)))
+    if user.role == "viewer":
+        if profile is None:
+            raise AppError("Your employee profile is not linked to this account.", status_code=400)
+        if payload.record_type == "crew_shift" and profile.portal_role != "foreman":
+            raise AppError("Foreman access is required to schedule crews.", status_code=403)
+        if profile.portal_role in {"employee", "operator"}:
+            if payload.employee_id and payload.employee_id != profile.id:
+                raise AppError("You can only create records for your own employee profile.", status_code=403)
+            values["employee_id"] = profile.id
+    if payload.record_type == "crew_shift":
+        values["status"] = "scheduled"
+        values["details"] = {**payload.details, "scheduled_by": user.display_name, "scheduled_at": datetime.now(UTC).isoformat()}
+    if payload.record_type == "time_off_request":
+        if profile is None and not payload.employee_id:
+            raise AppError("Select an employee for the time-off request.", status_code=400)
+        values["employee_id"] = values.get("employee_id") or profile.id
+        values["status"] = "pending"
+        values["details"] = {**payload.details, "requested_by": user.display_name, "requested_at": datetime.now(UTC).isoformat()}
     if payload.record_type == "milestone_review":
         employee = require_exists(db, Employee, payload.employee_id, "Employee") if payload.employee_id else db.scalar(
             select(Employee).where(Employee.email.ilike(user.email))
@@ -358,6 +381,32 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
     values["document_ids"] = [str(document_id) for document_id in payload.document_ids]
     values["alert_recipients"] = alerts
     item = FieldRecord(**values, submitted_by=user.email)
+    db.add(item)
+    commit(db)
+    db.refresh(item)
+    return FieldRecordRead.model_validate(item)
+
+
+def decide_time_off(
+    db: Session,
+    record_id: UUID,
+    payload: TimeOffDecision,
+    user: AuthenticatedUser,
+) -> FieldRecordRead:
+    if user.role not in {"admin", "operations_manager"}:
+        raise AppError("Management access is required for time-off decisions.", status_code=403)
+    item = require_exists(db, FieldRecord, record_id, "Time-off request")
+    if item.record_type != "time_off_request":
+        raise AppError("That record is not a time-off request.", status_code=400)
+    if item.status != "pending":
+        raise AppError("That time-off request has already been decided.", status_code=409)
+    item.status = payload.decision
+    item.details = {
+        **(item.details or {}),
+        "management_notes": payload.management_notes,
+        "decision_by": user.display_name,
+        "decision_at": datetime.now(UTC).isoformat(),
+    }
     db.add(item)
     commit(db)
     db.refresh(item)

--- a/docs/builds/BUILD_225.md
+++ b/docs/builds/BUILD_225.md
@@ -1,0 +1,25 @@
+# Build 225 — Crew scheduling and time-off workflow
+
+## Outcome
+
+Iron House OS now provides a role-scoped scheduling workflow across the Foreman, Operator, and Employee portals.
+
+## Delivered
+
+- Foremen can publish a job shift to one or more selected employees with date, start/end time, meeting point, and instructions.
+- Employees and operators see only their own scheduled shifts.
+- Employees and operators can submit dated time-off requests with comments.
+- Management can approve or decline pending requests and retain decision notes and audit timestamps.
+- Viewer accounts cannot schedule crews, create another employee's records, or submit another employee's time.
+- Schedule and time-off tools have dedicated dashboard workspaces without changing the locked Iron House visual baseline.
+
+## Data and privacy boundary
+
+This build stores operational schedule and request information only. It does not add SIN, banking, medical, or payroll data.
+
+## Verification
+
+- Backend scheduling, approval, date-validation, and denial tests.
+- Full backend suite.
+- Frontend unit tests and production TypeScript/Vite build.
+- Visual design lock and release gates.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ function AuthenticatedApp() {
 
   if (user.role === "viewer") {
     const root = `/${portalRole ?? "employee"}-portal`;
-    const sections = portalRole === "foreman" ? ["time", "production", "loads", "forms", "safety", "milestones", "small-equipment", "records"] : portalRole === "operator" ? ["time", "loads", "inspections", "small-equipment", "photos", "milestones", "records"] : ["time", "journal", "schedule", "safety", "milestones", "small-equipment", "profile", "records"];
+    const sections = portalRole === "foreman" ? ["time", "schedule", "production", "loads", "forms", "safety", "milestones", "small-equipment", "records"] : portalRole === "operator" ? ["time", "schedule", "loads", "inspections", "small-equipment", "photos", "milestones", "records"] : ["time", "journal", "schedule", "safety", "milestones", "small-equipment", "profile", "records"];
     const Page = portalRole === "foreman" ? ForemanPortalPage : portalRole === "operator" ? OperatorPortalPage : EmployeePortalPage;
     return <AppLayout><Routes><Route path={root} element={<Page />} />{sections.map((section) => <Route key={section} path={`${root}/${section}`} element={<Page section={section} />} />)}<Route path="*" element={<Navigate to={root} replace />} /></Routes></AppLayout>;
   }

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -137,6 +137,8 @@ export const fieldOperationsApi = {
     request<FieldRecord>("/field-operations/records/" + id + "/sign", { method: "POST", body: JSON.stringify(payload) }),
   decideMilestone: (id: string, payload: Record<string, unknown>) =>
     request<FieldRecord>("/field-operations/records/" + id + "/milestone-decision", { method: "POST", body: JSON.stringify(payload) }),
+  decideTimeOff: (id: string, payload: Record<string, unknown>) =>
+    request<FieldRecord>("/field-operations/records/" + id + "/time-off-decision", { method: "POST", body: JSON.stringify(payload) }),
   createEmployee: (payload: Record<string, unknown>) =>
     request("/field-operations/employees", { method: "POST", body: JSON.stringify(payload) }),
   createCertification: (payload: Record<string, unknown>) =>

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -137,7 +137,7 @@ export function ForemanPortalPage({ section = "dashboard" }: { section?: string 
   return (
     <PortalShell title="Foreman Portal" eyebrow="Field command centre" description="Crew time, daily records, vendors, quantities, weather, safety and production evidence." icon={<HardHat />}>
       <Status state={state} />
-      {section === "dashboard" ? <PortalSectionDashboard root="foreman-portal" items={[["time", "Crew timesheet"], ["production", "Job production"], ["loads", "Materials and loads"], ["forms", "Field forms and photos"], ["safety", "Safety and toolbox talks"], ["milestones", "Milestones and recognition"], ["small-equipment", "Small equipment inspections"], ["records", "Recent records"]]} /> : null}
+      {section === "dashboard" ? <PortalSectionDashboard root="foreman-portal" items={[["time", "Crew timesheet"], ["schedule", "Crew schedule"], ["production", "Job production"], ["loads", "Materials and loads"], ["forms", "Field forms and photos"], ["safety", "Safety and toolbox talks"], ["milestones", "Milestones and recognition"], ["small-equipment", "Small equipment inspections"], ["records", "Recent records"]]} /> : null}
       {state.data ? (
         <>
           <AlertStrip alerts={state.data.alerts} />
@@ -145,6 +145,7 @@ export function ForemanPortalPage({ section = "dashboard" }: { section?: string 
           {section === "loads" ? <MaterialMovementCard data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "milestones" ? <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "time" ? <TimeEntryForm data={state.data} mode="foreman_crew" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "schedule" ? <CrewScheduleCard data={state.data} canSchedule onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "forms" ? <RecordForm data={state.data} mode="foreman" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "safety" ? <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "small-equipment" ? <SmallEquipmentInspectionCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
@@ -271,13 +272,14 @@ export function OperatorPortalPage({ section = "dashboard" }: { section?: string
   return (
     <PortalShell title="Operator Portal" eyebrow="Equipment and time" description="Cost-coded time, machine inspections, service alerts, job photos and employee requests." icon={<Wrench />}>
       <Status state={state} />
-      {section === "dashboard" ? <PortalSectionDashboard root="operator-portal" items={[["time", "Time tracking"], ["loads", "Load tracker"], ["inspections", "Machine inspections"], ["small-equipment", "Small equipment inspections"], ["photos", "Job photos and requests"], ["milestones", "Milestones and recognition"], ["records", "Recent records"]]} /> : null}
+      {section === "dashboard" ? <PortalSectionDashboard root="operator-portal" items={[["time", "Time tracking"], ["schedule", "My schedule and time off"], ["loads", "Load tracker"], ["inspections", "Machine inspections"], ["small-equipment", "Small equipment inspections"], ["photos", "Job photos and requests"], ["milestones", "Milestones and recognition"], ["records", "Recent records"]]} /> : null}
       {state.data ? (
         <>
           <AlertStrip alerts={state.data.alerts} />
           {section === "loads" ? <MaterialMovementCard data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "milestones" ? <MilestoneCard data={state.data} track="operator" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "time" ? <TimeEntryForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "schedule" ? <CrewScheduleCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
           {["inspections", "photos"].includes(section) ? <RecordForm data={state.data} mode="operator" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "small-equipment" ? <SmallEquipmentInspectionCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "records" ? <RecentRecords records={state.data.records.filter((item) => ["material_movement", "equipment_inspection", "small_equipment_inspection", "job_photo", "time_off_request", "performance_review"].includes(item.record_type))} employees={state.data.employees} onSaved={state.refresh} onError={state.setError} /> : null}
@@ -297,7 +299,8 @@ export function EmployeePortalPage({ section = "dashboard" }: { section?: string
       {state.data ? (
         <>
           {section === "time" ? <TimeEntryForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} /> : null}
-          {["journal", "schedule"].includes(section) ? <RecordForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "journal" ? <RecordForm data={state.data} mode="employee" onSaved={state.refresh} onError={state.setError} /> : null}
+          {section === "schedule" ? <CrewScheduleCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "milestones" ? <MilestoneCard data={state.data} track="civil" onSaved={state.refresh} onError={state.setError} /> : null}
           {section === "profile" ? <EmployeeDirectory data={state.data} /> : null}
           {section === "safety" ? <ToolboxTalkCard data={state.data} onSaved={state.refresh} onError={state.setError} /> : null}
@@ -307,6 +310,94 @@ export function EmployeePortalPage({ section = "dashboard" }: { section?: string
       ) : null}
     </PortalShell>
   );
+}
+
+function CrewScheduleCard({ data, canSchedule = false, onSaved, onError }: { data: FieldOperationsBootstrap; canSchedule?: boolean; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
+  const { user } = useAuth();
+  const isManagement = ["admin", "operations_manager"].includes(user?.role ?? "");
+  const maySchedule = canSchedule || isManagement;
+  const employee = data.employees.find((item) => item.email.toLowerCase() === user?.email.toLowerCase()) ?? data.employees[0];
+  const [selectedEmployees, setSelectedEmployees] = useState<string[]>([]);
+  const [projectId, setProjectId] = useState("");
+  const [shiftDate, setShiftDate] = useState(today());
+  const [startTime, setStartTime] = useState("07:00");
+  const [endTime, setEndTime] = useState("15:30");
+  const [meetingPoint, setMeetingPoint] = useState("");
+  const [shiftNotes, setShiftNotes] = useState("");
+  const [timeOffStart, setTimeOffStart] = useState("");
+  const [timeOffEnd, setTimeOffEnd] = useState("");
+  const [timeOffReason, setTimeOffReason] = useState("");
+  const [decisionNotes, setDecisionNotes] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const shifts = data.records.filter((item) => item.record_type === "crew_shift").sort((a, b) => (a.work_date + String(a.details.start_time)).localeCompare(b.work_date + String(b.details.start_time)));
+  const requests = data.records.filter((item) => item.record_type === "time_off_request");
+
+  async function scheduleCrew(event: FormEvent) {
+    event.preventDefault();
+    if (!projectId || !selectedEmployees.length) return;
+    setSaving(true); onError(null);
+    try {
+      const project = data.projects.find((item) => item.id === projectId);
+      await Promise.all(selectedEmployees.map((employeeId) => fieldOperationsApi.createRecord({
+        record_type: "crew_shift", employee_id: employeeId, project_id: projectId, work_date: shiftDate,
+        title: "Scheduled shift — " + (project?.name ?? "Project"),
+        details: { start_time: startTime, end_time: endTime, meeting_point: meetingPoint, notes: shiftNotes },
+      })));
+      setSelectedEmployees([]); setMeetingPoint(""); setShiftNotes(""); await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to schedule crew."); }
+    finally { setSaving(false); }
+  }
+
+  async function requestTimeOff(event: FormEvent) {
+    event.preventDefault();
+    if (!employee || !timeOffStart || !timeOffEnd) return;
+    setSaving(true); onError(null);
+    try {
+      await fieldOperationsApi.createRecord({
+        record_type: "time_off_request", employee_id: employee.id, work_date: today(), title: "Time off request",
+        details: { start_date: timeOffStart, end_date: timeOffEnd, reason: timeOffReason },
+      });
+      setTimeOffStart(""); setTimeOffEnd(""); setTimeOffReason(""); await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to request time off."); }
+    finally { setSaving(false); }
+  }
+
+  async function decide(request: FieldRecord, decision: "approved" | "declined") {
+    setSaving(true); onError(null);
+    try {
+      await fieldOperationsApi.decideTimeOff(request.id, { decision, management_notes: decisionNotes[request.id] || null });
+      await onSaved();
+    } catch (current) { onError(current instanceof Error ? current.message : "Unable to decide time-off request."); }
+    finally { setSaving(false); }
+  }
+
+  return <div className="space-y-5">
+    {maySchedule ? <form onSubmit={scheduleCrew} className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<Clock3 />} title="Crew schedule" subtitle="Assign one or more employees to a job, shift time and meeting point." />
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <Select label="Project / job" value={projectId} onChange={setProjectId} required options={data.projects.map((item) => [item.id, item.name])} />
+        <Input label="Shift date" value={shiftDate} onChange={setShiftDate} type="date" required />
+        <Input label="Start time" value={startTime} onChange={setStartTime} type="time" required />
+        <Input label="End time" value={endTime} onChange={setEndTime} type="time" required />
+        <Input label="Meeting point" value={meetingPoint} onChange={setMeetingPoint} />
+        <Input label="Shift instructions / comments" value={shiftNotes} onChange={setShiftNotes} />
+      </div>
+      <EmployeeChecklist employees={data.employees} selected={selectedEmployees} onChange={setSelectedEmployees} />
+      <PrimaryButton disabled={saving || !projectId || !selectedEmployees.length}>{saving ? "Scheduling…" : "Publish crew schedule"}</PrimaryButton>
+    </form> : <form onSubmit={requestTimeOff} className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<Clock3 />} title="Request time off" subtitle="Submit dates and a comment for management review." />
+      <div className="mt-4 grid gap-3 md:grid-cols-3"><Input label="First day off" value={timeOffStart} onChange={setTimeOffStart} type="date" required /><Input label="Last day off" value={timeOffEnd} onChange={setTimeOffEnd} type="date" required /><Input label="Reason / comments" value={timeOffReason} onChange={setTimeOffReason} /></div>
+      <PrimaryButton disabled={saving || !timeOffStart || !timeOffEnd}>{saving ? "Submitting…" : "Submit request"}</PrimaryButton>
+    </form>}
+    <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<ClipboardCheck />} title="Upcoming shifts" subtitle="Your current job assignments, times, meeting points and instructions." />
+      <div className="mt-4 space-y-3">{shifts.map((shift) => { const worker = data.employees.find((item) => item.id === shift.employee_id); const project = data.projects.find((item) => item.id === shift.project_id); return <div key={shift.id} className="rounded-md border border-iron-100 p-4"><div className="font-semibold text-iron-950">{shift.work_date} · {String(shift.details.start_time)}–{String(shift.details.end_time)}</div><div className="mt-1 text-sm text-iron-600">{worker ? worker.first_name + " " + worker.last_name + " · " : ""}{project?.name ?? shift.title}</div><div className="mt-1 text-sm text-iron-500">{String(shift.details.meeting_point || "Meeting point not specified")}{shift.details.notes ? " · " + String(shift.details.notes) : ""}</div></div>; })}{!shifts.length ? <div className="rounded-md bg-iron-50 p-4 text-sm text-iron-500">No shifts are scheduled yet.</div> : null}</div>
+    </section>
+    <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+      <SectionTitle icon={<FileText />} title={isManagement ? "Time-off approvals" : "My time-off requests"} subtitle={isManagement ? "Approve or decline pending employee requests with management comments." : "Track pending and decided requests."} />
+      <div className="mt-4 space-y-3">{requests.map((request) => { const worker = data.employees.find((item) => item.id === request.employee_id); return <div key={request.id} className="rounded-md border border-iron-100 p-4"><div className="flex flex-wrap items-center justify-between gap-2"><div className="font-semibold text-iron-950">{worker ? worker.first_name + " " + worker.last_name : request.title} · {String(request.details.start_date)} to {String(request.details.end_date)}</div><StatusPill status={request.status} /></div><div className="mt-1 text-sm text-iron-500">{String(request.details.reason || "No comment provided")}</div>{isManagement && request.status === "pending" ? <div className="mt-3 grid gap-3 md:grid-cols-[1fr_auto]"><Input label="Management comments" value={decisionNotes[request.id] ?? ""} onChange={(value) => setDecisionNotes((current) => ({ ...current, [request.id]: value }))} /><div className="flex items-end gap-2"><button type="button" disabled={saving} onClick={() => void decide(request, "approved")} className="rounded-md bg-brand-gold px-3 py-2 text-sm font-semibold text-brand-black">Approve</button><button type="button" disabled={saving} onClick={() => void decide(request, "declined")} className="rounded-md border border-iron-100 px-3 py-2 text-sm font-semibold">Decline</button></div></div> : null}</div>; })}{!requests.length ? <div className="rounded-md bg-iron-50 p-4 text-sm text-iron-500">No time-off requests.</div> : null}</div>
+    </section>
+  </div>;
 }
 
 function MilestoneCard({ data, track, onSaved, onError }: { data: FieldOperationsBootstrap; track: "civil" | "operator"; onSaved: () => Promise<void>; onError: (value: string | null) => void }) {
@@ -440,8 +531,8 @@ function RecordForm({ data, mode, onSaved, onError }: { data: FieldOperationsBoo
   const availableTypes = mode === "foreman"
     ? [["journal", "Daily journal"], ["daily_hazard_assessment", "Daily hazard assessment"], ["weather", "Weather"], ["material_quantity", "Material / quantity"], ["subcontractor", "Subcontractor"], ["rental_equipment", "Rental equipment"], ["expense", "Expense"], ["missing_form", "Missing form"], ["job_photo", "Production photos"]]
     : mode === "operator"
-      ? [["equipment_inspection", "Machine inspection"], ["job_photo", "Job photos"], ["time_off_request", "Time-off request"], ["performance_review", "Performance review request"], ["journal", "Journal"]]
-      : [["journal", "Journal"], ["job_photo", "Job photos"], ["expense", "Expense"], ["missing_form", "Missing form"], ["time_off_request", "Time-off request"], ["performance_review", "Performance review request"]];
+      ? [["equipment_inspection", "Machine inspection"], ["job_photo", "Job photos"], ["performance_review", "Performance review request"], ["journal", "Journal"]]
+      : [["journal", "Journal"], ["job_photo", "Job photos"], ["expense", "Expense"], ["missing_form", "Missing form"], ["performance_review", "Performance review request"]];
   const [recordType, setRecordType] = useState(availableTypes[0][0]);
   const [employeeId, setEmployeeId] = useState("");
   const [projectId, setProjectId] = useState("");

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -378,3 +378,84 @@ def test_small_equipment_inspection_flags_unsafe_saw_for_management() -> None:
     )
     assert record.status_code == 201
     assert record.json()["alert_recipients"] == ["Jeremie Peters", "Mac Warren"]
+
+
+def test_foreman_schedule_and_management_time_off_decision_workflow() -> None:
+    employee = _employee()
+    project = _project()
+    shift = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "crew_shift",
+            "employee_id": employee["id"],
+            "project_id": project["id"],
+            "work_date": str(date.today() + timedelta(days=1)),
+            "title": "Scheduled shift — Field Operations Test",
+            "details": {"start_time": "07:00", "end_time": "15:30", "meeting_point": "Site trailer", "notes": "Bring pipe laser"},
+        },
+    )
+    assert shift.status_code == 201
+    assert shift.json()["status"] == "scheduled"
+
+    request = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "time_off_request",
+            "employee_id": employee["id"],
+            "work_date": str(date.today()),
+            "title": "Time off request",
+            "details": {"start_date": str(date.today() + timedelta(days=10)), "end_date": str(date.today() + timedelta(days=11)), "reason": "Appointment"},
+        },
+    )
+    assert request.status_code == 201
+    assert request.json()["status"] == "pending"
+    decision = client.post(
+        f"/api/v1/field-operations/records/{request.json()['id']}/time-off-decision",
+        json={"decision": "approved", "management_notes": "Coverage confirmed."},
+    )
+    assert decision.status_code == 200
+    assert decision.json()["status"] == "approved"
+    assert decision.json()["details"]["management_notes"] == "Coverage confirmed."
+
+
+def test_employee_cannot_schedule_or_submit_records_for_another_employee() -> None:
+    own = _employee()
+    other = client.post(
+        "/api/v1/field-operations/employees",
+        json={"first_name": "Other", "last_name": "Worker", "email": "other.schedule@ironhousecivil.com", "portal_role": "employee"},
+    ).json()
+    project = _project()
+
+    def employee_user(request: Request) -> AuthenticatedUser:
+        user = AuthenticatedUser(id=UUID("00000000-0000-0000-0000-000000000019"), email=own["email"], display_name="Crew Member", role="viewer", session_version=1)
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = employee_user
+    try:
+        shift = client.post(
+            "/api/v1/field-operations/records",
+            json={"record_type": "crew_shift", "employee_id": own["id"], "project_id": project["id"], "work_date": str(date.today()), "title": "Unauthorized shift", "details": {"start_time": "07:00", "end_time": "15:30"}},
+        )
+        assert shift.status_code == 403
+        other_record = client.post(
+            "/api/v1/field-operations/records",
+            json={"record_type": "journal", "employee_id": other["id"], "work_date": str(date.today()), "title": "Not mine", "details": {}},
+        )
+        assert other_record.status_code == 403
+        other_time = client.post(
+            "/api/v1/field-operations/time-entries",
+            json={"employee_id": other["id"], "project_id": project["id"], "cost_code": "02-200", "work_date": str(date.today()), "regular_hours": 8},
+        )
+        assert other_time.status_code == 403
+    finally:
+        app.dependency_overrides.pop(require_authenticated_user, None)
+
+
+def test_time_off_request_rejects_reversed_dates() -> None:
+    employee = _employee()
+    response = client.post(
+        "/api/v1/field-operations/records",
+        json={"record_type": "time_off_request", "employee_id": employee["id"], "work_date": str(date.today()), "title": "Invalid dates", "details": {"start_date": "2026-08-10", "end_date": "2026-08-09"}},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add dedicated crew scheduling workspaces to foreman, operator, and employee portals
- let foremen publish one shift to multiple selected employees with job, times, meeting point, and instructions
- let employees/operators view their own shifts and submit dated time-off requests
- let management approve or decline requests with comments and decision audit data
- prevent viewer accounts from scheduling crews or submitting another employee's time and records
- preserve the locked Iron House appearance and exclude SIN, banking, medical, and payroll data

## Validation
- 131 backend tests passed
- 21 frontend tests passed
- backend/frontend lint passed
- TypeScript/Vite production build passed
- visual design lock passed
- git diff check passed