### PR TITLE
Builds 231–234 — Identity Cutover and Governance Release

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -104,7 +104,7 @@ jobs:
       POSTGRES_USER: iron_house
       POSTGRES_PASSWORD: build-207-ci-database-password
       SECRET_KEY: build-207-ci-secret-key-at-least-32-characters
-      BOOTSTRAP_ADMIN_EMAIL: build209@ironhousecivil.com
+      BOOTSTRAP_ADMIN_EMAIL: build209@ironhousecontracting.com
       BOOTSTRAP_ADMIN_PASSWORD: build-209-ci-login-password
       BOOTSTRAP_ADMIN_NAME: Build 209 Release User
       SESSION_COOKIE_SECURE: "false"

--- a/backend/app/api/v1/routes/users.py
+++ b/backend/app/api/v1/routes/users.py
@@ -13,7 +13,9 @@ from app.schemas.auth import (
     UserAccountRead,
     UserAccountUpdate,
 )
+from app.schemas.identity_governance import IdentityGovernanceSnapshot
 from app.services import auth
+from app.services.identity_governance import build_identity_governance_snapshot
 from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
 from app.services.request_context import get_request_audit_context
 
@@ -35,6 +37,11 @@ def list_users(_: AdminUser, db: DBSession) -> UserAccountList:
         items=[UserAccountRead.model_validate(account) for account in accounts],
         total=len(accounts),
     )
