### PR TITLE
Build 231: standardize company email identities

### DIFF
--- a/backend/app/db/bootstrap_admin.py
+++ b/backend/app/db/bootstrap_admin.py
@@ -4,17 +4,26 @@ from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.models.user import UserAccount
 from app.services.auth import hash_password, normalize_email
+from app.services.email_domain_migration import LEGACY_EMAIL_DOMAIN
+
+
+def validate_bootstrap_admin_email(value: str) -> str:
+    email = normalize_email(value)
+    if email.rsplit("@", 1)[-1] == LEGACY_EMAIL_DOMAIN:
+        raise RuntimeError(
+            "BOOTSTRAP_ADMIN_EMAIL uses the retired company email domain. "
+            "Use the canonical Iron House Contracting email domain."
+        )
+    return email
 
 
 def bootstrap_admin() -> bool:
     settings = get_settings()
     if not settings.bootstrap_admin_email or not settings.bootstrap_admin_password:
         if settings.environment.lower() == "production":
-            raise RuntimeError(
-                "BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD are required in production."
-            )
+            raise RuntimeError("BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD are required in production.")
         return False
-    email = normalize_email(settings.bootstrap_admin_email)
+    email = validate_bootstrap_admin_email(settings.bootstrap_admin_email)
     with SessionLocal() as db:
         existing = db.scalar(select(UserAccount).where(func.lower(UserAccount.email) == email))
         if existing is not None:

