### PR TITLE
Build 232: add controlled administrator access recovery

### DIFF
--- a/backend/app/services/admin_access_recovery.py
+++ b/backend/app/services/admin_access_recovery.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import Session
+
+from app.models.user import LoginThrottle, UserAccount
+from app.services.auth import hash_password, login_subject_hash, normalize_email, verify_password
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+class AdminAccessRecoveryBlocked(ValueError):
+    def __init__(self, issues: list[str]) -> None:
+        self.issues = tuple(issues)
+        super().__init__("Administrator access recovery blocked: " + "; ".join(issues))
+
+
+@dataclass(frozen=True)
+class AdminRecoveryInspection:
+    account_id: str
+    email: str
+    display_name: str
+    role: str
+    is_active: bool
+    password_reset_required: bool
+    session_version: int
+    last_login_at: str | None
+    active_admin_count: int
+    eligible: bool
+    issues: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AdminRecoveryEvidence:
+    recovery_id: str
+    occurred_at: str
+    account_id: str
+    email: str
+    display_name: str
+    reason: str
+    operator: str
+    previous_session_version: int
+    new_session_version: int
+    password_reset_required: bool
+    sessions_invalidated: bool
+    login_throttles_cleared: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IdentityCutoverReadiness:
+    checked_at: str
+    canonical_admin_email: str
+    configured_bootstrap_email: str | None
+    pending_identity_changes: int
+    canonical_admin_found: bool
+    canonical_admin_active: bool
+    canonical_admin_role: bool
+    password_change_complete: bool
+    ready: bool
+    issues: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _load_account(db: Session, email: str, *, lock: bool) -> UserAccount:
+    normalised = normalize_email(email)
+    statement = select(UserAccount).where(func.lower(UserAccount.email) == normalised)
+    if lock:
+        statement = statement.with_for_update()
+    accounts = list(db.scalars(statement))
+    if not accounts:
+        raise AdminAccessRecoveryBlocked(["No account matches the supplied email."])
+    if len(accounts) > 1:
+        raise AdminAccessRecoveryBlocked(["Multiple accounts match the supplied email case-insensitively."])
+    return accounts[0]
+
+
+def inspect_admin_recovery(db: Session, email: str, *, lock: bool = False) -> AdminRecoveryInspection:
+    account = _load_account(db, email, lock=lock)
+    issues: list[str] = []
+    domain = account.email.rsplit("@", 1)[-1].casefold()
+    if domain != CANONICAL_EMAIL_DOMAIN:
+        issues.append("The account does not use the canonical company email domain.")
+    if account.role != "admin":
+        issues.append("The account is not an administrator.")
+    if not account.is_active:
+        issues.append("The account is inactive.")
+    active_admin_count = int(
+        db.scalar(
+            select(func.count(UserAccount.id)).where(
+                UserAccount.role == "admin",
+                UserAccount.is_active.is_(True),
+            )
+        )
+        or 0
+    )
+    return AdminRecoveryInspection(
+        account_id=str(account.id),
+        email=account.email,
+        display_name=account.display_name,
+        role=account.role,
+        is_active=account.is_active,
+        password_reset_required=account.password_reset_required,
+        session_version=account.session_version,
+        last_login_at=account.last_login_at.isoformat() if account.last_login_at else None,
+        active_admin_count=active_admin_count,
+        eligible=not issues,
+        issues=tuple(issues),
+    )
+
+
+def recover_admin_access(
+    db: Session,
+    *,
+    email: str,
+    confirm_account_id: str,
+    new_password: str,
+    reason: str,
+    operator: str,
+) -> AdminRecoveryEvidence:
+    inspection = inspect_admin_recovery(db, email, lock=True)
+    if not inspection.eligible:
+        raise AdminAccessRecoveryBlocked(list(inspection.issues))
+    try:
+        confirmed_id = UUID(confirm_account_id)
+    except ValueError as exc:
+        raise AdminAccessRecoveryBlocked(["The confirmed account ID is not a valid UUID."]) from exc
+    if str(confirmed_id) != inspection.account_id:
+        raise AdminAccessRecoveryBlocked(["The confirmed account ID does not match the account."])
+    cleaned_reason = reason.strip()
+    if len(cleaned_reason) < 10:
+        raise AdminAccessRecoveryBlocked(["A recovery reason of at least 10 characters is required."])
+    cleaned_operator = operator.strip()
+    if not cleaned_operator:
+        raise AdminAccessRecoveryBlocked(["The recovery operator is required."])
+
+    account = db.get(UserAccount, confirmed_id)
+    if account is None:
+        raise AdminAccessRecoveryBlocked(["The account no longer exists."])
+    if verify_password(new_password, account.password_hash):
+        raise AdminAccessRecoveryBlocked(["The temporary password must differ from the existing password."])
+    new_password_hash = hash_password(new_password)
+    previous_session_version = account.session_version
+    account.password_hash = new_password_hash
+    account.session_version += 1
+    account.password_reset_required = True
+
+    throttle_result = db.execute(
+        delete(LoginThrottle).where(LoginThrottle.key_hash == login_subject_hash(account.email))
+    )
+    db.flush()
+    return AdminRecoveryEvidence(
+        recovery_id=str(uuid4()),
+        occurred_at=datetime.now(UTC).isoformat(),
+        account_id=str(account.id),
+        email=account.email,
+        display_name=account.display_name,
+        reason=cleaned_reason,
+        operator=cleaned_operator,
+        previous_session_version=previous_session_version,
+        new_session_version=account.session_version,
+        password_reset_required=account.password_reset_required,
+        sessions_invalidated=True,
+        login_throttles_cleared=int(throttle_result.rowcount or 0),
+    )
+
+
+def inspect_identity_cutover(
+    db: Session,
+    *,
+    canonical_admin_email: str,
+    configured_bootstrap_email: str | None,
+) -> IdentityCutoverReadiness:
+    admin_email = normalize_email(canonical_admin_email)
+    issues: list[str] = []
+    migration = migrate_email_domain(db)
+    pending_changes = len(migration.changes)
+    if pending_changes:
+        issues.append(f"{pending_changes} active identity or routing values still require migration.")
+
+    configured_email = normalize_email(configured_bootstrap_email) if configured_bootstrap_email else None
+    if configured_email is None:
+        issues.append("BOOTSTRAP_ADMIN_EMAIL is not configured.")
+    elif configured_email != admin_email:
+        issues.append("BOOTSTRAP_ADMIN_EMAIL does not match the canonical administrator.")
+
+    account: UserAccount | None
+    try:
+        account = _load_account(db, admin_email, lock=False)
+    except AdminAccessRecoveryBlocked as exc:
+        account = None
+        issues.extend(exc.issues)
+
+    admin_found = account is not None
+    admin_active = bool(account and account.is_active)
+    admin_role = bool(account and account.role == "admin")
+    password_change_complete = bool(account and not account.password_reset_required)
+    if account is not None:
+        if not admin_active:
+            issues.append("The canonical administrator account is inactive.")
+        if not admin_role:
+            issues.append("The canonical administrator account does not have the admin role.")
+        if not password_change_complete:
+            issues.append("The canonical administrator must complete the forced password change.")
+
+    return IdentityCutoverReadiness(
+        checked_at=datetime.now(UTC).isoformat(),
+        canonical_admin_email=admin_email,
+        configured_bootstrap_email=configured_email,
+        pending_identity_changes=pending_changes,
+        canonical_admin_found=admin_found,
+        canonical_admin_active=admin_active,
+        canonical_admin_role=admin_role,
+        password_change_complete=password_change_complete,
+        ready=not issues,
+        issues=tuple(issues),
+    )

