### PR TITLE
Build 235 — fail closed on retired production identity

### DIFF
--- a/docs/builds/BUILD_235.md
+++ b/docs/builds/BUILD_235.md
@@ -1,0 +1,48 @@
+# Build 235 — Canonical Identity Deployment Preflight
+
+## Task card
+
+- **Lead function:** System Governance
+- **Supporting functions:** Quality Assurance, Administration and Communications
+- **Owner:** Jeremie Peters
+- **Priority:** High
+- **Status:** Ready
+- **Environment:** Development only
+- **Approval gate:** Pull-request review and green release gates before merge or deployment
+
+## Objective
+
+Prevent a production cutover from taking Iron House OS offline when the protected
+bootstrap administrator email still uses a retired or malformed company domain.
+
+## Verified
+
+- Build 231 rejects a retired bootstrap administrator email when the backend starts.
+- Production recovery on 2026-07-24 confirmed that a retired-domain value caused the
+  backend container to exit, prevented the frontend from starting and produced HTTP 502.
+- The canonical company identity domain is `ironhousecontracting.com`.
+- The production web hostname remains `os.ironhousecivil.com`.
+
+## Delivered
+
+- A fail-closed cutover preflight validates the bootstrap administrator email before
+  Nginx enters maintenance mode or Docker Compose changes the application stack.
+- The check rejects missing local parts, missing `@` separators and every
+  non-canonical domain.
+- Domain comparison is case-insensitive.
+- A regression test protects both the canonical-domain contract and the required
+  ordering ahead of the maintenance gateway change.
+
+## Risks and controls
+
+- **Risk:** A future identity-domain change could require a coordinated update.
+  **Control:** Change the canonical-domain contract only through an approved release
+  with production environment and migration evidence.
+- **Risk:** A malformed protected environment could interrupt deployment.
+  **Control:** The preflight exits before user traffic or running containers are
+  changed.
+
+## Record
+
+The pull request and release-gate results are the Build 235 system of record. Production
+deployment remains separately controlled.

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -84,6 +84,17 @@ export IHOS_RELEASE_ID="$release_sha"
 : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
 : "${IHOS_TLS_EMAIL:?IHOS_TLS_EMAIL is required}"
+
+canonical_email_domain=ironhousecontracting.com
+bootstrap_admin_local=${BOOTSTRAP_ADMIN_EMAIL%@*}
+bootstrap_admin_domain=${BOOTSTRAP_ADMIN_EMAIL##*@}
+if [[ "$BOOTSTRAP_ADMIN_EMAIL" != *@* ||
+      -z "$bootstrap_admin_local" ||
+      "${bootstrap_admin_domain,,}" != "$canonical_email_domain" ]]; then
+  echo "BOOTSTRAP_ADMIN_EMAIL must use the canonical $canonical_email_domain domain before cutover." >&2
+  exit 1
+fi
+
 if [[ "$IHOS_STORAGE_BACKEND" != "s3" || "$AWS_REGION" != "ca-central-1" ]]; then
   echo "Build 216 requires private S3 storage in ca-central-1." >&2
   exit 1

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -53,6 +53,21 @@ def test_gateway_configs_hold_maintenance_until_live_gate() -> None:
     assert "post-cutover-$stamp" in cutover
 
 
+def test_cutover_validates_canonical_bootstrap_domain_before_maintenance() -> None:
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+
+    validation = "BOOTSTRAP_ADMIN_EMAIL must use the canonical"
+    maintenance = (
+        "install -m 0644 ops/digitalocean/nginx-maintenance.conf "
+        "/etc/nginx/sites-available/iron-house-os"
+    )
+
+    assert "canonical_email_domain=ironhousecontracting.com" in cutover
+    assert '"${bootstrap_admin_domain,,}" != "$canonical_email_domain"' in cutover
+    assert validation in cutover
+    assert cutover.index(validation) < cutover.index(maintenance)
+
+
 def test_cloud_init_contains_no_production_credentials() -> None:
     cloud_init = (ROOT / "ops/digitalocean/cloud-init.yaml").read_text()
 


### PR DESCRIPTION
## What changed

- validates `BOOTSTRAP_ADMIN_EMAIL` before production maintenance mode or container changes
- rejects malformed addresses and any non-canonical domain
- compares the canonical domain case-insensitively
- adds a regression test that protects both the domain contract and pre-maintenance ordering
- records the recovery-driven hardening work as Build 235

## Root cause

Build 231 correctly rejected the retired `@ironhousecivil.com` bootstrap identity, but the cutover did not validate that protected environment value before starting the application transition. The backend exited, the frontend could not start, and production returned HTTP 502 until the identity migration and environment correction were completed.

## Impact

Future deployments fail closed before Nginx enters maintenance mode or Docker Compose changes the running application stack. The production hostname remains `os.ironhousecivil.com`; only the administrator identity domain is validated as `ironhousecontracting.com`.

## Validation

- `bash -n ops/digitalocean/cutover.sh`
- Ruff passed
- focused deployment configuration tests: 6 passed
- complete backend suite: 157 passed (one existing Pydantic warning)
- `git diff --check` passed

Production deployment remains separately controlled.