--- a/backend/app/services/email_domain_migration.py
+++ b/backend/app/services/email_domain_migration.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+import re
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.models.contact import Contact
+from app.models.field_operations import FieldRecord
+from app.models.rfq import RFQPackage
+from app.models.supplier import Supplier
+from app.models.user import Employee, LoginThrottle, UserAccount
+from app.services.auth import login_subject_hash
+
+LEGACY_EMAIL_DOMAIN = "ironhousecivil.com"
+CANONICAL_EMAIL_DOMAIN = "ironhousecontracting.com"
+
+
+@dataclass(frozen=True)
+class EmailDomainChange:
+    area: str
+    record_id: str
+    field: str
+    previous: str
+    replacement: str
+
+
+@dataclass(frozen=True)
+class EmailDomainMigrationReport:
+    applied: bool
+    from_domain: str
+    to_domain: str
+    changes: tuple[EmailDomainChange, ...]
+    sessions_invalidated: int
+    login_throttles_cleared: int
+    protected_history_policy: str = "Historical audit and provenance fields were not changed."
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["change_count"] = len(self.changes)
+        counts: dict[str, int] = {}
+        for change in self.changes:
+            counts[change.area] = counts.get(change.area, 0) + 1
+        payload["changes_by_area"] = counts
+        return payload
+
+
+class EmailDomainMigrationConflict(ValueError):
+    def __init__(self, conflicts: list[str]) -> None:
+        self.conflicts = tuple(conflicts)
+        super().__init__("Email-domain migration blocked: " + "; ".join(conflicts))
+
+
+def _normalise_domain(value: str) -> str:
+    return value.strip().lower().lstrip("@")
+
+
+def _replacement(value: str | None, from_domain: str, to_domain: str) -> str | None:
+    if value is None or "@" not in value:
+        return value
+    local_part, domain = value.strip().rsplit("@", 1)
+    if not local_part or domain.casefold() != from_domain.casefold():
+        return value
+    return f"{local_part}@{to_domain}".lower()
+
+
+def _text_replacement(value: str, from_domain: str, to_domain: str) -> str:
+    pattern = re.compile(
+        rf"(?P<local>[A-Z0-9.!#$%&'*+/=?^_`{{|}}~-]+)@{re.escape(from_domain)}\b",
+        re.IGNORECASE,
+    )
+    return pattern.sub(
+        lambda match: f"{match.group('local').lower()}@{to_domain}",
+        value,
+    )
+
+
+def _change(
+    changes: list[EmailDomainChange],
+    *,
+    area: str,
+    record_id: object,
+    field: str,
+    previous: str | None,
+    replacement: str | None,
+) -> bool:
+    if previous is None or replacement is None or previous == replacement:
+        return False
+    changes.append(
+        EmailDomainChange(
+            area=area,
+            record_id=str(record_id),
+            field=field,
+            previous=previous,
+            replacement=replacement,
+        )
+    )
+    return True
+
+
+def _collision_conflicts(
+    rows: list[UserAccount] | list[Employee],
+    *,
+    area: str,
+    from_domain: str,
+    to_domain: str,
+) -> list[str]:
+    projected: dict[str, list[str]] = {}
+    conflicts: list[str] = []
+    for row in rows:
+        replacement = _replacement(row.email, from_domain, to_domain)
+        assert replacement is not None
+        if len(replacement) > 255:
+            conflicts.append(f"{area} record {row.id} would exceed the 255-character email limit")
+        projected.setdefault(replacement.casefold(), []).append(str(row.id))
+    for email, record_ids in projected.items():
+        if len(record_ids) > 1:
+            conflicts.append(f"{area} records {', '.join(record_ids)} would collide at {email}")
+    return conflicts
+
+
+def _migrate_supplier_metadata(
+    supplier: Supplier,
+    from_domain: str,
+    to_domain: str,
+    changes: list[EmailDomainChange],
+) -> dict[str, Any] | None:
+    metadata = deepcopy(supplier.metadata_json or {})
+    previous = metadata.get("email")
+    if not isinstance(previous, str):
+        return None
+    replacement = _replacement(previous, from_domain, to_domain)
+    if _change(
+        changes,
+        area="supplier_routing",
+        record_id=supplier.id,
+        field="metadata.email",
+        previous=previous,
+        replacement=replacement,
+    ):
+        metadata["email"] = replacement
+        return metadata
+    return None
+
+
+def _migrate_rfq_metadata(
+    rfq_package: RFQPackage,
+    from_domain: str,
+    to_domain: str,
+    changes: list[EmailDomainChange],
+) -> dict[str, Any] | None:
+    metadata = deepcopy(rfq_package.metadata_json or {})
+    changed = False
+
+    supplier_contacts = metadata.get("supplier_contacts")
+    if isinstance(supplier_contacts, dict):
+        for supplier_id, contact in supplier_contacts.items():
+            if not isinstance(contact, dict) or not isinstance(contact.get("recipient_email"), str):
+                continue
+            previous = contact["recipient_email"]
+            replacement = _replacement(previous, from_domain, to_domain)
+            if _change(
+                changes,
+                area="rfq_routing",
+                record_id=rfq_package.id,
+                field=f"supplier_contacts.{supplier_id}.recipient_email",
+                previous=previous,
+                replacement=replacement,
+            ):
+                contact["recipient_email"] = replacement
+                changed = True
+
+    workflow = metadata.get("gmail_drive_workflow")
+    if isinstance(workflow, dict):
+        sender = workflow.get("sender")
+        if isinstance(sender, dict) and isinstance(sender.get("email"), str):
+            previous = sender["email"]
+            replacement = _replacement(previous, from_domain, to_domain)
+            if _change(
+                changes,
+                area="rfq_routing",
+                record_id=rfq_package.id,
+                field="gmail_drive_workflow.sender.email",
+                previous=previous,
+                replacement=replacement,
+            ):
+                sender["email"] = replacement
+                changed = True
+        drafts = workflow.get("gmail_drafts")
+        if isinstance(drafts, list):
+            for index, draft in enumerate(drafts):
+                if not isinstance(draft, dict):
+                    continue
+                for field in ("to", "body"):
+                    previous = draft.get(field)
+                    if not isinstance(previous, str):
+                        continue
+                    replacement = (
+                        _replacement(previous, from_domain, to_domain)
+                        if field == "to"
+                        else _text_replacement(previous, from_domain, to_domain)
+                    )
+                    if _change(
+                        changes,
+                        area="rfq_routing",
+                        record_id=rfq_package.id,
+                        field=f"gmail_drive_workflow.gmail_drafts.{index}.{field}",
+                        previous=previous,
+                        replacement=replacement,
+                    ):
+                        draft[field] = replacement
+                        changed = True
+    return metadata if changed else None
+
+
+def _migrate_alert_recipients(
+    field_record: FieldRecord,
+    from_domain: str,
+    to_domain: str,
+    changes: list[EmailDomainChange],
+) -> list[Any] | None:
+    recipients = list(field_record.alert_recipients or [])
+    changed = False
+    for index, recipient in enumerate(recipients):
+        if not isinstance(recipient, str):
+            continue
+        replacement = _replacement(recipient, from_domain, to_domain)
+        if _change(
+            changes,
+            area="field_routing",
+            record_id=field_record.id,
+            field=f"alert_recipients.{index}",
+            previous=recipient,
+            replacement=replacement,
+        ):
+            recipients[index] = replacement
+            changed = True
+    return recipients if changed else None
+
+
+def migrate_email_domain(
+    db: Session,
+    *,
+    from_domain: str = LEGACY_EMAIL_DOMAIN,
+    to_domain: str = CANONICAL_EMAIL_DOMAIN,
+    apply: bool = False,
+) -> EmailDomainMigrationReport:
+    source = _normalise_domain(from_domain)
+    target = _normalise_domain(to_domain)
+    if not source or not target or source == target:
+        raise ValueError("Source and target email domains must be different non-empty domains.")
+
+    accounts = list(db.scalars(select(UserAccount).with_for_update()))
+    employees = list(db.scalars(select(Employee).with_for_update()))
+    contacts = list(db.scalars(select(Contact).with_for_update()))
+    suppliers = list(db.scalars(select(Supplier).with_for_update()))
+    rfq_packages = list(db.scalars(select(RFQPackage).with_for_update()))
+    field_records = list(db.scalars(select(FieldRecord).with_for_update()))
+
+    conflicts = _collision_conflicts(
+        accounts,
+        area="user_accounts",
+        from_domain=source,
+        to_domain=target,
+    )
+    conflicts.extend(
+        _collision_conflicts(
+            employees,
+            area="employees",
+            from_domain=source,
+            to_domain=target,
+        )
+    )
+    if conflicts:
+        raise EmailDomainMigrationConflict(conflicts)
+
+    changes: list[EmailDomainChange] = []
+    changed_accounts: list[tuple[UserAccount, str, str]] = []
+    changed_employees: list[tuple[Employee, str]] = []
+    changed_contacts: list[tuple[Contact, str]] = []
+    changed_suppliers: list[tuple[Supplier, dict[str, Any]]] = []
+    changed_packages: list[tuple[RFQPackage, dict[str, Any]]] = []
+    changed_records: list[tuple[FieldRecord, list[Any]]] = []
+
+    for account in accounts:
+        replacement = _replacement(account.email, source, target)
+        if _change(
+            changes,
+            area="user_accounts",
+            record_id=account.id,
+            field="email",
+            previous=account.email,
+            replacement=replacement,
+        ):
+            assert replacement is not None
+            changed_accounts.append((account, account.email, replacement))
+    for employee in employees:
+        replacement = _replacement(employee.email, source, target)
+        if _change(
+            changes,
+            area="employees",
+            record_id=employee.id,
+            field="email",
+            previous=employee.email,
+            replacement=replacement,
+        ):
+            assert replacement is not None
+            changed_employees.append((employee, replacement))
+    for contact in contacts:
+        replacement = _replacement(contact.email, source, target)
+        if _change(
+            changes,
+            area="contacts",
+            record_id=contact.id,
+            field="email",
+            previous=contact.email,
+            replacement=replacement,
+        ):
+            assert replacement is not None
+            changed_contacts.append((contact, replacement))
+    for supplier in suppliers:
+        metadata = _migrate_supplier_metadata(supplier, source, target, changes)
+        if metadata is not None:
+            changed_suppliers.append((supplier, metadata))
+    for rfq_package in rfq_packages:
+        metadata = _migrate_rfq_metadata(rfq_package, source, target, changes)
+        if metadata is not None:
+            changed_packages.append((rfq_package, metadata))
+    for field_record in field_records:
+        recipients = _migrate_alert_recipients(field_record, source, target, changes)
+        if recipients is not None:
+            changed_records.append((field_record, recipients))
+
+    cleared_throttles = 0
+    if apply:
+        for account, _, replacement in changed_accounts:
+            account.email = replacement
+            account.session_version += 1
+        for employee, replacement in changed_employees:
+            employee.email = replacement
+        for contact, replacement in changed_contacts:
+            contact.email = replacement
+        for supplier, metadata in changed_suppliers:
+            supplier.metadata_json = metadata
+        for rfq_package, metadata in changed_packages:
+            rfq_package.metadata_json = metadata
+        for field_record, recipients in changed_records:
+            field_record.alert_recipients = recipients
+
+        throttle_hashes = {
+            login_subject_hash(email)
+            for _, previous, replacement in changed_accounts
+            for email in (previous, replacement)
+        }
+        if throttle_hashes:
+            result = db.execute(delete(LoginThrottle).where(LoginThrottle.key_hash.in_(throttle_hashes)))
+            cleared_throttles = int(result.rowcount or 0)
+        db.flush()
+
+    return EmailDomainMigrationReport(
+        applied=apply,
+        from_domain=source,
+        to_domain=target,
+        changes=tuple(changes),
+        sessions_invalidated=len(changed_accounts) if apply else 0,
+        login_throttles_cleared=cleared_throttles,
+    )