--- a/backend/app/tools/admin_access_recovery.py
+++ b/backend/app/tools/admin_access_recovery.py
@@ -1,0 +1,86 @@
+"""Protected server-console inspection, recovery and cutover-readiness commands."""
+
+from argparse import ArgumentParser
+from getpass import getpass
+import json
+
+from app.core.config import get_settings
+from app.db.session import SessionLocal
+from app.services.admin_access_recovery import (
+    AdminAccessRecoveryBlocked,
+    inspect_admin_recovery,
+    inspect_identity_cutover,
+    recover_admin_access,
+)
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = subparsers.add_parser("inspect")
+    inspect_parser.add_argument("--email", required=True)
+
+    recover_parser = subparsers.add_parser("recover")
+    recover_parser.add_argument("--email", required=True)
+    recover_parser.add_argument("--confirm-account-id", required=True)
+    recover_parser.add_argument("--reason", required=True)
+    recover_parser.add_argument("--operator", required=True)
+    recover_parser.add_argument("--apply", action="store_true")
+
+    verify_parser = subparsers.add_parser("verify-cutover")
+    verify_parser.add_argument("--email", required=True)
+    return parser
+
+
+def _temporary_password() -> str:
+    first = getpass("New temporary password: ")
+    second = getpass("Repeat temporary password: ")
+    if first != second:
+        raise AdminAccessRecoveryBlocked(["The temporary passwords do not match."])
+    return first
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    settings = get_settings()
+    with SessionLocal() as db:
+        try:
+            if args.command == "inspect":
+                result = inspect_admin_recovery(db, args.email)
+                payload = {"status": "eligible" if result.eligible else "blocked", **result.to_dict()}
+                db.rollback()
+            elif args.command == "verify-cutover":
+                result = inspect_identity_cutover(
+                    db,
+                    canonical_admin_email=args.email,
+                    configured_bootstrap_email=settings.bootstrap_admin_email,
+                )
+                payload = {"status": "ready" if result.ready else "blocked", **result.to_dict()}
+                db.rollback()
+            else:
+                if not args.apply:
+                    raise AdminAccessRecoveryBlocked(["The recover command requires --apply."])
+                evidence = recover_admin_access(
+                    db,
+                    email=args.email,
+                    confirm_account_id=args.confirm_account_id,
+                    new_password=_temporary_password(),
+                    reason=args.reason,
+                    operator=args.operator,
+                )
+                db.commit()
+                payload = {"status": "applied", **evidence.to_dict()}
+        except AdminAccessRecoveryBlocked as exc:
+            db.rollback()
+            print(json.dumps({"status": "blocked", "issues": exc.issues}, indent=2))
+            raise SystemExit(2) from exc
+        except ValueError as exc:
+            db.rollback()
+            print(json.dumps({"status": "blocked", "issues": [str(exc)]}, indent=2))
+            raise SystemExit(2) from exc
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/builds/BUILD_232.md
+++ b/docs/builds/BUILD_232.md
@@ -1,0 +1,84 @@
+# Build 232 — Identity Cutover and Administrator Access Recovery
+
+## Task Card
+
+- **Lead function:** System Governance
+- **Supporting functions:** Administration and Communications, Security
+- **Owner:** Jeremie Peters
+- **Priority:** High
+- **Status:** Ready
+- **Dependency:** Build 231 — Email Identity Domain Cleanup
+- **Environment:** Development only
+- **Approval gate:** Approved release, verified backup and explicit production recovery approval
+
+## Objective
+
+Provide a controlled server-console path to inspect and recover a canonical Iron House
+administrator account when normal in-app administrator recovery is unavailable. Produce
+cutover-readiness evidence without exposing passwords or changing production
+automatically.
+
+## Verified
+
+- The canonical administrator identity uses `ironhousecontracting.com`.
+- The production application remains at `https://os.ironhousecivil.com`.
+- Password hashes, account IDs, roles and session versions are held in the IHOS database.
+- Normal in-app password reset requires an already authenticated administrator.
+- Build 231 provides the current-identity migration and must precede cutover verification.
+
+## Assumptions
+
+- The operator has authorised server-console and Docker access.
+- The operator can securely enter a temporary password without placing it in command
+  history or an evidence file.
+- The recovered administrator will immediately complete the forced password change.
+
+## Included
+
+- Read-only administrator recovery inspection.
+- Exact UUID confirmation before recovery.
+- Canonical-domain, administrator-role and active-account eligibility checks.
+- Interactive hidden password entry with confirmation.
+- Existing-password reuse prevention.
+- Session invalidation and login-throttle removal.
+- Forced password change on next login.
+- Non-secret JSON recovery evidence.
+- Post-cutover readiness verification covering:
+  - residual Build 231 identity changes;
+  - canonical administrator presence, status and role;
+  - production bootstrap email alignment;
+  - completion of the forced password change.
+
+## Excluded
+
+- Email delivery, password-reset links or third-party identity providers.
+- Browser credential entry or transfer of Safari session cookies.
+- Account creation, account merging or role elevation.
+- Production deployment, recovery execution or merge.
+
+## Review Gates
+
+| Gate | Required evidence | Status |
+|---|---|---|
+| Recovery security | Wrong account, role, domain, state, UUID and reused password blocked | Complete |
+| Secret handling | Password absent from arguments and JSON evidence | Complete |
+| Cutover readiness | Pending migration and forced password change reported | Complete |
+| Regression | Backend, frontend, build and visual-lock checks | Complete |
+| Production approval | Backup and explicit recovery authorisation | Blocked pending approval |
+
+## Open Items
+
+- Review and approve Build 231 before using Build 232 in production.
+- Confirm the exact canonical administrator account ID from the read-only inspection.
+- Establish an approved production maintenance and recovery window.
+- Confirm secure evidence retention location and recovery operator.
+
+## Build Log
+
+- **2026-07-24:** Build 232 task card opened as a dependent development build.
+- **2026-07-24:** Server-console inspection, guarded recovery, session invalidation,
+  hidden password entry and cutover-readiness reporting implemented.
+- **2026-07-24:** Verification completed: 152 backend tests, 21 frontend tests,
+  TypeScript lint, frontend production build, Ruff and the 13-file visual-design lock
+  passed. One existing Pydantic warning and one existing frontend chunk-size warning
+  remain non-blocking.