+
+
+@router.get("/governance", response_model=IdentityGovernanceSnapshot)
+def identity_governance(_: AdminUser, db: DBSession) -> IdentityGovernanceSnapshot:
+    return build_identity_governance_snapshot(db)
 
 
 @router.post("", response_model=UserAccountRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/db/bootstrap_admin.py
+++ b/backend/app/db/bootstrap_admin.py
@@ -4,17 +4,26 @@ from app.core.config import get_settings
 from app.db.session import SessionLocal
 from app.models.user import UserAccount
 from app.services.auth import hash_password, normalize_email
+from app.services.email_domain_migration import LEGACY_EMAIL_DOMAIN
+
+
+def validate_bootstrap_admin_email(value: str) -> str:
+    email = normalize_email(value)
+    if email.rsplit("@", 1)[-1] == LEGACY_EMAIL_DOMAIN:
+        raise RuntimeError(
+            "BOOTSTRAP_ADMIN_EMAIL uses the retired company email domain. "
+            "Use the canonical Iron House Contracting email domain."
+        )
+    return email
 
 
 def bootstrap_admin() -> bool:
     settings = get_settings()
     if not settings.bootstrap_admin_email or not settings.bootstrap_admin_password:
         if settings.environment.lower() == "production":
-            raise RuntimeError(
-                "BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD are required in production."
-            )
+            raise RuntimeError("BOOTSTRAP_ADMIN_EMAIL and BOOTSTRAP_ADMIN_PASSWORD are required in production.")
         return False
-    email = normalize_email(settings.bootstrap_admin_email)
+    email = validate_bootstrap_admin_email(settings.bootstrap_admin_email)
     with SessionLocal() as db:
         existing = db.scalar(select(UserAccount).where(func.lower(UserAccount.email) == email))
         if existing is not None:

--- a/backend/app/schemas/identity_governance.py
+++ b/backend/app/schemas/identity_governance.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class IdentityGovernanceSummary(BaseModel):
+    total_accounts: int
+    active_accounts: int
+    active_administrators: int
+    legacy_domain_accounts: int
+    accounts_requiring_review: int
+    critical_findings: int
+
+
+class IdentityGovernanceAccount(BaseModel):
+    id: UUID
+    email: str
+    display_name: str
+    role: str
+    is_active: bool
+    last_login_at: datetime | None
+    password_reset_required: bool
+    review_reasons: list[str]
+
+
+class IdentityGovernanceFinding(BaseModel):
+    code: str
+    severity: Literal["critical", "high", "normal"]
+    title: str
+    recommendation: str
+    account_ids: list[UUID]
+
+
+class IdentityGovernanceSnapshot(BaseModel):
+    generated_at: datetime
+    canonical_email_domain: str
+    summary: IdentityGovernanceSummary
+    accounts: list[IdentityGovernanceAccount]
+    findings: list[IdentityGovernanceFinding]

--- a/backend/app/services/admin_access_recovery.py
+++ b/backend/app/services/admin_access_recovery.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.orm import Session
+
+from app.models.user import LoginThrottle, UserAccount
+from app.services.auth import hash_password, login_subject_hash, normalize_email, verify_password
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+class AdminAccessRecoveryBlocked(ValueError):
+    def __init__(self, issues: list[str]) -> None:
+        self.issues = tuple(issues)
+        super().__init__("Administrator access recovery blocked: " + "; ".join(issues))
+
+
+@dataclass(frozen=True)
+class AdminRecoveryInspection:
+    account_id: str
+    email: str
+    display_name: str
+    role: str
+    is_active: bool
+    password_reset_required: bool
+    session_version: int
+    last_login_at: str | None
+    active_admin_count: int
+    eligible: bool
+    issues: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AdminRecoveryEvidence:
+    recovery_id: str
+    occurred_at: str
+    account_id: str
+    email: str
+    display_name: str
+    reason: str
+    operator: str
+    previous_session_version: int
+    new_session_version: int
+    password_reset_required: bool
+    sessions_invalidated: bool
+    login_throttles_cleared: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class IdentityCutoverReadiness:
+    checked_at: str
+    canonical_admin_email: str
+    configured_bootstrap_email: str | None
+    pending_identity_changes: int
+    canonical_admin_found: bool
+    canonical_admin_active: bool
+    canonical_admin_role: bool
+    password_change_complete: bool
+    ready: bool
+    issues: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _load_account(db: Session, email: str, *, lock: bool) -> UserAccount:
+    normalised = normalize_email(email)
+    statement = select(UserAccount).where(func.lower(UserAccount.email) == normalised)
+    if lock:
+        statement = statement.with_for_update()
+    accounts = list(db.scalars(statement))
+    if not accounts:
+        raise AdminAccessRecoveryBlocked(["No account matches the supplied email."])
+    if len(accounts) > 1:
+        raise AdminAccessRecoveryBlocked(["Multiple accounts match the supplied email case-insensitively."])
+    return accounts[0]
+
+
+def inspect_admin_recovery(db: Session, email: str, *, lock: bool = False) -> AdminRecoveryInspection:
+    account = _load_account(db, email, lock=lock)
+    issues: list[str] = []
+    domain = account.email.rsplit("@", 1)[-1].casefold()
+    if domain != CANONICAL_EMAIL_DOMAIN:
+        issues.append("The account does not use the canonical company email domain.")
+    if account.role != "admin":
+        issues.append("The account is not an administrator.")
+    if not account.is_active:
+        issues.append("The account is inactive.")
+    active_admin_count = int(
+        db.scalar(
+            select(func.count(UserAccount.id)).where(
+                UserAccount.role == "admin",
+                UserAccount.is_active.is_(True),
+            )
+        )
+        or 0
+    )
+    return AdminRecoveryInspection(
+        account_id=str(account.id),
+        email=account.email,
+        display_name=account.display_name,
+        role=account.role,
+        is_active=account.is_active,
+        password_reset_required=account.password_reset_required,
+        session_version=account.session_version,
+        last_login_at=account.last_login_at.isoformat() if account.last_login_at else None,
+        active_admin_count=active_admin_count,
+        eligible=not issues,
+        issues=tuple(issues),
+    )
+
+
+def recover_admin_access(
+    db: Session,
+    *,
+    email: str,
+    confirm_account_id: str,
+    new_password: str,
+    reason: str,
+    operator: str,
+) -> AdminRecoveryEvidence:
+    inspection = inspect_admin_recovery(db, email, lock=True)
+    if not inspection.eligible:
+        raise AdminAccessRecoveryBlocked(list(inspection.issues))
+    try:
+        confirmed_id = UUID(confirm_account_id)
+    except ValueError as exc:
+        raise AdminAccessRecoveryBlocked(["The confirmed account ID is not a valid UUID."]) from exc
+    if str(confirmed_id) != inspection.account_id:
+        raise AdminAccessRecoveryBlocked(["The confirmed account ID does not match the account."])
+    cleaned_reason = reason.strip()
+    if len(cleaned_reason) < 10:
+        raise AdminAccessRecoveryBlocked(["A recovery reason of at least 10 characters is required."])
+    cleaned_operator = operator.strip()
+    if not cleaned_operator:
+        raise AdminAccessRecoveryBlocked(["The recovery operator is required."])
+
+    account = db.get(UserAccount, confirmed_id)
+    if account is None:
+        raise AdminAccessRecoveryBlocked(["The account no longer exists."])
+    if verify_password(new_password, account.password_hash):
+        raise AdminAccessRecoveryBlocked(["The temporary password must differ from the existing password."])
+    new_password_hash = hash_password(new_password)
+    previous_session_version = account.session_version
+    account.password_hash = new_password_hash
+    account.session_version += 1
+    account.password_reset_required = True
+
+    throttle_result = db.execute(
+        delete(LoginThrottle).where(LoginThrottle.key_hash == login_subject_hash(account.email))
+    )
+    db.flush()
+    return AdminRecoveryEvidence(
+        recovery_id=str(uuid4()),
+        occurred_at=datetime.now(UTC).isoformat(),
+        account_id=str(account.id),
+        email=account.email,
+        display_name=account.display_name,
+        reason=cleaned_reason,
+        operator=cleaned_operator,
+        previous_session_version=previous_session_version,
+        new_session_version=account.session_version,
+        password_reset_required=account.password_reset_required,
+        sessions_invalidated=True,
+        login_throttles_cleared=int(throttle_result.rowcount or 0),
+    )
+
+
+def inspect_identity_cutover(
+    db: Session,
+    *,
+    canonical_admin_email: str,
+    configured_bootstrap_email: str | None,
+) -> IdentityCutoverReadiness:
+    admin_email = normalize_email(canonical_admin_email)
+    issues: list[str] = []
+    migration = migrate_email_domain(db)
+    pending_changes = len(migration.changes)
+    if pending_changes:
+        issues.append(f"{pending_changes} active identity or routing values still require migration.")
+
+    configured_email = normalize_email(configured_bootstrap_email) if configured_bootstrap_email else None
+    if configured_email is None:
+        issues.append("BOOTSTRAP_ADMIN_EMAIL is not configured.")
+    elif configured_email != admin_email:
+        issues.append("BOOTSTRAP_ADMIN_EMAIL does not match the canonical administrator.")
+
+    account: UserAccount | None
+    try:
+        account = _load_account(db, admin_email, lock=False)
+    except AdminAccessRecoveryBlocked as exc:
+        account = None
+        issues.extend(exc.issues)
+
+    admin_found = account is not None
+    admin_active = bool(account and account.is_active)
+    admin_role = bool(account and account.role == "admin")
+    password_change_complete = bool(account and not account.password_reset_required)
+    if account is not None:
+        if not admin_active:
+            issues.append("The canonical administrator account is inactive.")
+        if not admin_role:
+            issues.append("The canonical administrator account does not have the admin role.")
+        if not password_change_complete:
+            issues.append("The canonical administrator must complete the forced password change.")
+
+    return IdentityCutoverReadiness(
+        checked_at=datetime.now(UTC).isoformat(),
+        canonical_admin_email=admin_email,
+        configured_bootstrap_email=configured_email,
+        pending_identity_changes=pending_changes,
+        canonical_admin_found=admin_found,
+        canonical_admin_active=admin_active,
+        canonical_admin_role=admin_role,
+        password_change_complete=password_change_complete,
+        ready=not issues,
+        issues=tuple(issues),
+    )

--- a/backend/app/services/email_domain_migration.py
+++ b/backend/app/services/email_domain_migration.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass
+import re
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from app.models.contact import Contact
+from app.models.field_operations import FieldRecord
+from app.models.rfq import RFQPackage
+from app.models.supplier import Supplier
+from app.models.user import Employee, LoginThrottle, UserAccount
+from app.services.auth import login_subject_hash
+
+LEGACY_EMAIL_DOMAIN = "ironhousecivil.com"
+CANONICAL_EMAIL_DOMAIN = "ironhousecontracting.com"
+
+
+@dataclass(frozen=True)
+class EmailDomainChange:
+    area: str
+    record_id: str
+    field: str
+    previous: str
+    replacement: str
+
+
+@dataclass(frozen=True)
+class EmailDomainMigrationReport:
+    applied: bool
+    from_domain: str
+    to_domain: str
+    changes: tuple[EmailDomainChange, ...]
+    sessions_invalidated: int
+    login_throttles_cleared: int
+    protected_history_policy: str = "Historical audit and provenance fields were not changed."
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["change_count"] = len(self.changes)
+        counts: dict[str, int] = {}
+        for change in self.changes:
+            counts[change.area] = counts.get(change.area, 0) + 1
+        payload["changes_by_area"] = counts
+        return payload
+
+
+class EmailDomainMigrationConflict(ValueError):
+    def __init__(self, conflicts: list[str]) -> None:
+        self.conflicts = tuple(conflicts)
+        super().__init__("Email-domain migration blocked: " + "; ".join(conflicts))
+
+
+def _normalise_domain(value: str) -> str:
+    return value.strip().lower().lstrip("@")
+
+
+def _replacement(value: str | None, from_domain: str, to_domain: str) -> str | None:
+    if value is None or "@" not in value:
+        return value
+    local_part, domain = value.strip().rsplit("@", 1)
+    if not local_part or domain.casefold() != from_domain.casefold():
+        return value
+    return f"{local_part}@{to_domain}".lower()
+
+
+def _text_replacement(value: str, from_domain: str, to_domain: str) -> str:
+    pattern = re.compile(
+        rf"(?P<local>[A-Z0-9.!#$%&'*+/=?^_`{{|}}~-]+)@{re.escape(from_domain)}\b",
+        re.IGNORECASE,
+    )
+    return pattern.sub(
+        lambda match: f"{match.group('local').lower()}@{to_domain}",
+        value,
+    )
+
+
+def _change(
+    changes: list[EmailDomainChange],
+    *,
+    area: str,
+    record_id: object,
+    field: str,
+    previous: str | None,
+    replacement: str | None,
+) -> bool:
+    if previous is None or replacement is None or previous == replacement:
+        return False
+    changes.append(
+        EmailDomainChange(
+            area=area,
+            record_id=str(record_id),
+            field=field,
+            previous=previous,
+            replacement=replacement,
+        )
+    )
+    return True
+
+
+def _collision_conflicts(
+    rows: list[UserAccount] | list[Employee],
+    *,
+    area: str,
+    from_domain: str,
+    to_domain: str,
+) -> list[str]:
+    projected: dict[str, list[str]] = {}
+    conflicts: list[str] = []
+    for row in rows:
+        replacement = _replacement(row.email, from_domain, to_domain)
+        assert replacement is not None
+        if len(replacement) > 255:
+            conflicts.append(f"{area} record {row.id} would exceed the 255-character email limit")
+        projected.setdefault(replacement.casefold(), []).append(str(row.id))
+    for email, record_ids in projected.items():
+        if len(record_ids) > 1:
+            conflicts.append(f"{area} records {', '.join(record_ids)} would collide at {email}")
+    return conflicts
+
+
+def _migrate_supplier_metadata(
+    supplier: Supplier,
+    from_domain: str,
+    to_domain: str,
+    changes: list[EmailDomainChange],
+) -> dict[str, Any] | None:
+    metadata = deepcopy(supplier.metadata_json or {})
+    previous = metadata.get("email")
+    if not isinstance(previous, str):
+        return None
+    replacement = _replacement(previous, from_domain, to_domain)
+    if _change(
+        changes,
+        area="supplier_routing",
+        record_id=supplier.id,
+        field="metadata.email",
+        previous=previous,
+        replacement=replacement,
+    ):
+        metadata["email"] = replacement
+        return metadata
+    return None
+
+
+def _migrate_rfq_metadata(
+    rfq_package: RFQPackage,
+    from_domain: str,
+    to_domain: str,
+    changes: list[EmailDomainChange],
+) -> dict[str, Any] | None:
+    metadata = deepcopy(rfq_package.metadata_json or {})
+    changed = False
+
+    supplier_contacts = metadata.get("supplier_contacts")
+    if isinstance(supplier_contacts, dict):
+        for supplier_id, contact in supplier_contacts.items():
+            if not isinstance(contact, dict) or not isinstance(contact.get("recipient_email"), str):
+                continue
+            previous = contact["recipient_email"]
+            replacement = _replacement(previous, from_domain, to_domain)
+            if _change(
+                changes,
+                area="rfq_routing",
+                record_id=rfq_package.id,
+                field=f"supplier_contacts.{supplier_id}.recipient_email",
+                previous=previous,
+                replacement=replacement,
+            ):
+                contact["recipient_email"] = replacement
+                changed = True
+
+    workflow = metadata.get("gmail_drive_workflow")
+    if isinstance(workflow, dict):
+        sender = workflow.get("sender")
+        if isinstance(sender, dict) and isinstance(sender.get("email"), str):
+            previous = sender["email"]
+            replacement = _replacement(previous, from_domain, to_domain)
+            if _change(
+                changes,
+                area="rfq_routing",
+                record_id=rfq_package.id,
+                field="gmail_drive_workflow.sender.email",
+                previous=previous,
+                replacement=replacement,
+            ):
+                sender["email"] = replacement
+                changed = True
+        drafts = workflow.get("gmail_drafts")
+        if isinstance(drafts, list):
+            for index, draft in enumerate(drafts):
+                if not isinstance(draft, dict):
+                    continue
+                for field in ("to", "body"):
+                    previous = draft.get(field)
+                    if not isinstance(previous, str):
+                        continue
+                    replacement = (
+                        _replacement(previous, from_domain, to_domain)
+                        if field == "to"
+                        else _text_replacement(previous, from_domain, to_domain)
+                    )
+                    if _change(
+                        changes,
+                        area="rfq_routing",
+                        record_id=rfq_package.id,
+                        field=f"gmail_drive_workflow.gmail_drafts.{index}.{field}",
+                        previous=previous,
+                        replacement=replacement,
+                    ):
+                        draft[field] = replacement
+                        changed = True
+    return metadata if changed else None
+
+
+def _migrate_alert_recipients(
+    field_record: FieldRecord,
+    from_domain: str,
+    to_domain: str,
+    changes: list[EmailDomainChange],
+) -> list[Any] | None:
+    recipients = list(field_record.alert_recipients or [])
+    changed = False
+    for index, recipient in enumerate(recipients):
+        if not isinstance(recipient, str):
+            continue
+        replacement = _replacement(recipient, from_domain, to_domain)
+        if _change(
+            changes,
+            area="field_routing",
+            record_id=field_record.id,
+            field=f"alert_recipients.{index}",
+            previous=recipient,
+            replacement=replacement,
+        ):
+            recipients[index] = replacement
+            changed = True
+    return recipients if changed else None
+
+
+def migrate_email_domain(
+    db: Session,
+    *,
+    from_domain: str = LEGACY_EMAIL_DOMAIN,
+    to_domain: str = CANONICAL_EMAIL_DOMAIN,
+    apply: bool = False,
+) -> EmailDomainMigrationReport:
+    source = _normalise_domain(from_domain)
+    target = _normalise_domain(to_domain)
+    if not source or not target or source == target:
+        raise ValueError("Source and target email domains must be different non-empty domains.")
+
+    accounts = list(db.scalars(select(UserAccount).with_for_update()))
+    employees = list(db.scalars(select(Employee).with_for_update()))
+    contacts = list(db.scalars(select(Contact).with_for_update()))
+    suppliers = list(db.scalars(select(Supplier).with_for_update()))
+    rfq_packages = list(db.scalars(select(RFQPackage).with_for_update()))
+    field_records = list(db.scalars(select(FieldRecord).with_for_update()))
+
+    conflicts = _collision_conflicts(
+        accounts,
+        area="user_accounts",
+        from_domain=source,
+        to_domain=target,
+    )
+    conflicts.extend(
+        _collision_conflicts(
+            employees,
+            area="employees",
+            from_domain=source,
+            to_domain=target,
+        )
+    )
+    if conflicts:
+        raise EmailDomainMigrationConflict(conflicts)
+
+    changes: list[EmailDomainChange] = []
+    changed_accounts: list[tuple[UserAccount, str, str]] = []
+    changed_employees: list[tuple[Employee, str]] = []
+    changed_contacts: list[tuple[Contact, str]] = []
+    changed_suppliers: list[tuple[Supplier, dict[str, Any]]] = []
+    changed_packages: list[tuple[RFQPackage, dict[str, Any]]] = []
+    changed_records: list[tuple[FieldRecord, list[Any]]] = []
+
+    for account in accounts:
+        replacement = _replacement(account.email, source, target)
+        if _change(
+            changes,
+            area="user_accounts",
+            record_id=account.id,
+            field="email",
+            previous=account.email,
+            replacement=replacement,
+        ):
+            assert replacement is not None
+            changed_accounts.append((account, account.email, replacement))
+    for employee in employees:
+        replacement = _replacement(employee.email, source, target)
+        if _change(
+            changes,
+            area="employees",
+            record_id=employee.id,
+            field="email",
+            previous=employee.email,
+            replacement=replacement,
+        ):
+            assert replacement is not None
+            changed_employees.append((employee, replacement))
+    for contact in contacts:
+        replacement = _replacement(contact.email, source, target)
+        if _change(
+            changes,
+            area="contacts",
+            record_id=contact.id,
+            field="email",
+            previous=contact.email,
+            replacement=replacement,
+        ):
+            assert replacement is not None
+            changed_contacts.append((contact, replacement))
+    for supplier in suppliers:
+        metadata = _migrate_supplier_metadata(supplier, source, target, changes)
+        if metadata is not None:
+            changed_suppliers.append((supplier, metadata))
+    for rfq_package in rfq_packages:
+        metadata = _migrate_rfq_metadata(rfq_package, source, target, changes)
+        if metadata is not None:
+            changed_packages.append((rfq_package, metadata))
+    for field_record in field_records:
+        recipients = _migrate_alert_recipients(field_record, source, target, changes)
+        if recipients is not None:
+            changed_records.append((field_record, recipients))
+
+    cleared_throttles = 0
+    if apply:
+        for account, _, replacement in changed_accounts:
+            account.email = replacement
+            account.session_version += 1
+        for employee, replacement in changed_employees:
+            employee.email = replacement
+        for contact, replacement in changed_contacts:
+            contact.email = replacement
+        for supplier, metadata in changed_suppliers:
+            supplier.metadata_json = metadata
+        for rfq_package, metadata in changed_packages:
+            rfq_package.metadata_json = metadata
+        for field_record, recipients in changed_records:
+            field_record.alert_recipients = recipients
+
+        throttle_hashes = {
+            login_subject_hash(email)
+            for _, previous, replacement in changed_accounts
+            for email in (previous, replacement)
+        }
+        if throttle_hashes:
+            result = db.execute(delete(LoginThrottle).where(LoginThrottle.key_hash.in_(throttle_hashes)))
+            cleared_throttles = int(result.rowcount or 0)
+        db.flush()
+
+    return EmailDomainMigrationReport(
+        applied=apply,
+        from_domain=source,
+        to_domain=target,
+        changes=tuple(changes),
+        sessions_invalidated=len(changed_accounts) if apply else 0,
+        login_throttles_cleared=cleared_throttles,
+    )

--- a/backend/app/services/estimate_workbooks.py
+++ b/backend/app/services/estimate_workbooks.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.worksheet import Worksheet
 
 from app.schemas.estimate import EstimateCreate, EstimateSummary

--- a/backend/app/services/identity_governance.py
+++ b/backend/app/services/identity_governance.py
@@ -1,0 +1,183 @@
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.user import UserAccount
+from app.schemas.identity_governance import (
+    IdentityGovernanceAccount,
+    IdentityGovernanceFinding,
+    IdentityGovernanceSnapshot,
+    IdentityGovernanceSummary,
+)
+from app.services.email_domain_migration import CANONICAL_EMAIL_DOMAIN, LEGACY_EMAIL_DOMAIN
+
+
+def _utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+
+
+def build_identity_governance_snapshot(
+    db: Session,
+    *,
+    now: datetime | None = None,
+) -> IdentityGovernanceSnapshot:
+    generated_at = _utc(now) or datetime.now(timezone.utc)
+    accounts = list(db.scalars(select(UserAccount).order_by(UserAccount.email)))
+    reasons: dict[object, list[str]] = {account.id: [] for account in accounts}
+    findings: list[IdentityGovernanceFinding] = []
+
+    def add_finding(
+        code: str,
+        severity: str,
+        title: str,
+        recommendation: str,
+        affected: list[UserAccount],
+        reason: str,
+    ) -> None:
+        if not affected:
+            return
+        for account in affected:
+            reasons[account.id].append(reason)
+        findings.append(
+            IdentityGovernanceFinding(
+                code=code,
+                severity=severity,
+                title=title,
+                recommendation=recommendation,
+                account_ids=[account.id for account in affected],
+            )
+        )
+
+    active_admins = [account for account in accounts if account.is_active and account.role == "admin"]
+    if not active_admins:
+        findings.append(
+            IdentityGovernanceFinding(
+                code="no_active_administrator",
+                severity="critical",
+                title="No active administrator account",
+                recommendation="Recover and verify an administrator account before further access changes.",
+                account_ids=[],
+            )
+        )
+    elif len(active_admins) == 1:
+        add_finding(
+            "single_active_administrator",
+            "high",
+            "Single active administrator",
+            "Approve and provision a second named administrator to remove the access single point of failure.",
+            active_admins,
+            "Only active administrator",
+        )
+
+    legacy = [account for account in accounts if account.email.lower().endswith(f"@{LEGACY_EMAIL_DOMAIN}")]
+    add_finding(
+        "legacy_email_domain",
+        "critical",
+        "Legacy company email domain remains",
+        f"Migrate the affected account to @{CANONICAL_EMAIL_DOMAIN} and invalidate its sessions.",
+        legacy,
+        "Legacy email domain",
+    )
+
+    noncanonical = [
+        account
+        for account in accounts
+        if not account.email.lower().endswith(f"@{CANONICAL_EMAIL_DOMAIN}") and account not in legacy
+    ]
+    add_finding(
+        "noncanonical_email_domain",
+        "high",
+        "Account uses a non-canonical email domain",
+        "Confirm the business reason and document approval, or move the account to the company domain.",
+        noncanonical,
+        "Non-canonical email domain",
+    )
+
+    pending_reset = [account for account in accounts if account.is_active and account.password_reset_required]
+    add_finding(
+        "password_change_pending",
+        "high",
+        "Temporary password change is pending",
+        "Have the named user sign in and replace the temporary password.",
+        pending_reset,
+        "Password change pending",
+    )
+
+    never_used = [
+        account
+        for account in accounts
+        if account.is_active
+        and account.last_login_at is None
+        and _utc(account.created_at)
+        and generated_at - _utc(account.created_at) >= timedelta(days=7)
+    ]
+    add_finding(
+        "never_used_account",
+        "normal",
+        "Active account has never signed in",
+        "Confirm the account is still required; deactivate it if onboarding is no longer proceeding.",
+        never_used,
+        "Never signed in",
+    )
+
+    stale = [
+        account
+        for account in accounts
+        if account.is_active
+        and _utc(account.last_login_at)
+        and generated_at - _utc(account.last_login_at) >= timedelta(days=90)
+    ]
+    add_finding(
+        "stale_account",
+        "high",
+        "Active account has been unused for 90 days",
+        "Confirm access with the account owner and deactivate access that is no longer required.",
+        stale,
+        "No sign-in for 90 days",
+    )
+
+    by_email: dict[str, list[UserAccount]] = defaultdict(list)
+    for account in accounts:
+        by_email[account.email.casefold()].append(account)
+    duplicates = [group for group in by_email.values() if len(group) > 1]
+    for index, group in enumerate(duplicates, start=1):
+        add_finding(
+            f"duplicate_identity_{index}",
+            "critical",
+            "Case-insensitive duplicate identity",
+            "Freeze account changes and reconcile the duplicate records before migration or recovery.",
+            group,
+            "Duplicate identity",
+        )
+
+    governed_accounts = [
+        IdentityGovernanceAccount(
+            id=account.id,
+            email=account.email,
+            display_name=account.display_name,
+            role=account.role,
+            is_active=account.is_active,
+            last_login_at=_utc(account.last_login_at),
+            password_reset_required=account.password_reset_required,
+            review_reasons=reasons[account.id],
+        )
+        for account in accounts
+    ]
+    return IdentityGovernanceSnapshot(
+        generated_at=generated_at,
+        canonical_email_domain=CANONICAL_EMAIL_DOMAIN,
+        summary=IdentityGovernanceSummary(
+            total_accounts=len(accounts),
+            active_accounts=sum(account.is_active for account in accounts),
+            active_administrators=len(active_admins),
+            legacy_domain_accounts=len(legacy),
+            accounts_requiring_review=sum(bool(account.review_reasons) for account in governed_accounts),
+            critical_findings=sum(finding.severity == "critical" for finding in findings),
+        ),
+        accounts=governed_accounts,
+        findings=sorted(findings, key=lambda finding: {"critical": 0, "high": 1, "normal": 2}[finding.severity]),
+    )

--- a/backend/app/tools/__init__.py
+++ b/backend/app/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Controlled operator tools shipped with the Iron House OS backend."""

--- a/backend/app/tools/admin_access_recovery.py
+++ b/backend/app/tools/admin_access_recovery.py
@@ -1,0 +1,86 @@
+"""Protected server-console inspection, recovery and cutover-readiness commands."""
+
+from argparse import ArgumentParser
+from getpass import getpass
+import json
+
+from app.core.config import get_settings
+from app.db.session import SessionLocal
+from app.services.admin_access_recovery import (
+    AdminAccessRecoveryBlocked,
+    inspect_admin_recovery,
+    inspect_identity_cutover,
+    recover_admin_access,
+)
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = subparsers.add_parser("inspect")
+    inspect_parser.add_argument("--email", required=True)
+
+    recover_parser = subparsers.add_parser("recover")
+    recover_parser.add_argument("--email", required=True)
+    recover_parser.add_argument("--confirm-account-id", required=True)
+    recover_parser.add_argument("--reason", required=True)
+    recover_parser.add_argument("--operator", required=True)
+    recover_parser.add_argument("--apply", action="store_true")
+
+    verify_parser = subparsers.add_parser("verify-cutover")
+    verify_parser.add_argument("--email", required=True)
+    return parser
+
+
+def _temporary_password() -> str:
+    first = getpass("New temporary password: ")
+    second = getpass("Repeat temporary password: ")
+    if first != second:
+        raise AdminAccessRecoveryBlocked(["The temporary passwords do not match."])
+    return first
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    settings = get_settings()
+    with SessionLocal() as db:
+        try:
+            if args.command == "inspect":
+                result = inspect_admin_recovery(db, args.email)
+                payload = {"status": "eligible" if result.eligible else "blocked", **result.to_dict()}
+                db.rollback()
+            elif args.command == "verify-cutover":
+                result = inspect_identity_cutover(
+                    db,
+                    canonical_admin_email=args.email,
+                    configured_bootstrap_email=settings.bootstrap_admin_email,
+                )
+                payload = {"status": "ready" if result.ready else "blocked", **result.to_dict()}
+                db.rollback()
+            else:
+                if not args.apply:
+                    raise AdminAccessRecoveryBlocked(["The recover command requires --apply."])
+                evidence = recover_admin_access(
+                    db,
+                    email=args.email,
+                    confirm_account_id=args.confirm_account_id,
+                    new_password=_temporary_password(),
+                    reason=args.reason,
+                    operator=args.operator,
+                )
+                db.commit()
+                payload = {"status": "applied", **evidence.to_dict()}
+        except AdminAccessRecoveryBlocked as exc:
+            db.rollback()
+            print(json.dumps({"status": "blocked", "issues": exc.issues}, indent=2))
+            raise SystemExit(2) from exc
+        except ValueError as exc:
+            db.rollback()
+            print(json.dumps({"status": "blocked", "issues": [str(exc)]}, indent=2))
+            raise SystemExit(2) from exc
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/tools/identity_governance_report.py
+++ b/backend/app/tools/identity_governance_report.py
@@ -1,0 +1,70 @@
+"""Generate secret-safe identity governance evidence for scheduled operations."""
+
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from app.db.session import SessionLocal
+from app.services.identity_governance import build_identity_governance_snapshot
+
+SEVERITY_RANK = {"normal": 1, "high": 2, "critical": 3}
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--fail-on",
+        choices=["never", "normal", "high", "critical"],
+        default="critical",
+        help="Return exit code 3 when a finding reaches this severity.",
+    )
+    return parser
+
+
+def evidence_envelope(payload: dict) -> dict:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return {
+        "evidence_type": "identity_governance_snapshot",
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "snapshot_sha256": hashlib.sha256(canonical).hexdigest(),
+        "snapshot": payload,
+    }
+
+
+def exit_code_for_findings(findings: list[dict], fail_on: str) -> int:
+    if fail_on == "never":
+        return 0
+    threshold = SEVERITY_RANK[fail_on]
+    return 3 if any(SEVERITY_RANK[finding["severity"]] >= threshold for finding in findings) else 0
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as temporary:
+        temporary.write(content)
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    with SessionLocal() as db:
+        snapshot = build_identity_governance_snapshot(db)
+        db.rollback()
+    payload = snapshot.model_dump(mode="json")
+    envelope = evidence_envelope(payload)
+    rendered = json.dumps(envelope, indent=2) + "\n"
+    if args.output:
+        _write_atomic(args.output, rendered)
+    else:
+        print(rendered, end="")
+    raise SystemExit(exit_code_for_findings(payload["findings"], args.fail_on))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/tools/migrate_email_domain.py
+++ b/backend/app/tools/migrate_email_domain.py
@@ -1,0 +1,49 @@
+"""Dry-run or apply the controlled Iron House operational email-domain migration."""
+
+from argparse import ArgumentParser
+import json
+
+from app.db.session import SessionLocal
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    EmailDomainMigrationConflict,
+    LEGACY_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--from-domain", default=LEGACY_EMAIL_DOMAIN)
+    parser.add_argument("--to-domain", default=CANONICAL_EMAIL_DOMAIN)
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument(
+        "--confirm",
+        help="Required with --apply; must exactly match --to-domain.",
+    )
+    args = parser.parse_args()
+    if args.apply and args.confirm != args.to_domain:
+        raise SystemExit("--apply requires --confirm matching --to-domain exactly.")
+
+    with SessionLocal() as db:
+        try:
+            report = migrate_email_domain(
+                db,
+                from_domain=args.from_domain,
+                to_domain=args.to_domain,
+                apply=args.apply,
+            )
+            if args.apply:
+                db.commit()
+            else:
+                db.rollback()
+        except EmailDomainMigrationConflict as exc:
+            db.rollback()
+            print(json.dumps({"status": "blocked", "conflicts": exc.conflicts}, indent=2))
+            raise SystemExit(2) from exc
+
+    print(json.dumps({"status": "applied" if args.apply else "dry_run", **report.to_dict()}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -107,7 +107,7 @@ def test_admin_can_create_users_and_new_user_cannot_administer_accounts() -> Non
     created = client.post(
         "/api/v1/users",
         json={
-            "email": "estimator@ironhousecivil.com",
+            "email": "estimator@ironhousecontracting.com",
             "display_name": "Iron House Estimator",
             "role": "estimator",
             "password": "estimate-password-2026",
@@ -122,7 +122,7 @@ def test_admin_can_create_users_and_new_user_cannot_administer_accounts() -> Non
     client.post(
         "/api/v1/auth/login",
         json={
-            "email": "estimator@ironhousecivil.com",
+            "email": "estimator@ironhousecontracting.com",
             "password": "estimate-password-2026",
         },
     )
@@ -169,7 +169,7 @@ def test_admin_cannot_change_user_email_to_an_existing_account() -> None:
     created = client.post(
         "/api/v1/users",
         json={
-            "email": "estimator@ironhousecivil.com",
+            "email": "estimator@ironhousecontracting.com",
             "display_name": "Iron House Estimator",
             "role": "estimator",
             "password": "estimate-password-2026",

--- a/docs/builds/BUILD_231.md
+++ b/docs/builds/BUILD_231.md
@@ -1,0 +1,84 @@
+# Build 231 — Email Identity Domain Cleanup
+
+## Task Card
+
+- **Lead function:** Administration and Communications
+- **Supporting functions:** System Governance, Security, Estimating, Operations
+- **Owner:** Jeremie Peters
+- **Priority:** High
+- **Status:** Ready
+- **Environment:** Development only
+- **Approval gate:** Production backup, reviewed dry-run evidence, explicit apply approval
+
+## Objective
+
+Make `ironhousecontracting.com` the canonical email domain for current Iron House
+accounts, employee identities, supplier contacts and active communication routing.
+The live hostname `os.ironhousecivil.com` remains unchanged.
+
+## Verified
+
+- The canonical company email domain is `ironhousecontracting.com`.
+- The approved IHOS hostname is `os.ironhousecivil.com` and is separate from company
+  email identity.
+- Current authentication tokens contain both the account email and a session version.
+- User accounts and employee records have unique email constraints.
+- Production is not modified by this build branch.
+
+## Assumptions
+
+- Existing password hashes, roles, account IDs and employee IDs must remain unchanged.
+- Active RFQ draft routing should use the canonical domain after migration.
+- Historic authorship, submission, signature, source-email and append-only audit evidence
+  must retain the value recorded at the time of the event.
+
+## Included
+
+- Dry-run-by-default operator tool.
+- Case-insensitive collision detection before any write.
+- One-transaction updates to:
+  - user accounts;
+  - employee identities;
+  - supplier contacts;
+  - supplier routing metadata;
+  - active RFQ recipient and Gmail draft routing;
+  - field alert email recipients.
+- Session-version increments for migrated user accounts.
+- Removal of login throttles for both retired and canonical account addresses.
+- Bootstrap protection that refuses the retired email domain.
+- Development, backend and browser test identities updated to the canonical domain.
+
+## Excluded
+
+- DNS or hostname changes.
+- Mailbox creation, Google Workspace administration or email forwarding.
+- Rewriting financial provenance, submitted-by values, digital signatures, imported-by
+  values or append-only document-audit actors.
+- Production execution, deployment or merge.
+
+## Review Gates
+
+| Gate | Required evidence | Status |
+|---|---|---|
+| Source review | No retired-domain literals in current test identities | Complete |
+| Migration review | Dry run, collision refusal, idempotence and history preservation | Complete |
+| Test review | Backend, frontend and build checks | Complete |
+| Production approval | Backup plus reviewed dry-run JSON | Blocked pending approval |
+
+## Open Items
+
+- Confirm the production dry-run inventory and resolve any collision it reports.
+- Confirm `/etc/iron-house-os/production.env` uses the canonical bootstrap administrator
+  email before the next backend restart.
+- Approve or reject production application after reviewing the backup and dry-run.
+
+## Build Log
+
+- **2026-07-24:** Task card opened; source inventory separated email identities from the
+  approved web hostname.
+- **2026-07-24:** Migration service, packaged operator command, collision controls,
+  session invalidation and bootstrap-domain guard implemented in development.
+- **2026-07-24:** Verification completed: 143 backend tests, 21 frontend tests,
+  TypeScript lint, frontend production build, Ruff and the 13-file visual-design lock
+  passed. One existing Pydantic warning and one existing frontend chunk-size warning
+  remain non-blocking.

--- a/docs/builds/BUILD_232.md
+++ b/docs/builds/BUILD_232.md
@@ -1,0 +1,84 @@
+# Build 232 — Identity Cutover and Administrator Access Recovery
+
+## Task Card
+
+- **Lead function:** System Governance
+- **Supporting functions:** Administration and Communications, Security
+- **Owner:** Jeremie Peters
+- **Priority:** High
+- **Status:** Ready
+- **Dependency:** Build 231 — Email Identity Domain Cleanup
+- **Environment:** Development only
+- **Approval gate:** Approved release, verified backup and explicit production recovery approval
+
+## Objective
+
+Provide a controlled server-console path to inspect and recover a canonical Iron House
+administrator account when normal in-app administrator recovery is unavailable. Produce
+cutover-readiness evidence without exposing passwords or changing production
+automatically.
+
+## Verified
+
+- The canonical administrator identity uses `ironhousecontracting.com`.
+- The production application remains at `https://os.ironhousecivil.com`.
+- Password hashes, account IDs, roles and session versions are held in the IHOS database.
+- Normal in-app password reset requires an already authenticated administrator.
+- Build 231 provides the current-identity migration and must precede cutover verification.
+
+## Assumptions
+
+- The operator has authorised server-console and Docker access.
+- The operator can securely enter a temporary password without placing it in command
+  history or an evidence file.
+- The recovered administrator will immediately complete the forced password change.
+
+## Included
+
+- Read-only administrator recovery inspection.
+- Exact UUID confirmation before recovery.
+- Canonical-domain, administrator-role and active-account eligibility checks.
+- Interactive hidden password entry with confirmation.
+- Existing-password reuse prevention.
+- Session invalidation and login-throttle removal.
+- Forced password change on next login.
+- Non-secret JSON recovery evidence.
+- Post-cutover readiness verification covering:
+  - residual Build 231 identity changes;
+  - canonical administrator presence, status and role;
+  - production bootstrap email alignment;
+  - completion of the forced password change.
+
+## Excluded
+
+- Email delivery, password-reset links or third-party identity providers.
+- Browser credential entry or transfer of Safari session cookies.
+- Account creation, account merging or role elevation.
+- Production deployment, recovery execution or merge.
+
+## Review Gates
+
+| Gate | Required evidence | Status |
+|---|---|---|
+| Recovery security | Wrong account, role, domain, state, UUID and reused password blocked | Complete |
+| Secret handling | Password absent from arguments and JSON evidence | Complete |
+| Cutover readiness | Pending migration and forced password change reported | Complete |
+| Regression | Backend, frontend, build and visual-lock checks | Complete |
+| Production approval | Backup and explicit recovery authorisation | Blocked pending approval |
+
+## Open Items
+
+- Review and approve Build 231 before using Build 232 in production.
+- Confirm the exact canonical administrator account ID from the read-only inspection.
+- Establish an approved production maintenance and recovery window.
+- Confirm secure evidence retention location and recovery operator.
+
+## Build Log
+
+- **2026-07-24:** Build 232 task card opened as a dependent development build.
+- **2026-07-24:** Server-console inspection, guarded recovery, session invalidation,
+  hidden password entry and cutover-readiness reporting implemented.
+- **2026-07-24:** Verification completed: 152 backend tests, 21 frontend tests,
+  TypeScript lint, frontend production build, Ruff and the 13-file visual-design lock
+  passed. One existing Pydantic warning and one existing frontend chunk-size warning
+  remain non-blocking.

--- a/docs/builds/BUILD_233.md
+++ b/docs/builds/BUILD_233.md
@@ -1,0 +1,40 @@
+# Build 233 — Identity Governance Centre
+
+## Task card
+
+- **Status:** Development complete; verification pending
+- **Owner:** Iron House OS build program
+- **Environment:** Development only
+- **Approval boundary:** No production deployment and no merge without approval
+
+## Verified
+
+- User accounts already record role, active state, last sign-in, and forced-password-change state.
+- User administration is restricted to the administrator role.
+- The approved Settings page can host governance information without changing the locked navigation or application shell.
+
+## Assumption
+
+- Seven days without a first sign-in warrants review.
+- Ninety days without a sign-in warrants review.
+- One active administrator is an access-continuity risk; zero is critical.
+
+## Delivered
+
+- Administrator-only identity governance snapshot API.
+- Canonical and legacy domain checks.
+- Active-administrator coverage check.
+- Pending password change, never-used, and stale-account checks.
+- Case-insensitive duplicate identity detection.
+- Settings-based Identity Governance Centre with summary, findings, and account review reasons.
+- Responses exclude password hashes and session versions.
+
+## Open items
+
+- Thresholds require management approval before they become formal policy.
+- Account review decisions and evidence are not yet persisted.
+- Production identity data has not been inspected or changed.
+
+## Automation recommendation
+
+Run the governance snapshot weekly and notify administrators only when findings change or critical findings exist.

--- a/docs/builds/BUILD_234.md
+++ b/docs/builds/BUILD_234.md
@@ -1,0 +1,37 @@
+# Build 234 — Identity Governance Evidence Automation
+
+## Task card
+
+- **Status:** Development complete; verification pending
+- **Owner:** Iron House OS build program
+- **Environment:** Development only
+- **Approval boundary:** No production schedule, notification, deployment, or merge without approval
+
+## Verified
+
+- Build 233 produces a secret-safe, administrator-only governance snapshot.
+- The production notification recipient, channel, evidence retention period, and formal risk thresholds are not approved.
+
+## Assumption
+
+- A weekly read-only snapshot is an appropriate starting cadence.
+- Only critical findings should fail the proposed scheduled check until policy is approved.
+
+## Delivered
+
+- Operator command for JSON identity-governance evidence.
+- Versioned evidence envelope with SHA-256 snapshot integrity.
+- Atomic evidence-file replacement.
+- Configurable alert thresholds and machine-readable exit code.
+- Development runbook for a future weekly schedule.
+
+## Open items
+
+- Approve the administrator recipient and notification channel.
+- Approve evidence retention.
+- Approve formal review and alert thresholds.
+- Production scheduling remains blocked pending approval.
+
+## Automation recommendation
+
+Install the weekly check only after the open items are approved. Notify only on a threshold breach or a changed finding set.

--- a/docs/operations/admin-access-recovery.md
+++ b/docs/operations/admin-access-recovery.md
@@ -1,0 +1,110 @@
+# Administrator Access Recovery Runbook
+
+Use this runbook only when the canonical IHOS administrator cannot sign in and normal
+in-app administrator recovery is unavailable.
+
+## Preconditions
+
+Do not perform recovery until:
+
+1. Builds 231 and 232 are approved and deployed through the protected release process.
+2. A complete recovery backup has been created and verified.
+3. The maintenance window and recovery operator are approved.
+4. The Build 231 identity migration has been applied or its dry run has been reviewed.
+5. The operator is connected to the canonical production server,
+   `iron-house-os-prod-1`.
+
+Never place the temporary password in a command argument, chat, shell history, evidence
+file or support ticket.
+
+## Inspect the Account
+
+This command is read-only:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps backend \
+  python -m app.tools.admin_access_recovery inspect \
+  --email jeremie@ironhousecontracting.com
+```
+
+Confirm:
+
+- the display name is Jeremie Peters;
+- the role is `admin`;
+- the account is active;
+- `eligible` is `true`;
+- the account UUID matches the approved recovery target.
+
+## Recover Access
+
+Run interactively so the password prompts remain hidden:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps backend \
+  python -m app.tools.admin_access_recovery recover \
+  --email jeremie@ironhousecontracting.com \
+  --confirm-account-id <UUID-FROM-INSPECTION> \
+  --reason "Business account migration access recovery" \
+  --operator "Jeremie Peters" \
+  --apply
+```
+
+Enter the temporary password twice at the hidden prompts. Save the resulting JSON as
+restricted recovery evidence only after confirming it contains no password or password
+hash.
+
+The recovery:
+
+- preserves the account ID, email, role and active state;
+- replaces the password hash;
+- increments the session version and invalidates existing sessions;
+- clears the account login throttle;
+- requires a password change after the next successful login.
+
+## Complete the Recovery
+
+1. Sign in at `https://os.ironhousecivil.com` using the canonical email and temporary
+   password.
+2. Complete the forced password change.
+3. Confirm administrator access and required navigation.
+4. Do not reuse or retain the temporary password.
+
+## Verify Cutover
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps -T backend \
+  python -m app.tools.admin_access_recovery verify-cutover \
+  --email jeremie@ironhousecontracting.com
+```
+
+The result is ready only when:
+
+- no active identity or routing values remain for Build 231 migration;
+- the configured bootstrap email matches the canonical administrator;
+- the administrator exists, is active and has the admin role;
+- the forced password change is complete.
+
+## Stop Conditions
+
+Stop without applying recovery if:
+
+- inspection reports more than one matching account;
+- the account ID, display name, domain, role or active state is unexpected;
+- the recovery backup is missing or unverified;
+- the reason or operator is not approved;
+- any command output contains a password or password hash.
+
+## Rollback
+
+If the confirmed account was changed incorrectly, stop the application and restore the
+verified pre-recovery backup using the approved recovery procedure. Do not create a
+replacement administrator, merge accounts or edit password hashes directly.

--- a/docs/operations/email-domain-migration.md
+++ b/docs/operations/email-domain-migration.md
@@ -1,0 +1,76 @@
+# Email Identity Domain Migration Runbook
+
+This runbook changes current operational email identities to
+`ironhousecontracting.com`. It does not change `os.ironhousecivil.com`.
+
+## Approval and Preconditions
+
+Do not run `--apply` until all of the following are verified:
+
+1. The release containing Build 231 has passed CI and has been separately approved for
+   production deployment.
+2. A complete recovery backup has been created and verified.
+3. `/etc/iron-house-os/production.env` has the canonical
+   `BOOTSTRAP_ADMIN_EMAIL`.
+4. The dry-run JSON has been reviewed and contains no collision.
+5. The production apply has explicit approval from Jeremie Peters.
+
+## Backup
+
+From the production repository:
+
+```bash
+sudo IHOS_COMPOSE_ENV_FILE=/etc/iron-house-os/production.env \
+  bash scripts/backup.sh \
+  --output /var/backups/iron-house-os/pre-email-domain-migration-20260724
+```
+
+## Dry Run
+
+The default command is read-only:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps -T backend \
+  python -m app.tools.migrate_email_domain \
+  | sudo tee /var/lib/iron-house-os/email-domain-dry-run-20260724.json
+```
+
+Review `change_count`, `changes_by_area`, every proposed replacement and the protected
+history policy. A collision exits with status 2 and performs no write.
+
+## Apply
+
+Only after the approval gate:
+
+```bash
+sudo docker compose \
+  --env-file /etc/iron-house-os/production.env \
+  -f docker-compose.production.yml \
+  run --rm --no-deps -T backend \
+  python -m app.tools.migrate_email_domain \
+  --apply \
+  --confirm ironhousecontracting.com \
+  | sudo tee /var/lib/iron-house-os/email-domain-apply-20260724.json
+```
+
+The apply is transactional and idempotent. Migrated accounts keep their passwords,
+roles and IDs, but their existing sessions are invalidated.
+
+## Verification
+
+1. Run the dry-run command again and confirm `change_count` is `0`.
+2. Sign in with the canonical administrator email and the existing password.
+3. Confirm the administrator role and required menus.
+4. Confirm employee and supplier email displays.
+5. Preview an RFQ communication workflow and confirm canonical sender/recipient routing.
+6. Confirm production readiness is healthy.
+7. Retain backup, dry-run and apply evidence with the Build 231 approval record.
+
+## Rollback
+
+Stop the application and restore the verified pre-change recovery backup using the
+approved recovery procedure. Do not manually merge colliding accounts or rewrite
+historic audit records.

--- a/docs/operations/identity-governance-monitoring.md
+++ b/docs/operations/identity-governance-monitoring.md
@@ -1,0 +1,37 @@
+# Identity governance monitoring
+
+This development runbook defines the proposed weekly identity-health check. It does not authorize a production installation.
+
+## Command
+
+Run from the application release directory with the application environment loaded:
+
+```bash
+python scripts/identity_governance_report.py \
+  --output /var/lib/iron-house-os/evidence/identity-governance.json \
+  --fail-on critical
+```
+
+The command:
+
+- reads account governance fields without changing them;
+- writes a versioned JSON evidence envelope atomically;
+- includes a SHA-256 digest of the snapshot;
+- excludes password hashes and session versions;
+- exits `3` when a finding meets the selected alert threshold.
+
+## Proposed schedule
+
+- Frequency: weekly, Monday morning.
+- Owner: named Iron House OS administrator.
+- Alert threshold: critical until management approves the formal access policy.
+- Retention: pending management and legal approval.
+- Notification channel: pending administrator recipient and channel approval.
+
+## Response
+
+1. Preserve the evidence file and command result.
+2. Inspect the Identity Governance Centre.
+3. Confirm each affected named account with management.
+4. Use the approved recovery or deactivation procedure.
+5. Do not delete or merge duplicate identities until the records are reconciled.

--- a/frontend/e2e/release-gate.spec.ts
+++ b/frontend/e2e/release-gate.spec.ts
@@ -3,7 +3,7 @@ import { expect, Page, test } from "@playwright/test";
 
 const user = {
   id: "00000000-0000-0000-0000-000000000214",
-  email: "release-gate@ironhousecivil.com",
+  email: "release-gate@ironhousecontracting.com",
   display_name: "Release Gate Operator",
   role: "admin",
   is_active: true,
@@ -45,7 +45,7 @@ async function mockApi(page: Page) {
 
 async function signIn(page: Page) {
   await page.goto("/");
-  await page.getByLabel("Email").fill("release-gate@ironhousecivil.com");
+  await page.getByLabel("Email").fill("release-gate@ironhousecontracting.com");
   await page.getByLabel("Password").fill("Local-release-gate-only");
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.getByRole("heading", { name: "Iron House Dashboard" })).toBeVisible();

--- a/frontend/e2e/release-gate.spec.ts
+++ b/frontend/e2e/release-gate.spec.ts
@@ -35,6 +35,32 @@ async function mockApi(page: Page) {
       await route.fulfill({ status: 200, json: { role: "admin", modules: { projects: ["read", "write"], suppliers: ["read", "write"], equipment: ["read", "write"] } } });
       return;
     }
+    if (path.endsWith("/users/governance")) {
+      await route.fulfill({
+        status: 200,
+        json: {
+          generated_at: "2026-07-24T00:00:00Z",
+          canonical_email_domain: "ironhousecontracting.com",
+          summary: {
+            total_accounts: 1,
+            active_accounts: 1,
+            active_administrators: 1,
+            legacy_domain_accounts: 0,
+            accounts_requiring_review: 1,
+            critical_findings: 0,
+          },
+          accounts: [{ ...user, review_reasons: ["Only active administrator"] }],
+          findings: [{
+            code: "single_active_administrator",
+            severity: "high",
+            title: "Single active administrator",
+            recommendation: "Approve and provision a second named administrator.",
+            account_ids: [user.id],
+          }],
+        },
+      });
+      return;
+    }
     if (path.endsWith("/estimates/rate-library")) {
       await route.fulfill({ status: 200, json: { production_rates: [] } });
       return;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -22,6 +22,27 @@ export type RoleAccess = {
   modules: Record<string, string[]>;
 };
 
+export type IdentityGovernance = {
+  generated_at: string;
+  canonical_email_domain: string;
+  summary: {
+    total_accounts: number;
+    active_accounts: number;
+    active_administrators: number;
+    legacy_domain_accounts: number;
+    accounts_requiring_review: number;
+    critical_findings: number;
+  };
+  accounts: Array<AuthUser & { review_reasons: string[] }>;
+  findings: Array<{
+    code: string;
+    severity: "critical" | "high" | "normal";
+    title: string;
+    recommendation: string;
+    account_ids: string[];
+  }>;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function readAuthResponse(response: Response): Promise<AuthStatus> {
@@ -64,5 +85,10 @@ export const authApi = {
     const response = await apiFetch(`${API_BASE_URL}/auth/me/permissions`);
     if (!response.ok) throw new Error(`Unable to load permissions (${response.status})`);
     return response.json() as Promise<RoleAccess>;
+  },
+  identityGovernance: async (): Promise<IdentityGovernance> => {
+    const response = await apiFetch(`${API_BASE_URL}/users/governance`);
+    if (!response.ok) throw new Error(`Unable to load identity governance (${response.status})`);
+    return response.json() as Promise<IdentityGovernance>;
   },
 };

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
-import { Bot, KeyRound, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Bot, KeyRound, ShieldCheck, Users } from "lucide-react";
 import { FormEvent, useEffect, useState } from "react";
 
-import { RoleAccess, authApi } from "../api/auth";
+import { IdentityGovernance, RoleAccess, authApi } from "../api/auth";
 import { useAuth } from "../contexts/AuthContext";
 import { Link } from "react-router-dom";
 
@@ -54,8 +54,61 @@ export function SettingsPage() {
 
         <ChangePasswordPanel />
       </div>
+      {user?.role === "admin" ? <IdentityGovernancePanel /> : null}
     </section>
   );
+}
+
+function IdentityGovernancePanel() {
+  const [governance, setGovernance] = useState<IdentityGovernance | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    authApi.identityGovernance().then(setGovernance).catch((currentError) => {
+      setError(currentError instanceof Error ? currentError.message : "Unable to load identity governance");
+    });
+  }, []);
+
+  return (
+    <div className="rounded-md border border-iron-100 bg-white p-5">
+      <div className="flex items-center gap-2"><Users className="h-5 w-5" /><h2 className="font-semibold">Identity Governance Centre</h2></div>
+      <p className="mt-2 text-sm text-iron-500">Administrator-only review of company identities, access continuity, and account hygiene.</p>
+      {error ? <div role="alert" className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
+      {!governance && !error ? <p className="mt-4 text-sm text-iron-500">Loading identity governance…</p> : null}
+      {governance ? (
+        <>
+          <div className="mt-5 grid gap-3 sm:grid-cols-3 xl:grid-cols-6">
+            <Metric label="Accounts" value={governance.summary.total_accounts} />
+            <Metric label="Active" value={governance.summary.active_accounts} />
+            <Metric label="Administrators" value={governance.summary.active_administrators} />
+            <Metric label="Legacy domain" value={governance.summary.legacy_domain_accounts} />
+            <Metric label="Needs review" value={governance.summary.accounts_requiring_review} />
+            <Metric label="Critical" value={governance.summary.critical_findings} />
+          </div>
+          <div className="mt-6 grid gap-3">
+            {governance.findings.length ? governance.findings.map((finding) => (
+              <div key={finding.code} className="rounded-md border border-iron-100 p-4">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className={`mt-0.5 h-5 w-5 ${finding.severity === "critical" ? "text-red-600" : "text-brand-gold"}`} />
+                  <div><div className="font-semibold text-iron-950">{finding.title}</div><div className="mt-1 text-sm text-iron-500">{finding.recommendation}</div><div className="mt-2 text-xs uppercase tracking-wide text-iron-500">{finding.severity} · {finding.account_ids.length} affected</div></div>
+                </div>
+              </div>
+            )) : <div className="rounded-md bg-green-50 p-4 text-sm text-green-800">No identity governance findings require action.</div>}
+          </div>
+          <div className="mt-6 overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead><tr className="border-b border-iron-100 text-xs uppercase tracking-wide text-iron-500"><th className="px-3 py-2">Account</th><th className="px-3 py-2">Role</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Review</th></tr></thead>
+              <tbody>{governance.accounts.map((account) => <tr key={account.id} className="border-b border-iron-100"><td className="px-3 py-3"><div className="font-medium">{account.display_name}</div><div className="text-xs text-iron-500">{account.email}</div></td><td className="px-3 py-3 capitalize">{account.role.replace("_", " ")}</td><td className="px-3 py-3">{account.is_active ? "Active" : "Inactive"}</td><td className="px-3 py-3 text-iron-500">{account.review_reasons.join(", ") || "Clear"}</td></tr>)}</tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return <div className="rounded-md bg-iron-50 p-3"><div className="text-xs uppercase tracking-wide text-iron-500">{label}</div><div className="mt-1 text-2xl font-semibold text-iron-950">{value}</div></div>;
 }
 
 function ChangePasswordPanel() {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -95,7 +95,7 @@ function IdentityGovernancePanel() {
               </div>
             )) : <div className="rounded-md bg-green-50 p-4 text-sm text-green-800">No identity governance findings require action.</div>}
           </div>
-          <div className="mt-6 overflow-x-auto">
+          <div className="mt-6 overflow-x-auto" tabIndex={0} aria-label="Identity governance account review table">
             <table className="w-full text-left text-sm">
               <thead><tr className="border-b border-iron-100 text-xs uppercase tracking-wide text-iron-500"><th className="px-3 py-2">Account</th><th className="px-3 py-2">Role</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Review</th></tr></thead>
               <tbody>{governance.accounts.map((account) => <tr key={account.id} className="border-b border-iron-100"><td className="px-3 py-3"><div className="font-medium">{account.display_name}</div><div className="text-xs text-iron-500">{account.email}</div></td><td className="px-3 py-3 capitalize">{account.role.replace("_", " ")}</td><td className="px-3 py-3">{account.is_active ? "Active" : "Inactive"}</td><td className="px-3 py-3 text-iron-500">{account.review_reasons.join(", ") || "Clear"}</td></tr>)}</tbody>

--- a/scripts/admin_access_recovery.py
+++ b/scripts/admin_access_recovery.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Repository wrapper for the packaged administrator recovery operator tool."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "backend"))
+
+from app.tools.admin_access_recovery import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/identity_governance_report.py
+++ b/scripts/identity_governance_report.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Repository wrapper for the identity governance evidence tool."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "backend"))
+
+from app.tools.identity_governance_report import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_email_domain.py
+++ b/scripts/migrate_email_domain.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Repository wrapper for the packaged email-domain migration operator tool."""
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "backend"))
+
+from app.tools.migrate_email_domain import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -33,7 +33,7 @@ def override_get_db() -> Generator[Session, None, None]:
 def override_authenticated_user(request: Request) -> AuthenticatedUser:
     user = AuthenticatedUser(
         id=UUID("00000000-0000-0000-0000-000000000001"),
-        email="test-admin@ironhousecivil.com",
+        email="test-admin@ironhousecontracting.com",
         display_name="Test Administrator",
         role="admin",
         session_version=1,

--- a/tests/backend/test_admin_access_recovery.py
+++ b/tests/backend/test_admin_access_recovery.py
@@ -1,0 +1,194 @@
+import json
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+from app.models.user import Employee, LoginThrottle, UserAccount
+from app.services.admin_access_recovery import (
+    AdminAccessRecoveryBlocked,
+    inspect_admin_recovery,
+    inspect_identity_cutover,
+    recover_admin_access,
+)
+from app.services.auth import hash_password, login_subject_hash, verify_password
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    LEGACY_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+def _email(local_part: str, domain: str = CANONICAL_EMAIL_DOMAIN) -> str:
+    return f"{local_part}@{domain}"
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _admin(
+    *,
+    email: str | None = None,
+    role: str = "admin",
+    is_active: bool = True,
+    password_reset_required: bool = False,
+) -> UserAccount:
+    return UserAccount(
+        email=email or _email("jeremie"),
+        display_name="Jeremie Peters",
+        role=role,
+        password_hash=hash_password("existing-admin-password"),
+        is_active=is_active,
+        session_version=3,
+        password_reset_required=password_reset_required,
+    )
+
+
+def test_admin_recovery_inspection_returns_safe_account_confirmation() -> None:
+    with _session() as db:
+        account = _admin()
+        db.add(account)
+        db.commit()
+
+        result = inspect_admin_recovery(db, account.email)
+        rendered = json.dumps(result.to_dict())
+
+        assert result.eligible is True
+        assert result.account_id == str(account.id)
+        assert result.active_admin_count == 1
+        assert "existing-admin-password" not in rendered
+        assert "password_hash" not in rendered
+
+
+def test_admin_recovery_resets_password_invalidates_sessions_and_clears_throttle() -> None:
+    with _session() as db:
+        account = _admin()
+        db.add(account)
+        db.flush()
+        db.add(
+            LoginThrottle(
+                key_hash=login_subject_hash(account.email),
+                failed_attempts=5,
+            )
+        )
+        db.commit()
+
+        evidence = recover_admin_access(
+            db,
+            email=account.email,
+            confirm_account_id=str(account.id),
+            new_password="temporary-admin-password",
+            reason="Business account migration access loss",
+            operator="Jeremie Peters",
+        )
+        db.commit()
+        recovered = db.get(UserAccount, account.id)
+
+        assert recovered is not None
+        assert verify_password("temporary-admin-password", recovered.password_hash)
+        assert recovered.session_version == 4
+        assert recovered.password_reset_required is True
+        assert evidence.previous_session_version == 3
+        assert evidence.new_session_version == 4
+        assert evidence.login_throttles_cleared == 1
+        assert db.scalars(select(LoginThrottle)).all() == []
+        rendered = json.dumps(evidence.to_dict())
+        assert "temporary-admin-password" not in rendered
+        assert "password_hash" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("account", "confirmed_id", "reason", "issue"),
+    [
+        (_admin(role="viewer"), None, "Business access recovery", "not an administrator"),
+        (_admin(is_active=False), None, "Business access recovery", "inactive"),
+        (
+            _admin(email=_email("jeremie", LEGACY_EMAIL_DOMAIN)),
+            None,
+            "Business access recovery",
+            "canonical company email domain",
+        ),
+        (_admin(), "00000000-0000-0000-0000-000000000999", "Business access recovery", "does not match"),
+        (_admin(), None, "short", "at least 10 characters"),
+    ],
+)
+def test_admin_recovery_refuses_unsafe_targets(
+    account: UserAccount,
+    confirmed_id: str | None,
+    reason: str,
+    issue: str,
+) -> None:
+    with _session() as db:
+        db.add(account)
+        db.commit()
+
+        with pytest.raises(AdminAccessRecoveryBlocked, match=issue):
+            recover_admin_access(
+                db,
+                email=account.email,
+                confirm_account_id=confirmed_id or str(account.id),
+                new_password="temporary-admin-password",
+                reason=reason,
+                operator="Jeremie Peters",
+            )
+        db.rollback()
+        unchanged = db.get(UserAccount, account.id)
+        assert unchanged is not None
+        assert unchanged.session_version == 3
+        assert verify_password("existing-admin-password", unchanged.password_hash)
+
+
+def test_admin_recovery_refuses_password_reuse() -> None:
+    with _session() as db:
+        account = _admin()
+        db.add(account)
+        db.commit()
+
+        with pytest.raises(AdminAccessRecoveryBlocked, match="must differ"):
+            recover_admin_access(
+                db,
+                email=account.email,
+                confirm_account_id=str(account.id),
+                new_password="existing-admin-password",
+                reason="Business account migration access loss",
+                operator="Jeremie Peters",
+            )
+
+
+def test_identity_cutover_readiness_tracks_migration_and_password_change() -> None:
+    with _session() as db:
+        account = _admin(password_reset_required=True)
+        employee = Employee(
+            first_name="Jeremie",
+            last_name="Peters",
+            email=_email("jeremie", LEGACY_EMAIL_DOMAIN),
+            status="active",
+            portal_role="employee",
+        )
+        db.add_all([account, employee])
+        db.commit()
+
+        blocked = inspect_identity_cutover(
+            db,
+            canonical_admin_email=account.email,
+            configured_bootstrap_email=account.email,
+        )
+        assert blocked.ready is False
+        assert blocked.pending_identity_changes == 1
+        assert any("forced password change" in issue for issue in blocked.issues)
+
+        migrate_email_domain(db, apply=True)
+        account.password_reset_required = False
+        db.commit()
+        ready = inspect_identity_cutover(
+            db,
+            canonical_admin_email=account.email,
+            configured_bootstrap_email=account.email,
+        )
+        assert ready.ready is True
+        assert ready.pending_identity_changes == 0
+        assert ready.issues == ()

