### PR TITLE
Build 233 — Identity Governance Centre

### DIFF
--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -13,7 +13,9 @@ from app.schemas.auth import (
     UserAccountRead,
     UserAccountUpdate,
 )
+from app.schemas.identity_governance import IdentityGovernanceSnapshot
 from app.services import auth
+from app.services.identity_governance import build_identity_governance_snapshot
 from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
 from app.services.request_context import get_request_audit_context
 
@@ -35,6 +37,11 @@ def list_users(_: AdminUser, db: DBSession) -> UserAccountList:
         items=[UserAccountRead.model_validate(account) for account in accounts],
         total=len(accounts),
     )
+
+
+@router.get("/governance", response_model=IdentityGovernanceSnapshot)
+def identity_governance(_: AdminUser, db: DBSession) -> IdentityGovernanceSnapshot:
+    return build_identity_governance_snapshot(db)
 
 
 @router.post("", response_model=UserAccountRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/schemas/identity_governance.py
+++ b/backend/app/schemas/identity_governance.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class IdentityGovernanceSummary(BaseModel):
+    total_accounts: int
+    active_accounts: int
+    active_administrators: int
+    legacy_domain_accounts: int
+    accounts_requiring_review: int
+    critical_findings: int
+
+
+class IdentityGovernanceAccount(BaseModel):
+    id: UUID
+    email: str
+    display_name: str
+    role: str
+    is_active: bool
+    last_login_at: datetime | None
+    password_reset_required: bool
+    review_reasons: list[str]
+
+
+class IdentityGovernanceFinding(BaseModel):
+    code: str
+    severity: Literal["critical", "high", "normal"]
+    title: str
+    recommendation: str
+    account_ids: list[UUID]
+
+
+class IdentityGovernanceSnapshot(BaseModel):
+    generated_at: datetime
+    canonical_email_domain: str
+    summary: IdentityGovernanceSummary
+    accounts: list[IdentityGovernanceAccount]
+    findings: list[IdentityGovernanceFinding]

--- a/backend/app/services/identity_governance.py
+++ b/backend/app/services/identity_governance.py
@@ -1,0 +1,183 @@
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.user import UserAccount
+from app.schemas.identity_governance import (
+    IdentityGovernanceAccount,
+    IdentityGovernanceFinding,
+    IdentityGovernanceSnapshot,
+    IdentityGovernanceSummary,
+)
+from app.services.email_domain_migration import CANONICAL_EMAIL_DOMAIN, LEGACY_EMAIL_DOMAIN
+
+
+def _utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+
+
+def build_identity_governance_snapshot(
+    db: Session,
+    *,
+    now: datetime | None = None,
+) -> IdentityGovernanceSnapshot:
+    generated_at = _utc(now) or datetime.now(timezone.utc)
+    accounts = list(db.scalars(select(UserAccount).order_by(UserAccount.email)))
+    reasons: dict[object, list[str]] = {account.id: [] for account in accounts}
+    findings: list[IdentityGovernanceFinding] = []
+
+    def add_finding(
+        code: str,
+        severity: str,
+        title: str,
+        recommendation: str,
+        affected: list[UserAccount],
+        reason: str,
+    ) -> None:
+        if not affected:
+            return
+        for account in affected:
+            reasons[account.id].append(reason)
+        findings.append(
+            IdentityGovernanceFinding(
+                code=code,
+                severity=severity,
+                title=title,
+                recommendation=recommendation,
+                account_ids=[account.id for account in affected],
+            )
+        )
+
+    active_admins = [account for account in accounts if account.is_active and account.role == "admin"]
+    if not active_admins:
+        findings.append(
+            IdentityGovernanceFinding(
+                code="no_active_administrator",
+                severity="critical",
+                title="No active administrator account",
+                recommendation="Recover and verify an administrator account before further access changes.",
+                account_ids=[],
+            )
+        )
+    elif len(active_admins) == 1:
+        add_finding(
+            "single_active_administrator",
+            "high",
+            "Single active administrator",
+            "Approve and provision a second named administrator to remove the access single point of failure.",
+            active_admins,
+            "Only active administrator",
+        )
+
+    legacy = [account for account in accounts if account.email.lower().endswith(f"@{LEGACY_EMAIL_DOMAIN}")]
+    add_finding(
+        "legacy_email_domain",
+        "critical",
+        "Legacy company email domain remains",
+        f"Migrate the affected account to @{CANONICAL_EMAIL_DOMAIN} and invalidate its sessions.",
+        legacy,
+        "Legacy email domain",
+    )
+
+    noncanonical = [
+        account
+        for account in accounts
+        if not account.email.lower().endswith(f"@{CANONICAL_EMAIL_DOMAIN}") and account not in legacy
+    ]
+    add_finding(
+        "noncanonical_email_domain",
+        "high",
+        "Account uses a non-canonical email domain",
+        "Confirm the business reason and document approval, or move the account to the company domain.",
+        noncanonical,
+        "Non-canonical email domain",
+    )
+
+    pending_reset = [account for account in accounts if account.is_active and account.password_reset_required]
+    add_finding(
+        "password_change_pending",
+        "high",
+        "Temporary password change is pending",
+        "Have the named user sign in and replace the temporary password.",
+        pending_reset,
+        "Password change pending",
+    )
+
+    never_used = [
+        account
+        for account in accounts
+        if account.is_active
+        and account.last_login_at is None
+        and _utc(account.created_at)
+        and generated_at - _utc(account.created_at) >= timedelta(days=7)
+    ]
+    add_finding(
+        "never_used_account",
+        "normal",
+        "Active account has never signed in",
+        "Confirm the account is still required; deactivate it if onboarding is no longer proceeding.",
+        never_used,
+        "Never signed in",
+    )
+
+    stale = [
+        account
+        for account in accounts
+        if account.is_active
+        and _utc(account.last_login_at)
+        and generated_at - _utc(account.last_login_at) >= timedelta(days=90)
+    ]
+    add_finding(
+        "stale_account",
+        "high",
+        "Active account has been unused for 90 days",
+        "Confirm access with the account owner and deactivate access that is no longer required.",
+        stale,
+        "No sign-in for 90 days",
+    )
+
+    by_email: dict[str, list[UserAccount]] = defaultdict(list)
+    for account in accounts:
+        by_email[account.email.casefold()].append(account)
+    duplicates = [group for group in by_email.values() if len(group) > 1]
+    for index, group in enumerate(duplicates, start=1):
+        add_finding(
+            f"duplicate_identity_{index}",
+            "critical",
+            "Case-insensitive duplicate identity",
+            "Freeze account changes and reconcile the duplicate records before migration or recovery.",
+            group,
+            "Duplicate identity",
+        )
+
+    governed_accounts = [
+        IdentityGovernanceAccount(
+            id=account.id,
+            email=account.email,
+            display_name=account.display_name,
+            role=account.role,
+            is_active=account.is_active,
+            last_login_at=_utc(account.last_login_at),
+            password_reset_required=account.password_reset_required,
+            review_reasons=reasons[account.id],
+        )
+        for account in accounts
+    ]
+    return IdentityGovernanceSnapshot(
+        generated_at=generated_at,
+        canonical_email_domain=CANONICAL_EMAIL_DOMAIN,
+        summary=IdentityGovernanceSummary(
+            total_accounts=len(accounts),
+            active_accounts=sum(account.is_active for account in accounts),
+            active_administrators=len(active_admins),
+            legacy_domain_accounts=len(legacy),
+            accounts_requiring_review=sum(bool(account.review_reasons) for account in governed_accounts),
+            critical_findings=sum(finding.severity == "critical" for finding in findings),
+        ),
+        accounts=governed_accounts,
+        findings=sorted(findings, key=lambda finding: {"critical": 0, "high": 1, "normal": 2}[finding.severity]),
+    )

--- a/docs/builds/BUILD_233.md
+++ b/docs/builds/BUILD_233.md
@@ -1,0 +1,40 @@
+# Build 233 — Identity Governance Centre
+
+## Task card
+
+- **Status:** Development complete; verification pending
+- **Owner:** Iron House OS build program
+- **Environment:** Development only
+- **Approval boundary:** No production deployment and no merge without approval
+
+## Verified
+
+- User accounts already record role, active state, last sign-in, and forced-password-change state.
+- User administration is restricted to the administrator role.
+- The approved Settings page can host governance information without changing the locked navigation or application shell.
+
+## Assumption
+
+- Seven days without a first sign-in warrants review.
+- Ninety days without a sign-in warrants review.
+- One active administrator is an access-continuity risk; zero is critical.
+
+## Delivered
+
+- Administrator-only identity governance snapshot API.
+- Canonical and legacy domain checks.
+- Active-administrator coverage check.
+- Pending password change, never-used, and stale-account checks.
+- Case-insensitive duplicate identity detection.
+- Settings-based Identity Governance Centre with summary, findings, and account review reasons.
+- Responses exclude password hashes and session versions.
+
+## Open items
+
+- Thresholds require management approval before they become formal policy.
+- Account review decisions and evidence are not yet persisted.
+- Production identity data has not been inspected or changed.
+
+## Automation recommendation
+
+Run the governance snapshot weekly and notify administrators only when findings change or critical findings exist.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -22,6 +22,27 @@ export type RoleAccess = {
   modules: Record<string, string[]>;
 };
 
+export type IdentityGovernance = {
+  generated_at: string;
+  canonical_email_domain: string;
+  summary: {
+    total_accounts: number;
+    active_accounts: number;
+    active_administrators: number;
+    legacy_domain_accounts: number;
+    accounts_requiring_review: number;
+    critical_findings: number;
+  };
+  accounts: Array<AuthUser & { review_reasons: string[] }>;
+  findings: Array<{
+    code: string;
+    severity: "critical" | "high" | "normal";
+    title: string;
+    recommendation: string;
+    account_ids: string[];
+  }>;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function readAuthResponse(response: Response): Promise<AuthStatus> {
@@ -64,5 +85,10 @@ export const authApi = {
     const response = await apiFetch(`${API_BASE_URL}/auth/me/permissions`);
     if (!response.ok) throw new Error(`Unable to load permissions (${response.status})`);
     return response.json() as Promise<RoleAccess>;
+  },
+  identityGovernance: async (): Promise<IdentityGovernance> => {
+    const response = await apiFetch(`${API_BASE_URL}/users/governance`);
+    if (!response.ok) throw new Error(`Unable to load identity governance (${response.status})`);
+    return response.json() as Promise<IdentityGovernance>;
   },
 };

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
-import { Bot, KeyRound, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Bot, KeyRound, ShieldCheck, Users } from "lucide-react";
 import { FormEvent, useEffect, useState } from "react";
 
-import { RoleAccess, authApi } from "../api/auth";
+import { IdentityGovernance, RoleAccess, authApi } from "../api/auth";
 import { useAuth } from "../contexts/AuthContext";
 import { Link } from "react-router-dom";
 
@@ -54,8 +54,61 @@ export function SettingsPage() {
 
         <ChangePasswordPanel />
       </div>
+      {user?.role === "admin" ? <IdentityGovernancePanel /> : null}
     </section>
   );
+}
+
+function IdentityGovernancePanel() {
+  const [governance, setGovernance] = useState<IdentityGovernance | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    authApi.identityGovernance().then(setGovernance).catch((currentError) => {
+      setError(currentError instanceof Error ? currentError.message : "Unable to load identity governance");
+    });
+  }, []);
+
+  return (
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <div className="flex items-center gap-2"><Users className="h-5 w-5" /><h2 className="font-semibold">Identity Governance Centre</h2></div>
+      <p className="mt-2 text-sm text-iron-500">Administrator-only review of company identities, access continuity, and account hygiene.</p>
+      {error ? <div role="alert" className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
+      {!governance && !error ? <p className="mt-4 text-sm text-iron-500">Loading identity governance…</p> : null}
+      {governance ? (
+        <>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3 xl:grid-cols-6">
+            <Metric label="Accounts" value={governance.summary.total_accounts} />
+            <Metric label="Active" value={governance.summary.active_accounts} />
+            <Metric label="Administrators" value={governance.summary.active_administrators} />
+            <Metric label="Legacy domain" value={governance.summary.legacy_domain_accounts} />
+            <Metric label="Needs review" value={governance.summary.accounts_requiring_review} />
+            <Metric label="Critical" value={governance.summary.critical_findings} />
+          </div>
+          <div className="mt-6 grid gap-3">
+            {governance.findings.length ? governance.findings.map((finding) => (
+              <div key={finding.code} className="rounded-md border border-iron-100 p-4">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className={`mt-0.5 h-5 w-5 ${finding.severity === "critical" ? "text-red-600" : "text-brand-gold"}`} />
+                  <div><div className="font-semibold text-iron-950">{finding.title}</div><div className="mt-1 text-sm text-iron-500">{finding.recommendation}</div><div className="mt-2 text-xs uppercase tracking-wide text-iron-500">{finding.severity} · {finding.account_ids.length} affected</div></div>
+                </div>
+              </div>
+            )) : <div className="rounded-md bg-green-50 p-4 text-sm text-green-800">No identity governance findings require action.</div>}
+          </div>
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead><tr className="border-b border-iron-100 text-xs uppercase tracking-wide text-iron-500"><th className="px-3 py-2">Account</th><th className="px-3 py-2">Role</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Review</th></tr></thead>
+              <tbody>{governance.accounts.map((account) => <tr key={account.id} className="border-b border-iron-100"><td className="px-3 py-3"><div className="font-medium">{account.display_name}</div><div className="text-xs text-iron-500">{account.email}</div></td><td className="px-3 py-3 capitalize">{account.role.replace("_", " ")}</td><td className="px-3 py-3">{account.is_active ? "Active" : "Inactive"}</td><td className="px-3 py-3 text-iron-500">{account.review_reasons.join(", ") || "Clear"}</td></tr>)}</tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return <div className="rounded-md bg-iron-50 p-3"><div className="text-xs uppercase tracking-wide text-iron-500">{label}</div><div className="mt-1 text-2xl font-semibold text-iron-950">{value}</div></div>;
 }
 
 function ChangePasswordPanel() {

--- a/tests/backend/test_identity_governance.py
+++ b/tests/backend/test_identity_governance.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.user import UserAccount
+from app.services.auth import hash_password
+from app.services.identity_governance import build_identity_governance_snapshot
+from conftest import TestingSessionLocal
+
+client = TestClient(app)
+NOW = datetime(2026, 7, 24, 16, 0, tzinfo=timezone.utc)
+
+
+def account(email: str, *, role: str = "viewer", active: bool = True) -> UserAccount:
+    return UserAccount(
+        email=email,
+        display_name=email.split("@")[0].replace(".", " ").title(),
+        role=role,
+        password_hash=hash_password("Build-233-secure-password"),
+        is_active=active,
+    )
+
+
+def test_snapshot_identifies_access_and_domain_risks_without_secrets() -> None:
+    with TestingSessionLocal() as db:
+        admin = account("jeremie@ironhousecontracting.com", role="admin")
+        admin.created_at = NOW - timedelta(days=30)
+        admin.last_login_at = NOW - timedelta(days=1)
+        legacy = account("taryn@ironhousecivil.com")
+        legacy.created_at = NOW - timedelta(days=100)
+        legacy.last_login_at = NOW - timedelta(days=95)
+        legacy.password_reset_required = True
+        db.add_all([admin, legacy])
+        db.commit()
+
+        snapshot = build_identity_governance_snapshot(db, now=NOW)
+        payload = snapshot.model_dump(mode="json")
+
+    assert snapshot.summary.total_accounts == 2
+    assert snapshot.summary.active_administrators == 1
+    assert snapshot.summary.legacy_domain_accounts == 1
+    assert snapshot.summary.accounts_requiring_review == 2
+    assert [finding.code for finding in snapshot.findings][:2] == [
+        "legacy_email_domain",
+        "single_active_administrator",
+    ]
+    assert "password_hash" not in str(payload)
+    assert "session_version" not in str(payload)
+
+
+def test_governance_endpoint_is_administrator_only_and_has_stable_shape() -> None:
+    response = client.get("/api/v1/users/governance")
+    assert response.status_code == 200
+    assert response.json()["canonical_email_domain"] == "ironhousecontracting.com"
+    assert response.json()["summary"]["total_accounts"] == 0
+    assert response.json()["findings"][0]["code"] == "no_active_administrator"


### PR DESCRIPTION
## Task card

Development-only Build 233. Adds an administrator-only Identity Governance Centre with legacy-domain detection, administrator coverage, stale/unused account checks, pending password changes, duplicate identity detection, and secret-safe reporting.

## Verified

- 154 backend tests pass
- Ruff passes
- 21 frontend tests pass
- TypeScript lint and production build pass
- 13-file visual design lock passes

## Assumptions

- 7 days without first sign-in triggers review
- 90 days without sign-in triggers review
- One active administrator is a continuity risk

## Open items

- Management approval of policy thresholds
- Persisted review decisions are deferred
- No production data inspected or changed

Dependent on Build 232. Stop before merge.