--- a/backend/app/tools/__init__.py
+++ b/backend/app/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Controlled operator tools shipped with the Iron House OS backend."""

--- a/backend/app/tools/migrate_email_domain.py
+++ b/backend/app/tools/migrate_email_domain.py
@@ -1,0 +1,49 @@
+"""Dry-run or apply the controlled Iron House operational email-domain migration."""
+
+from argparse import ArgumentParser
+import json
+
+from app.db.session import SessionLocal
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    EmailDomainMigrationConflict,
+    LEGACY_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--from-domain", default=LEGACY_EMAIL_DOMAIN)
+    parser.add_argument("--to-domain", default=CANONICAL_EMAIL_DOMAIN)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--confirm",
+        help="Required with --apply; must exactly match --to-domain.",
+    )
+    args = parser.parse_args()
+    if args.apply and args.confirm != args.to_domain:
+        raise SystemExit("--apply requires --confirm matching --to-domain exactly.")
+
+    with SessionLocal() as db:
+        try:
+            report = migrate_email_domain(
+                db,
+                from_domain=args.from_domain,
+                to_domain=args.to_domain,
+                apply=args.apply,
+            )
+            if args.apply:
+                db.commit()
+            else:
+                db.rollback()
+        except EmailDomainMigrationConflict as exc:
+            db.rollback()
+            print(json.dumps({"status": "blocked", "conflicts": exc.conflicts}, indent=2))
+            raise SystemExit(2) from exc
+
+    print(json.dumps({"status": "applied" if args.apply else "dry_run", **report.to_dict()}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -107,7 +107,7 @@ def test_admin_can_create_users_and_new_user_cannot_administer_accounts() -> Non
     created = client.post(
         "/api/v1/users",
         json={
-            "email": "estimator@ironhousecivil.com",
+            "email": "estimator@ironhousecontracting.com",
             "display_name": "Iron House Estimator",
             "role": "estimator",
             "password": "estimate-password-2026",
@@ -122,7 +122,7 @@ def test_admin_can_create_users_and_new_user_cannot_administer_accounts() -> Non
     client.post(
         "/api/v1/auth/login",
         json={
-            "email": "estimator@ironhousecivil.com",
+            "email": "estimator@ironhousecontracting.com",
             "password": "estimate-password-2026",
         },
     )
@@ -169,7 +169,7 @@ def test_admin_cannot_change_user_email_to_an_existing_account() -> None:
     created = client.post(
         "/api/v1/users",
         json={
-            "email": "estimator@ironhousecivil.com",
+            "email": "estimator@ironhousecontracting.com",
             "display_name": "Iron House Estimator",
             "role": "estimator",
             "password": "estimate-password-2026",

--- a/docs/builds/BUILD_231.md
+++ b/docs/builds/BUILD_231.md
@@ -1,0 +1,84 @@
+# Build 231 — Email Identity Domain Cleanup
+
+## Task Card
+
+- **Lead function:** Administration and Communications
+- **Supporting functions:** System Governance, Security, Estimating, Operations
+- **Owner:** Jeremie Peters
+- **Priority:** High
+- **Status:** Ready
+- **Environment:** Development only
+- **Approval gate:** Production backup, reviewed dry-run evidence, explicit apply approval
+
+## Objective
+
+Make `ironhousecontracting.com` the canonical email domain for current Iron House
+accounts, employee identities, supplier contacts and active communication routing.
+The live hostname `os.ironhousecivil.com` remains unchanged.
+
+## Verified
+
+- The canonical company email domain is `ironhousecontracting.com`.
+- The approved IHOS hostname is `os.ironhousecivil.com` and is separate from company
+  email identity.
+- Current authentication tokens contain both the account email and a session version.
+- User accounts and employee records have unique email constraints.
+- Production is not modified by this build branch.
+
+## Assumptions
+
+- Existing password hashes, roles, account IDs and employee IDs must remain unchanged.
+- Active RFQ draft routing should use the canonical domain after migration.
+- Historic authorship, submission, signature, source-email and append-only audit evidence
+  must retain the value recorded at the time of the event.
+
+## Included
+
+- Dry-run-by-default operator tool.
+- Case-insensitive collision detection before any write.
+- One-transaction updates to:
+  - user accounts;
+  - employee identities;
+  - supplier contacts;
+  - supplier routing metadata;
+  - active RFQ recipient and Gmail draft routing;
+  - field alert email recipients.
+- Session-version increments for migrated user accounts.
+- Removal of login throttles for both retired and canonical account addresses.
+- Bootstrap protection that refuses the retired email domain.
+- Development, backend and browser test identities updated to the canonical domain.
+
+## Excluded
+
+- DNS or hostname changes.
+- Mailbox creation, Google Workspace administration or email forwarding.
+- Rewriting financial provenance, submitted-by values, digital signatures, imported-by
+  values or append-only document-audit actors.
+- Production execution, deployment or merge.
+
+## Review Gates
+
+| Gate | Required evidence | Status |
+|---|---|---|
+| Source review | No retired-domain literals in current test identities | Complete |
+| Migration review | Dry run, collision refusal, idempotence and history preservation | Complete |
+| Test review | Backend, frontend and build checks | Complete |
+| Production approval | Backup plus reviewed dry-run JSON | Blocked pending approval |
+
+## Open Items
+
+- Confirm the production dry-run inventory and resolve any collision it reports.
+- Confirm `/etc/iron-house-os/production.env` uses the canonical bootstrap administrator
+  email before the next backend restart.
+- Approve or reject production application after reviewing the backup and dry-run.
+
+## Build Log
+
+- **2026-07-24:** Task card opened; source inventory separated email identities from the
+  approved web hostname.
+- **2026-07-24:** Migration service, packaged operator command, collision controls,
+  session invalidation and bootstrap-domain guard implemented in development.
+- **2026-07-24:** Verification completed: 143 backend tests, 21 frontend tests,
+  TypeScript lint, frontend production build, Ruff and the 13-file visual-design lock
+  passed. One existing Pydantic warning and one existing frontend chunk-size warning
+  remain non-blocking.

--- a/docs/operations/email-domain-migration.md
+++ b/docs/operations/email-domain-migration.md
@@ -1,0 +1,76 @@
+# Email Identity Domain Migration Runbook
+
+This runbook changes current operational email identities to
+`ironhousecontracting.com`. It does not change `os.ironhousecivil.com`.
+
+## Approval and Preconditions
+
+Do not run `--apply` until all of the following are verified:
+
+1. The release containing Build 231 has passed CI and has been separately approved for
+   production deployment.
+2. A complete recovery backup has been created and verified.
+3. `/etc/iron-house-os/production.env` has the canonical
+   `BOOTSTRAP_ADMIN_EMAIL`.
+4. The dry-run JSON has been reviewed and contains no collision.
+5. The production apply has explicit approval from Jeremie Peters.
+
+## Backup
+
+From the production repository:
+
+```bash
+sudo IHOS_COMPOSE_ENV_FILE=/etc/iron-house-os/production.env \
+  bash scripts/backup.sh \
+  --output /var/backups/iron-house-os/pre-email-domain-migration-20260724
+```
+
+## Dry Run
+
+The default command is read-only:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps -T backend \
+  python -m app.tools.migrate_email_domain \
+  | sudo tee /var/lib/iron-house-os/email-domain-dry-run-20260724.json
+```
+
+Review `change_count`, `changes_by_area`, every proposed replacement and the protected
+history policy. A collision exits with status 2 and performs no write.
+
+## Apply
+
+Only after the approval gate:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps -T backend \
+  python -m app.tools.migrate_email_domain \
+  --apply \
+  --confirm ironhousecontracting.com \
+  | sudo tee /var/lib/iron-house-os/email-domain-apply-20260724.json
+```
+
+The apply is transactional and idempotent. Migrated accounts keep their passwords,
+roles and IDs, but their existing sessions are invalidated.
+
+## Verification
+
+1. Run the dry-run command again and confirm `change_count` is `0`.
+2. Sign in with the canonical administrator email and the existing password.
+3. Confirm the administrator role and required menus.
+4. Confirm employee and supplier email displays.
+5. Preview an RFQ communication workflow and confirm canonical sender/recipient routing.
+6. Confirm production readiness is healthy.
+7. Retain backup, dry-run and apply evidence with the Build 231 approval record.
+
+## Rollback
+
+Stop the application and restore the verified pre-change recovery backup using the
+approved recovery procedure. Do not manually merge colliding accounts or rewrite
+historic audit records.

--- a/frontend/e2e/release-gate.spec.ts
+++ b/frontend/e2e/release-gate.spec.ts
@@ -3,7 +3,7 @@ import { expect, Page, test } from "@playwright/test";
 
 const user = {
   id: "00000000-0000-0000-0000-000000000214",
-  email: "release-gate@ironhousecivil.com",
+  email: "release-gate@ironhousecontracting.com",
   display_name: "Release Gate Operator",
   role: "admin",
   is_active: true,
@@ -45,7 +45,7 @@ async function mockApi(page: Page) {
 
 async function signIn(page: Page) {
   await page.goto("/");
-  await page.getByLabel("Email").fill("release-gate@ironhousecivil.com");
+  await page.getByLabel("Email").fill("release-gate@ironhousecontracting.com");
   await page.getByLabel("Password").fill("Local-release-gate-only");
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.getByRole("heading", { name: "Iron House Dashboard" })).toBeVisible();

--- a/scripts/migrate_email_domain.py
+++ b/scripts/migrate_email_domain.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Repository wrapper for the packaged email-domain migration operator tool."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "backend"))
+
+from app.tools.migrate_email_domain import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -33,7 +33,7 @@ def override_get_db() -> Generator[Session, None, None]:
 def override_authenticated_user(request: Request) -> AuthenticatedUser:
     user = AuthenticatedUser(
         id=UUID("00000000-0000-0000-0000-000000000001"),
-        email="test-admin@ironhousecivil.com",
+        email="test-admin@ironhousecontracting.com",
         display_name="Test Administrator",
         role="admin",
         session_version=1,

--- a/tests/backend/test_email_domain_migration.py
+++ b/tests/backend/test_email_domain_migration.py
@@ -1,0 +1,218 @@
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+from app.db.bootstrap_admin import validate_bootstrap_admin_email
+from app.models.contact import Contact
+from app.models.field_operations import FieldRecord
+from app.models.finance import StartupExpense
+from app.models.rfq import RFQPackage
+from app.models.supplier import Supplier
+from app.models.user import Employee, LoginThrottle, UserAccount
+from app.services.auth import hash_password, login_subject_hash
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    EmailDomainMigrationConflict,
+    LEGACY_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+def _email(local_part: str, domain: str) -> str:
+    return f"{local_part}@{domain}"
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _seed_operational_records(db: Session) -> dict[str, object]:
+    legacy_admin = _email("jeremie", LEGACY_EMAIL_DOMAIN)
+    canonical_admin = _email("jeremie", CANONICAL_EMAIL_DOMAIN)
+    supplier = Supplier(
+        name="Domain Migration Supplier",
+        metadata_json={"email": _email("estimating", LEGACY_EMAIL_DOMAIN), "status": "preferred"},
+    )
+    db.add(supplier)
+    db.flush()
+    account = UserAccount(
+        email=legacy_admin,
+        display_name="Jeremie Peters",
+        role="admin",
+        password_hash=hash_password("build-231-test-password"),
+        is_active=True,
+        session_version=4,
+    )
+    employee = Employee(
+        first_name="Jeremie",
+        last_name="Peters",
+        email=_email("Jeremie", LEGACY_EMAIL_DOMAIN.upper()),
+        status="active",
+        portal_role="employee",
+    )
+    contact = Contact(
+        supplier_id=supplier.id,
+        first_name="Estimator",
+        email=_email("quotes", LEGACY_EMAIL_DOMAIN),
+    )
+    package = RFQPackage(
+        title="Build 231 routing test",
+        status="draft",
+        supplier_category_targets=[],
+        metadata_json={
+            "supplier_contacts": {"supplier-1": {"recipient_email": _email("quotes", LEGACY_EMAIL_DOMAIN)}},
+            "gmail_drive_workflow": {
+                "sender": {"email": legacy_admin},
+                "gmail_drafts": [
+                    {
+                        "to": _email("quotes", LEGACY_EMAIL_DOMAIN),
+                        "body": f"Reply to {legacy_admin}.\n\nThank you.",
+                    }
+                ],
+            },
+        },
+    )
+    field_record = FieldRecord(
+        record_type="issue",
+        work_date=date(2026, 7, 24),
+        title="Build 231 routing test",
+        alert_recipients=[legacy_admin, "Mac Warren"],
+        status="submitted",
+        severity="medium",
+        details={},
+        document_ids=[],
+        signatures=[{"signed_by_account": legacy_admin}],
+        submitted_by=legacy_admin,
+    )
+    expense = StartupExpense(
+        expense_date=date(2026, 7, 1),
+        vendor_name="Historical Vendor",
+        description="Historical evidence",
+        amount=100,
+        category="legal",
+        source_email=legacy_admin,
+        funding_source="owner_loan",
+        tax_treatment="needs_review",
+        status="review",
+        receipt_metadata={},
+        created_by=legacy_admin,
+    )
+    db.add_all(
+        [
+            account,
+            employee,
+            contact,
+            package,
+            field_record,
+            expense,
+            LoginThrottle(key_hash=login_subject_hash(legacy_admin), failed_attempts=2),
+            LoginThrottle(key_hash=login_subject_hash(canonical_admin), failed_attempts=1),
+        ]
+    )
+    db.commit()
+    return {
+        "account": account,
+        "employee": employee,
+        "contact": contact,
+        "supplier": supplier,
+        "package": package,
+        "field_record": field_record,
+        "expense": expense,
+        "legacy_admin": legacy_admin,
+        "canonical_admin": canonical_admin,
+    }
+
+
+def test_email_domain_migration_dry_run_has_no_writes() -> None:
+    with _session() as db:
+        seeded = _seed_operational_records(db)
+        report = migrate_email_domain(db)
+        assert report.applied is False
+        assert len(report.changes) == 9
+        assert report.sessions_invalidated == 0
+        assert db.get(UserAccount, seeded["account"].id).email == seeded["legacy_admin"]
+        assert len(db.scalars(select(LoginThrottle)).all()) == 2
+
+
+def test_email_domain_migration_updates_active_routing_and_preserves_history() -> None:
+    with _session() as db:
+        seeded = _seed_operational_records(db)
+        report = migrate_email_domain(db, apply=True)
+        db.commit()
+
+        account = db.get(UserAccount, seeded["account"].id)
+        employee = db.get(Employee, seeded["employee"].id)
+        contact = db.get(Contact, seeded["contact"].id)
+        supplier = db.get(Supplier, seeded["supplier"].id)
+        package = db.get(RFQPackage, seeded["package"].id)
+        field_record = db.get(FieldRecord, seeded["field_record"].id)
+        expense = db.get(StartupExpense, seeded["expense"].id)
+
+        assert report.sessions_invalidated == 1
+        assert report.login_throttles_cleared == 2
+        assert account.email == seeded["canonical_admin"]
+        assert account.session_version == 5
+        assert employee.email == _email("jeremie", CANONICAL_EMAIL_DOMAIN)
+        assert contact.email == _email("quotes", CANONICAL_EMAIL_DOMAIN)
+        assert supplier.metadata_json["email"] == _email("estimating", CANONICAL_EMAIL_DOMAIN)
+        assert package.metadata_json["supplier_contacts"]["supplier-1"]["recipient_email"] == _email(
+            "quotes", CANONICAL_EMAIL_DOMAIN
+        )
+        workflow = package.metadata_json["gmail_drive_workflow"]
+        assert workflow["sender"]["email"] == seeded["canonical_admin"]
+        assert workflow["gmail_drafts"][0]["to"] == _email("quotes", CANONICAL_EMAIL_DOMAIN)
+        assert workflow["gmail_drafts"][0]["body"] == (f"Reply to {seeded['canonical_admin']}.\n\nThank you.")
+        assert field_record.alert_recipients == [seeded["canonical_admin"], "Mac Warren"]
+        assert field_record.submitted_by == seeded["legacy_admin"]
+        assert field_record.signatures[0]["signed_by_account"] == seeded["legacy_admin"]
+        assert expense.source_email == seeded["legacy_admin"]
+        assert expense.created_by == seeded["legacy_admin"]
+        assert db.scalars(select(LoginThrottle)).all() == []
+
+        second = migrate_email_domain(db, apply=True)
+        assert second.changes == ()
+        assert second.sessions_invalidated == 0
+
+
+def test_email_domain_migration_refuses_case_insensitive_collisions() -> None:
+    with _session() as db:
+        db.add_all(
+            [
+                UserAccount(
+                    email=_email("owner", LEGACY_EMAIL_DOMAIN),
+                    display_name="Legacy Owner",
+                    role="admin",
+                    password_hash=hash_password("build-231-test-password"),
+                    is_active=True,
+                ),
+                UserAccount(
+                    email=_email("OWNER", CANONICAL_EMAIL_DOMAIN),
+                    display_name="Canonical Owner",
+                    role="viewer",
+                    password_hash=hash_password("build-231-test-password"),
+                    is_active=True,
+                ),
+            ]
+        )
+        db.commit()
+
+        with pytest.raises(EmailDomainMigrationConflict):
+            migrate_email_domain(db, apply=True)
+        db.rollback()
+
+        emails = set(db.scalars(select(UserAccount.email)))
+        assert _email("owner", LEGACY_EMAIL_DOMAIN) in emails
+        assert _email("OWNER", CANONICAL_EMAIL_DOMAIN) in emails
+
+
+def test_bootstrap_admin_rejects_retired_domain() -> None:
+    with pytest.raises(RuntimeError, match="retired company email domain"):
+        validate_bootstrap_admin_email(_email("admin", LEGACY_EMAIL_DOMAIN))
+    assert validate_bootstrap_admin_email(_email("ADMIN", CANONICAL_EMAIL_DOMAIN)) == _email(
+        "admin", CANONICAL_EMAIL_DOMAIN
+    )

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -18,7 +18,7 @@ def _employee() -> dict:
         json={
             "first_name": "Crew",
             "last_name": "Member",
-            "email": "crew.member@ironhousecivil.com",
+            "email": "crew.member@ironhousecontracting.com",
             "portal_role": "operator",
             "phone": "604-555-0100",
             "emergency_contact_name": "Emergency Contact",
@@ -340,13 +340,13 @@ def test_bootstrap_exposes_milestone_ladders_and_on_time_paperwork_recognition()
 def test_employee_creation_provisions_a_password_change_required_portal_account() -> None:
     response = client.post(
         "/api/v1/field-operations/employees",
-        json={"first_name": "New", "last_name": "Worker", "email": "new.worker@ironhousecivil.com", "portal_role": "employee"},
+        json={"first_name": "New", "last_name": "Worker", "email": "new.worker@ironhousecontracting.com", "portal_role": "employee"},
     )
     assert response.status_code == 201
     assert response.json()["portal_access_created"] is True
     temporary_password = response.json()["temporary_password"]
     assert len(temporary_password) >= 12
-    login = client.post("/api/v1/auth/login", json={"email": "new.worker@ironhousecivil.com", "password": temporary_password})
+    login = client.post("/api/v1/auth/login", json={"email": "new.worker@ironhousecontracting.com", "password": temporary_password})
     assert login.status_code == 200
     assert login.json()["user"]["password_reset_required"] is True
 
@@ -355,7 +355,7 @@ def test_employee_bootstrap_is_limited_to_own_records() -> None:
     own = _employee()
     other = client.post(
         "/api/v1/field-operations/employees",
-        json={"first_name": "Other", "last_name": "Worker", "email": "other.worker@ironhousecivil.com", "portal_role": "employee"},
+        json={"first_name": "Other", "last_name": "Worker", "email": "other.worker@ironhousecontracting.com", "portal_role": "employee"},
     ).json()
 
     def employee_user(request: Request) -> AuthenticatedUser:
@@ -422,7 +422,7 @@ def test_employee_cannot_schedule_or_submit_records_for_another_employee() -> No
     own = _employee()
     other = client.post(
         "/api/v1/field-operations/employees",
-        json={"first_name": "Other", "last_name": "Worker", "email": "other.schedule@ironhousecivil.com", "portal_role": "employee"},
+        json={"first_name": "Other", "last_name": "Worker", "email": "other.schedule@ironhousecontracting.com", "portal_role": "employee"},
     ).json()
     project = _project()
 

--- a/tests/backend/test_finance.py
+++ b/tests/backend/test_finance.py
@@ -75,7 +75,7 @@ def test_startup_expenses_build_owner_loan_until_reimbursed() -> None:
 def test_financial_data_is_denied_to_non_management_accounts() -> None:
     project = _project()
     def estimator_user(request: Request) -> AuthenticatedUser:
-        user = AuthenticatedUser(id=UUID("00000000-0000-0000-0000-000000000026"), email="estimator@ironhousecivil.com", display_name="Estimator", role="estimator", session_version=1)
+        user = AuthenticatedUser(id=UUID("00000000-0000-0000-0000-000000000026"), email="estimator@ironhousecontracting.com", display_name="Estimator", role="estimator", session_version=1)
         request.state.authenticated_user = user
         return user
     app.dependency_overrides[require_authenticated_user] = estimator_user

--- a/tests/backend/test_iron_house_chat.py
+++ b/tests/backend/test_iron_house_chat.py
@@ -16,7 +16,7 @@ def _authenticate_as(role: str) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000001"),
-            email=f"{role}@ironhousecivil.com",
+            email=f"{role}@ironhousecontracting.com",
             display_name=f"Test {role}", role=role, session_version=1,
         )
         request.state.authenticated_user = user

--- a/tests/backend/test_login_security.py
+++ b/tests/backend/test_login_security.py
@@ -16,7 +16,7 @@ from app.services.document_audit import (
     list_recent_document_audit_events,
 )
 
-ADMIN_EMAIL = "security-admin@ironhousecivil.com"
+ADMIN_EMAIL = "security-admin@ironhousecontracting.com"
 ADMIN_PASSWORD = "correct-horse-battery-staple"
 
 
@@ -98,7 +98,7 @@ def test_admin_recovery_forces_password_change_and_clears_lockout() -> None:
     created = client.post(
         "/api/v1/users",
         json={
-            "email": "recovering-estimator@ironhousecivil.com",
+            "email": "recovering-estimator@ironhousecontracting.com",
             "display_name": "Recovering Estimator",
             "role": "estimator",
             "password": "initial-password-2026",
@@ -112,7 +112,7 @@ def test_admin_recovery_forces_password_change_and_clears_lockout() -> None:
         client.post("/api/v1/auth/logout")
         client.post(
             "/api/v1/auth/login",
-            json={"email": "recovering-estimator@ironhousecivil.com", "password": "wrong-password"},
+            json={"email": "recovering-estimator@ironhousecontracting.com", "password": "wrong-password"},
         )
 
     client.cookies.clear()
@@ -132,7 +132,7 @@ def test_admin_recovery_forces_password_change_and_clears_lockout() -> None:
     login = client.post(
         "/api/v1/auth/login",
         json={
-            "email": "recovering-estimator@ironhousecivil.com",
+            "email": "recovering-estimator@ironhousecontracting.com",
             "password": "temporary-password-2026",
         },
     )

--- a/tests/backend/test_operational_observability.py
+++ b/tests/backend/test_operational_observability.py
@@ -20,7 +20,7 @@ def _authenticate_as(role: str) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000213"),
-            email=f"{role}@ironhousecivil.com",
+            email=f"{role}@ironhousecontracting.com",
             display_name=f"Build 213 {role}",
             role=role,
             session_version=1,

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -24,7 +24,7 @@ def _authenticate_as(role: str) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000001"),
-            email=f"{role}@ironhousecivil.com",
+            email=f"{role}@ironhousecontracting.com",
             display_name=f"Test {role}",
             role=role,
             session_version=1,
@@ -67,7 +67,7 @@ def test_viewer_is_read_only_and_denial_is_audited() -> None:
     assert response.status_code == 403
     assert "write" in response.json()["detail"]
     event = list_recent_document_audit_events(action="module_access", outcome="denied")[0]
-    assert event["actor"] == "viewer@ironhousecivil.com"
+    assert event["actor"] == "viewer@ironhousecontracting.com"
     assert event["request_id"] == "build-210-viewer-denial"
     assert event["metadata"] == {
         "module": "projects",


### PR DESCRIPTION
## Outcome

Makes `ironhousecontracting.com` the canonical domain for current Iron House identities and active communication routing while leaving `os.ironhousecivil.com` unchanged.

## Included

- dry-run-by-default, transaction-safe migration tool
- case-insensitive collision detection before writes
- user account, employee, contact, supplier-routing, RFQ-routing and field-alert updates
- session invalidation and old/new login-throttle cleanup
- bootstrap guard against the retired email domain
- canonical development, backend and browser test identities
- production backup, dry-run, approval and rollback runbook
- preserved historic audit, provenance, submission and signature values

## Verification

- Ruff: passed
- Backend: 143 passed (one existing Pydantic warning)
- Frontend: 21 passed
- TypeScript lint: passed
- Frontend production build: passed (one existing chunk-size warning)
- Visual design lock: passed, 13 protected files
- Literal `@ironhousecivil.com` source scan: zero matches

## Approval gate

This PR does not deploy or modify production. Before production apply: deploy an approved release, create and verify a recovery backup, update the production bootstrap administrator email, review the dry-run JSON, and obtain explicit apply approval.