--- a/tests/backend/test_email_domain_migration.py
+++ b/tests/backend/test_email_domain_migration.py
@@ -1,0 +1,218 @@
+from datetime import date
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.db.base import Base
+from app.db.bootstrap_admin import validate_bootstrap_admin_email
+from app.models.contact import Contact
+from app.models.field_operations import FieldRecord
+from app.models.finance import StartupExpense
+from app.models.rfq import RFQPackage
+from app.models.supplier import Supplier
+from app.models.user import Employee, LoginThrottle, UserAccount
+from app.services.auth import hash_password, login_subject_hash
+from app.services.email_domain_migration import (
+    CANONICAL_EMAIL_DOMAIN,
+    EmailDomainMigrationConflict,
+    LEGACY_EMAIL_DOMAIN,
+    migrate_email_domain,
+)
+
+
+def _email(local_part: str, domain: str) -> str:
+    return f"{local_part}@{domain}"
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _seed_operational_records(db: Session) -> dict[str, object]:
+    legacy_admin = _email("jeremie", LEGACY_EMAIL_DOMAIN)
+    canonical_admin = _email("jeremie", CANONICAL_EMAIL_DOMAIN)
+    supplier = Supplier(
+        name="Domain Migration Supplier",
+        metadata_json={"email": _email("estimating", LEGACY_EMAIL_DOMAIN), "status": "preferred"},
+    )
+    db.add(supplier)
+    db.flush()
+    account = UserAccount(
+        email=legacy_admin,
+        display_name="Jeremie Peters",
+        role="admin",
+        password_hash=hash_password("build-231-test-password"),
+        is_active=True,
+        session_version=4,
+    )
+    employee = Employee(
+        first_name="Jeremie",
+        last_name="Peters",
+        email=_email("Jeremie", LEGACY_EMAIL_DOMAIN.upper()),
+        status="active",
+        portal_role="employee",
+    )
+    contact = Contact(
+        supplier_id=supplier.id,
+        first_name="Estimator",
+        email=_email("quotes", LEGACY_EMAIL_DOMAIN),
+    )
+    package = RFQPackage(
+        title="Build 231 routing test",
+        status="draft",
+        supplier_category_targets=[],
+        metadata_json={
+            "supplier_contacts": {"supplier-1": {"recipient_email": _email("quotes", LEGACY_EMAIL_DOMAIN)}},
+            "gmail_drive_workflow": {
+                "sender": {"email": legacy_admin},
+                "gmail_drafts": [
+                    {
+                        "to": _email("quotes", LEGACY_EMAIL_DOMAIN),
+                        "body": f"Reply to {legacy_admin}.\n\nThank you.",
+                    }
+                ],
+            },
+        },
+    )
+    field_record = FieldRecord(
+        record_type="issue",
+        work_date=date(2026, 7, 24),
+        title="Build 231 routing test",
+        alert_recipients=[legacy_admin, "Mac Warren"],
+        status="submitted",
+        severity="medium",
+        details={},
+        document_ids=[],
+        signatures=[{"signed_by_account": legacy_admin}],
+        submitted_by=legacy_admin,
+    )
+    expense = StartupExpense(
+        expense_date=date(2026, 7, 1),
+        vendor_name="Historical Vendor",
+        description="Historical evidence",
+        amount=100,
+        category="legal",
+        source_email=legacy_admin,
+        funding_source="owner_loan",
+        tax_treatment="needs_review",
+        status="review",
+        receipt_metadata={},
+        created_by=legacy_admin,
+    )
+    db.add_all(
+        [
+            account,
+            employee,
+            contact,
+            package,
+            field_record,
+            expense,
+            LoginThrottle(key_hash=login_subject_hash(legacy_admin), failed_attempts=2),
+            LoginThrottle(key_hash=login_subject_hash(canonical_admin), failed_attempts=1),
+        ]
+    )
+    db.commit()
+    return {
+        "account": account,
+        "employee": employee,
+        "contact": contact,
+        "supplier": supplier,
+        "package": package,
+        "field_record": field_record,
+        "expense": expense,
+        "legacy_admin": legacy_admin,
+        "canonical_admin": canonical_admin,
+    }
+
+
+def test_email_domain_migration_dry_run_has_no_writes() -> None:
+    with _session() as db:
+        seeded = _seed_operational_records(db)
+        report = migrate_email_domain(db)
+        assert report.applied is False
+        assert len(report.changes) == 9
+        assert report.sessions_invalidated == 0
+        assert db.get(UserAccount, seeded["account"].id).email == seeded["legacy_admin"]
+        assert len(db.scalars(select(LoginThrottle)).all()) == 2
+
+
+def test_email_domain_migration_updates_active_routing_and_preserves_history() -> None:
+    with _session() as db:
+        seeded = _seed_operational_records(db)
+        report = migrate_email_domain(db, apply=True)
+        db.commit()
+
+        account = db.get(UserAccount, seeded["account"].id)
+        employee = db.get(Employee, seeded["employee"].id)
+        contact = db.get(Contact, seeded["contact"].id)
+        supplier = db.get(Supplier, seeded["supplier"].id)
+        package = db.get(RFQPackage, seeded["package"].id)
+        field_record = db.get(FieldRecord, seeded["field_record"].id)
+        expense = db.get(StartupExpense, seeded["expense"].id)
+
+        assert report.sessions_invalidated == 1
+        assert report.login_throttles_cleared == 2
+        assert account.email == seeded["canonical_admin"]
+        assert account.session_version == 5
+        assert employee.email == _email("jeremie", CANONICAL_EMAIL_DOMAIN)
+        assert contact.email == _email("quotes", CANONICAL_EMAIL_DOMAIN)
+        assert supplier.metadata_json["email"] == _email("estimating", CANONICAL_EMAIL_DOMAIN)
+        assert package.metadata_json["supplier_contacts"]["supplier-1"]["recipient_email"] == _email(
+            "quotes", CANONICAL_EMAIL_DOMAIN
+        )
+        workflow = package.metadata_json["gmail_drive_workflow"]
+        assert workflow["sender"]["email"] == seeded["canonical_admin"]
+        assert workflow["gmail_drafts"][0]["to"] == _email("quotes", CANONICAL_EMAIL_DOMAIN)
+        assert workflow["gmail_drafts"][0]["body"] == (f"Reply to {seeded['canonical_admin']}.\n\nThank you.")
+        assert field_record.alert_recipients == [seeded["canonical_admin"], "Mac Warren"]
+        assert field_record.submitted_by == seeded["legacy_admin"]
+        assert field_record.signatures[0]["signed_by_account"] == seeded["legacy_admin"]
+        assert expense.source_email == seeded["legacy_admin"]
+        assert expense.created_by == seeded["legacy_admin"]
+        assert db.scalars(select(LoginThrottle)).all() == []
+
+        second = migrate_email_domain(db, apply=True)
+        assert second.changes == ()
+        assert second.sessions_invalidated == 0
+
+
+def test_email_domain_migration_refuses_case_insensitive_collisions() -> None:
+    with _session() as db:
+        db.add_all(
+            [
+                UserAccount(
+                    email=_email("owner", LEGACY_EMAIL_DOMAIN),
+                    display_name="Legacy Owner",
+                    role="admin",
+                    password_hash=hash_password("build-231-test-password"),
+                    is_active=True,
+                ),
+                UserAccount(
+                    email=_email("OWNER", CANONICAL_EMAIL_DOMAIN),
+                    display_name="Canonical Owner",
+                    role="viewer",
+                    password_hash=hash_password("build-231-test-password"),
+                    is_active=True,
+                ),
+            ]
+        )
+        db.commit()
+
+        with pytest.raises(EmailDomainMigrationConflict):
+            migrate_email_domain(db, apply=True)
+        db.rollback()
+
+        emails = set(db.scalars(select(UserAccount.email)))
+        assert _email("owner", LEGACY_EMAIL_DOMAIN) in emails
+        assert _email("OWNER", CANONICAL_EMAIL_DOMAIN) in emails
+
+
+def test_bootstrap_admin_rejects_retired_domain() -> None:
+    with pytest.raises(RuntimeError, match="retired company email domain"):
+        validate_bootstrap_admin_email(_email("admin", LEGACY_EMAIL_DOMAIN))
+    assert validate_bootstrap_admin_email(_email("ADMIN", CANONICAL_EMAIL_DOMAIN)) == _email(
+        "admin", CANONICAL_EMAIL_DOMAIN
+    )

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -18,7 +18,7 @@ def _employee() -> dict:
         json={
             "first_name": "Crew",
             "last_name": "Member",
-            "email": "crew.member@ironhousecivil.com",
+            "email": "crew.member@ironhousecontracting.com",
             "portal_role": "operator",
             "phone": "604-555-0100",
             "emergency_contact_name": "Emergency Contact",
@@ -340,13 +340,13 @@ def test_bootstrap_exposes_milestone_ladders_and_on_time_paperwork_recognition()
 def test_employee_creation_provisions_a_password_change_required_portal_account() -> None:
     response = client.post(
         "/api/v1/field-operations/employees",
-        json={"first_name": "New", "last_name": "Worker", "email": "new.worker@ironhousecivil.com", "portal_role": "employee"},
+        json={"first_name": "New", "last_name": "Worker", "email": "new.worker@ironhousecontracting.com", "portal_role": "employee"},
     )
     assert response.status_code == 201
     assert response.json()["portal_access_created"] is True
     temporary_password = response.json()["temporary_password"]
     assert len(temporary_password) >= 12
-    login = client.post("/api/v1/auth/login", json={"email": "new.worker@ironhousecivil.com", "password": temporary_password})
+    login = client.post("/api/v1/auth/login", json={"email": "new.worker@ironhousecontracting.com", "password": temporary_password})
     assert login.status_code == 200
     assert login.json()["user"]["password_reset_required"] is True
 
@@ -355,7 +355,7 @@ def test_employee_bootstrap_is_limited_to_own_records() -> None:
     own = _employee()
     other = client.post(
         "/api/v1/field-operations/employees",
-        json={"first_name": "Other", "last_name": "Worker", "email": "other.worker@ironhousecivil.com", "portal_role": "employee"},
+        json={"first_name": "Other", "last_name": "Worker", "email": "other.worker@ironhousecontracting.com", "portal_role": "employee"},
     ).json()
 
     def employee_user(request: Request) -> AuthenticatedUser:
@@ -422,7 +422,7 @@ def test_employee_cannot_schedule_or_submit_records_for_another_employee() -> No
     own = _employee()
     other = client.post(
         "/api/v1/field-operations/employees",
-        json={"first_name": "Other", "last_name": "Worker", "email": "other.schedule@ironhousecivil.com", "portal_role": "employee"},
+        json={"first_name": "Other", "last_name": "Worker", "email": "other.schedule@ironhousecontracting.com", "portal_role": "employee"},
     ).json()
     project = _project()
 

--- a/tests/backend/test_finance.py
+++ b/tests/backend/test_finance.py
@@ -75,7 +75,7 @@ def test_startup_expenses_build_owner_loan_until_reimbursed() -> None:
 def test_financial_data_is_denied_to_non_management_accounts() -> None:
     project = _project()
     def estimator_user(request: Request) -> AuthenticatedUser:
-        user = AuthenticatedUser(id=UUID("00000000-0000-0000-0000-000000000026"), email="estimator@ironhousecivil.com", display_name="Estimator", role="estimator", session_version=1)
+        user = AuthenticatedUser(id=UUID("00000000-0000-0000-0000-000000000026"), email="estimator@ironhousecontracting.com", display_name="Estimator", role="estimator", session_version=1)
         request.state.authenticated_user = user
         return user
     app.dependency_overrides[require_authenticated_user] = estimator_user

--- a/tests/backend/test_identity_governance.py
+++ b/tests/backend/test_identity_governance.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.user import UserAccount
+from app.services.auth import hash_password
+from app.services.identity_governance import build_identity_governance_snapshot
+from conftest import TestingSessionLocal
+
+client = TestClient(app)
+NOW = datetime(2026, 7, 24, 16, 0, tzinfo=timezone.utc)
+
+
+def account(email: str, *, role: str = "viewer", active: bool = True) -> UserAccount:
+    return UserAccount(
+        email=email,
+        display_name=email.split("@")[0].replace(".", " ").title(),
+        role=role,
+        password_hash=hash_password("Build-233-secure-password"),
+        is_active=active,
+    )
+
+
+def test_snapshot_identifies_access_and_domain_risks_without_secrets() -> None:
+    with TestingSessionLocal() as db:
+        admin = account("jeremie@ironhousecontracting.com", role="admin")
+        admin.created_at = NOW - timedelta(days=30)
+        admin.last_login_at = NOW - timedelta(days=1)
+        legacy = account("taryn@ironhousecivil.com")
+        legacy.created_at = NOW - timedelta(days=100)
+        legacy.last_login_at = NOW - timedelta(days=95)
+        legacy.password_reset_required = True
+        db.add_all([admin, legacy])
+        db.commit()
+
+        snapshot = build_identity_governance_snapshot(db, now=NOW)
+        payload = snapshot.model_dump(mode="json")
+
+    assert snapshot.summary.total_accounts == 2
+    assert snapshot.summary.active_administrators == 1
+    assert snapshot.summary.legacy_domain_accounts == 1
+    assert snapshot.summary.accounts_requiring_review == 2
+    assert [finding.code for finding in snapshot.findings][:2] == [
+        "legacy_email_domain",
+        "single_active_administrator",
+    ]
+    assert "password_hash" not in str(payload)
+    assert "session_version" not in str(payload)
+
+
+def test_governance_endpoint_is_administrator_only_and_has_stable_shape() -> None:
+    response = client.get("/api/v1/users/governance")
+    assert response.status_code == 200
+    assert response.json()["canonical_email_domain"] == "ironhousecontracting.com"
+    assert response.json()["summary"]["total_accounts"] == 0
+    assert response.json()["findings"][0]["code"] == "no_active_administrator"

--- a/tests/backend/test_identity_governance_report.py
+++ b/tests/backend/test_identity_governance_report.py
@@ -1,0 +1,25 @@
+from app.tools.identity_governance_report import evidence_envelope, exit_code_for_findings
+
+
+def test_evidence_envelope_is_repeatably_hashed_and_secret_safe() -> None:
+    payload = {
+        "summary": {"total_accounts": 1},
+        "findings": [{"severity": "high", "code": "single_active_administrator"}],
+        "accounts": [{"email": "jeremie@ironhousecontracting.com"}],
+    }
+    first = evidence_envelope(payload)
+    second = evidence_envelope(payload)
+
+    assert first["schema_version"] == 1
+    assert first["snapshot_sha256"] == second["snapshot_sha256"]
+    assert len(first["snapshot_sha256"]) == 64
+    assert first["snapshot"] == payload
+    assert "password" not in str(first).lower()
+
+
+def test_alert_exit_code_obeys_configured_threshold() -> None:
+    findings = [{"severity": "normal"}, {"severity": "high"}]
+    assert exit_code_for_findings(findings, "never") == 0
+    assert exit_code_for_findings(findings, "critical") == 0
+    assert exit_code_for_findings(findings, "high") == 3
+    assert exit_code_for_findings(findings, "normal") == 3

--- a/tests/backend/test_iron_house_chat.py
+++ b/tests/backend/test_iron_house_chat.py
@@ -16,7 +16,7 @@ def _authenticate_as(role: str) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000001"),
-            email=f"{role}@ironhousecivil.com",
+            email=f"{role}@ironhousecontracting.com",
             display_name=f"Test {role}", role=role, session_version=1,
         )
         request.state.authenticated_user = user