--- a/docs/operations/admin-access-recovery.md
+++ b/docs/operations/admin-access-recovery.md
@@ -1,0 +1,110 @@
+# Administrator Access Recovery Runbook
+
+Use this runbook only when the canonical IHOS administrator cannot sign in and normal
+in-app administrator recovery is unavailable.
+
+## Preconditions
+
+Do not perform recovery until:
+
+1. Builds 231 and 232 are approved and deployed through the protected release process.
+2. A complete recovery backup has been created and verified.
+3. The maintenance window and recovery operator are approved.
+4. The Build 231 identity migration has been applied or its dry run has been reviewed.
+5. The operator is connected to the canonical production server,
+   `iron-house-os-prod-1`.
+
+Never place the temporary password in a command argument, chat, shell history, evidence
+file or support ticket.
+
+## Inspect the Account
+
+This command is read-only:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps backend \
+  python -m app.tools.admin_access_recovery inspect \
+  --email jeremie@ironhousecontracting.com
+```
+
+Confirm:
+
+- the display name is Jeremie Peters;
+- the role is `admin`;
+- the account is active;
+- `eligible` is `true`;
+- the account UUID matches the approved recovery target.
+
+## Recover Access
+
+Run interactively so the password prompts remain hidden:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps backend \
+  python -m app.tools.admin_access_recovery recover \
+  --email jeremie@ironhousecontracting.com \
+  --confirm-account-id <UUID-FROM-INSPECTION> \
+  --reason "Business account migration access recovery" \
+  --operator "Jeremie Peters" \
+  --apply
+```
+
+Enter the temporary password twice at the hidden prompts. Save the resulting JSON as
+restricted recovery evidence only after confirming it contains no password or password
+hash.
+
+The recovery:
+
+- preserves the account ID, email, role and active state;
+- replaces the password hash;
+- increments the session version and invalidates existing sessions;
+- clears the account login throttle;
+- requires a password change after the next successful login.
+
+## Complete the Recovery
+
+1. Sign in at `https://os.ironhousecivil.com` using the canonical email and temporary
+   password.
+2. Complete the forced password change.
+3. Confirm administrator access and required navigation.
+4. Do not reuse or retain the temporary password.
+
+## Verify Cutover
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps -T backend \
+  python -m app.tools.admin_access_recovery verify-cutover \
+  --email jeremie@ironhousecontracting.com
+```
+
+The result is ready only when:
+
+- no active identity or routing values remain for Build 231 migration;
+- the configured bootstrap email matches the canonical administrator;
+- the administrator exists, is active and has the admin role;
+- the forced password change is complete.
+
+## Stop Conditions
+
+Stop without applying recovery if:
+
+- inspection reports more than one matching account;
+- the account ID, display name, domain, role or active state is unexpected;
+- the recovery backup is missing or unverified;
+- the reason or operator is not approved;
+- any command output contains a password or password hash.
+
+## Rollback
+
+If the confirmed account was changed incorrectly, stop the application and restore the
+verified pre-recovery backup using the approved recovery procedure. Do not create a
+replacement administrator, merge accounts or edit password hashes directly.

--- a/scripts/admin_access_recovery.py
+++ b/scripts/admin_access_recovery.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Repository wrapper for the packaged administrator recovery operator tool."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "backend"))
+
+from app.tools.admin_access_recovery import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backend/test_admin_access_recovery.py
+++ b/tests/backend/test_admin_access_recovery.py
@@ -1,0 +1,194 @@
+import json
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+from app.models.user import Employee, LoginThrottle, UserAccount
+from app.services.admin_access_recovery import (
+    AdminAccessRecoveryBlocked,
+    inspect_admin_recovery,
+    inspect_identity_cutover,
+    recover_admin_access,
+)
+from app.services.auth import hash_password, login_subject_hash, verify_password
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    LEGACY_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+def _email(local_part: str, domain: str = CANONICAL_EMAIL_DOMAIN) -> str:
+    return f"{local_part}@{domain}"
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _admin(
+    *,
+    email: str | None = None,
+    role: str = "admin",
+    is_active: bool = True,
+    password_reset_required: bool = False,
+) -> UserAccount:
+    return UserAccount(
+        email=email or _email("jeremie"),
+        display_name="Jeremie Peters",
+        role=role,
+        password_hash=hash_password("existing-admin-password"),
+        is_active=is_active,
+        session_version=3,
+        password_reset_required=password_reset_required,
+    )
+
+
+def test_admin_recovery_inspection_returns_safe_account_confirmation() -> None:
+    with _session() as db:
+        account = _admin()
+        db.add(account)
+        db.commit()
+
+        result = inspect_admin_recovery(db, account.email)
+        rendered = json.dumps(result.to_dict())
+
+        assert result.eligible is True
+        assert result.account_id == str(account.id)
+        assert result.active_admin_count == 1
+        assert "existing-admin-password" not in rendered
+        assert "password_hash" not in rendered
+
+
+def test_admin_recovery_resets_password_invalidates_sessions_and_clears_throttle() -> None:
+    with _session() as db:
+        account = _admin()
+        db.add(account)
+        db.flush()
+        db.add(
+            LoginThrottle(
+                key_hash=login_subject_hash(account.email),
+                failed_attempts=5,
+            )
+        )
+        db.commit()
+
+        evidence = recover_admin_access(
+            db,
+            email=account.email,
+            confirm_account_id=str(account.id),
+            new_password="temporary-admin-password",
+            reason="Business account migration access loss",
+            operator="Jeremie Peters",
+        )
+        db.commit()
+        recovered = db.get(UserAccount, account.id)
+
+        assert recovered is not None
+        assert verify_password("temporary-admin-password", recovered.password_hash)
+        assert recovered.session_version == 4
+        assert recovered.password_reset_required is True
+        assert evidence.previous_session_version == 3
+        assert evidence.new_session_version == 4
+        assert evidence.login_throttles_cleared == 1
+        assert db.scalars(select(LoginThrottle)).all() == []
+        rendered = json.dumps(evidence.to_dict())
+        assert "temporary-admin-password" not in rendered
+        assert "password_hash" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("account", "confirmed_id", "reason", "issue"),
+    [
+        (_admin(role="viewer"), None, "Business access recovery", "not an administrator"),
+        (_admin(is_active=False), None, "Business access recovery", "inactive"),
+        (
+            _admin(email=_email("jeremie", LEGACY_EMAIL_DOMAIN)),
+            None,
+            "Business access recovery",
+            "canonical company email domain",
+        ),
+        (_admin(), "00000000-0000-0000-0000-000000000999", "Business access recovery", "does not match"),
+        (_admin(), None, "short", "at least 10 characters"),
+    ],
+)
+def test_admin_recovery_refuses_unsafe_targets(
+    account: UserAccount,
+    confirmed_id: str | None,
+    reason: str,
+    issue: str,
+) -> None:
+    with _session() as db:
+        db.add(account)
+        db.commit()
+
+        with pytest.raises(AdminAccessRecoveryBlocked, match=issue):
+            recover_admin_access(
+                db,
+                email=account.email,
+                confirm_account_id=confirmed_id or str(account.id),
+                new_password="temporary-admin-password",
+                reason=reason,
+                operator="Jeremie Peters",
+            )
+        db.rollback()
+        unchanged = db.get(UserAccount, account.id)
+        assert unchanged is not None
+        assert unchanged.session_version == 3
+        assert verify_password("existing-admin-password", unchanged.password_hash)
+
+
+def test_admin_recovery_refuses_password_reuse() -> None:
+    with _session() as db:
+        account = _admin()
+        db.add(account)
+        db.commit()
+
+        with pytest.raises(AdminAccessRecoveryBlocked, match="must differ"):
+            recover_admin_access(
+                db,
+                email=account.email,
+                confirm_account_id=str(account.id),
+                new_password="existing-admin-password",
+                reason="Business account migration access loss",
+                operator="Jeremie Peters",
+            )
+
+
+def test_identity_cutover_readiness_tracks_migration_and_password_change() -> None:
+    with _session() as db:
+        account = _admin(password_reset_required=True)
+        employee = Employee(
+            first_name="Jeremie",
+            last_name="Peters",
+            email=_email("jeremie", LEGACY_EMAIL_DOMAIN),
+            status="active",
+            portal_role="employee",
+        )
+        db.add_all([account, employee])
+        db.commit()
+
+        blocked = inspect_identity_cutover(
+            db,
+            canonical_admin_email=account.email,
+            configured_bootstrap_email=account.email,
+        )
+        assert blocked.ready is False
+        assert blocked.pending_identity_changes == 1
+        assert any("forced password change" in issue for issue in blocked.issues)
+
+        migrate_email_domain(db, apply=True)
+        account.password_reset_required = False
+        db.commit()
+        ready = inspect_identity_cutover(
+            db,
+            canonical_admin_email=account.email,
+            configured_bootstrap_email=account.email,
+        )
+        assert ready.ready is True
+        assert ready.pending_identity_changes == 0
+        assert ready.issues == ()


### PR DESCRIPTION
## Outcome

Adds a protected server-console path to inspect and recover the canonical IHOS administrator when normal in-app administrator recovery is unavailable. This is a dependent PR and targets Build 231.

## Included

- read-only administrator recovery inspection
- exact account UUID confirmation
- canonical-domain, active-account and administrator-role eligibility checks
- interactive hidden temporary-password entry
- existing-password reuse prevention
- session invalidation and login-throttle cleanup
- forced password change after recovery
- non-secret JSON recovery evidence
- post-cutover readiness verification for residual identity changes, bootstrap email alignment, administrator status/role and password-change completion
- Build 232 task card and production operator runbook

## Verification

- Ruff: passed
- Backend: 152 passed (one existing Pydantic warning)
- Frontend: 21 passed
- TypeScript lint: passed
- Frontend production build: passed (one existing chunk-size warning)
- Visual design lock: passed, 13 protected files

## Approval gate

This PR does not deploy, recover an account, merge, or modify production. Production use requires approved Builds 231 and 232, a verified backup, confirmed account inspection, an approved maintenance window, and explicit recovery authorisation.