--- a/tests/backend/test_login_security.py
+++ b/tests/backend/test_login_security.py
@@ -16,7 +16,7 @@ from app.services.document_audit import (
     list_recent_document_audit_events,
 )
 
-ADMIN_EMAIL = "security-admin@ironhousecivil.com"
+ADMIN_EMAIL = "security-admin@ironhousecontracting.com"
 ADMIN_PASSWORD = "correct-horse-battery-staple"
 
 
@@ -98,7 +98,7 @@ def test_admin_recovery_forces_password_change_and_clears_lockout() -> None:
     created = client.post(
         "/api/v1/users",
         json={
-            "email": "recovering-estimator@ironhousecivil.com",
+            "email": "recovering-estimator@ironhousecontracting.com",
             "display_name": "Recovering Estimator",
             "role": "estimator",
             "password": "initial-password-2026",
@@ -112,7 +112,7 @@ def test_admin_recovery_forces_password_change_and_clears_lockout() -> None:
         client.post("/api/v1/auth/logout")
         client.post(
             "/api/v1/auth/login",
-            json={"email": "recovering-estimator@ironhousecivil.com", "password": "wrong-password"},
+            json={"email": "recovering-estimator@ironhousecontracting.com", "password": "wrong-password"},
         )
 
     client.cookies.clear()
@@ -132,7 +132,7 @@ def test_admin_recovery_forces_password_change_and_clears_lockout() -> None:
     login = client.post(
         "/api/v1/auth/login",
         json={
-            "email": "recovering-estimator@ironhousecivil.com",
+            "email": "recovering-estimator@ironhousecontracting.com",
             "password": "temporary-password-2026",
         },
     )

--- a/tests/backend/test_operational_observability.py
+++ b/tests/backend/test_operational_observability.py
@@ -20,7 +20,7 @@ def _authenticate_as(role: str) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000213"),
-            email=f"{role}@ironhousecivil.com",
+            email=f"{role}@ironhousecontracting.com",
             display_name=f"Build 213 {role}",
             role=role,
             session_version=1,

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -24,7 +24,7 @@ def _authenticate_as(role: str) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000001"),
-            email=f"{role}@ironhousecivil.com",
+            email=f"{role}@ironhousecontracting.com",
             display_name=f"Test {role}",
             role=role,
             session_version=1,
@@ -67,7 +67,7 @@ def test_viewer_is_read_only_and_denial_is_audited() -> None:
     assert response.status_code == 403
     assert "write" in response.json()["detail"]
     event = list_recent_document_audit_events(action="module_access", outcome="denied")[0]
-    assert event["actor"] == "viewer@ironhousecivil.com"
+    assert event["actor"] == "viewer@ironhousecontracting.com"
     assert event["request_id"] == "build-210-viewer-denial"
     assert event["metadata"] == {
         "module": "projects",


### PR DESCRIPTION
## Release candidate

Consolidates the complete dependent chain for Builds 231–234 into one deployable review against `main`.

## Included

- canonical `@ironhousecontracting.com` identity migration
- controlled administrator access recovery
- administrator-only Identity Governance Centre
- secret-safe governance evidence automation
- release lint, browser mock, mobile keyboard-accessibility, and canonical CI bootstrap repairs

## Verified locally

- Ruff passed
- 156 backend tests passed
- TypeScript lint passed
- 21 frontend tests passed
- frontend production build passed
- 4 Playwright desktop/mobile/accessibility tests passed
- 13-file visual design lock passed

## Release gates

GitHub must pass CI and the complete disposable production-stack migration, smoke, backup, restore, and evidence workflow before merge or deployment.

The live identity migration remains a separately controlled post-deployment operation requiring backup, dry run, review, and explicit apply authorisation.