### PR TITLE
Build 236: Hands-free Hey Chat across Iron House OS

### DIFF
--- a/docs/builds/BUILD_236.md
+++ b/docs/builds/BUILD_236.md
@@ -1,0 +1,54 @@
+# Build 236 — Hands-Free Hey Chat
+
+## Task card
+
+- **Lead function:** System Governance
+- **Supporting functions:** Quality Assurance, Administration and Communications
+- **Owner:** Jeremie Peters
+- **Priority:** High
+- **Status:** Ready
+- **Environment:** Development only
+- **Approval gate:** Pull-request review and green release gates before merge or deployment
+
+## Objective
+
+Extend the management-only Iron House Chat foundation into a hands-free voice layer
+that remains available across Iron House OS pages without weakening its read-only,
+account-isolated or privacy controls.
+
+## Delivered
+
+- One explicit microphone-permission action enables Hey Chat across the open,
+  authenticated Iron House OS tab.
+- “Hey Chat” accepts a command in the same sentence or speaks a short acknowledgement
+  and accepts the next spoken sentence.
+- Recognition pauses while the assistant is working or speaking, then automatically
+  resumes to avoid hearing its own answer.
+- Interrupted browser recognition automatically restarts while the user keeps the
+  control enabled.
+- A persistent, visible microphone state and stop control provide clear privacy
+  indication from every OS page.
+- Access remains limited to administrators and operations managers.
+- Voice requests continue through the existing audited, read-only Iron House Chat API.
+
+## Boundaries and controls
+
+- Browser security requires the initial enable action and microphone permission.
+- Listening operates only while the authenticated Iron House OS tab remains open; it
+  is not a device-level or lock-screen assistant.
+- No new write tools, operational approvals or external actions are introduced.
+- Passwords, SINs, banking, medical and payroll information remain prohibited inputs.
+
+## Verification
+
+- 157 backend tests passed.
+- 26 frontend tests passed, including five focused voice-assistant tests.
+- Four Playwright desktop, mobile and accessibility release-gate tests passed.
+- Ruff, TypeScript and the production frontend build passed.
+- The visual-design lock passed with no protected-file changes.
+
+## Record
+
+The pull request and release-gate results will be the Build 236 system of record.
+Production deployment remains separately controlled and must not be inferred from
+merge or CI completion.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes, useParams } from "react-router-dom";
 
 import { AppLayout } from "./components/AppLayout";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import { HandsFreeVoiceProvider } from "./contexts/HandsFreeVoiceContext";
 import { BidPackageGeneratorPage } from "./pages/BidPackageGeneratorPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { DocumentLibraryPage } from "./pages/DocumentLibraryPage";
@@ -107,7 +108,9 @@ function AuthenticatedApp() {
 export function App() {
   return (
     <AuthProvider>
-      <AuthenticatedApp />
+      <HandsFreeVoiceProvider>
+        <AuthenticatedApp />
+      </HandsFreeVoiceProvider>
     </AuthProvider>
   );
 }

--- a/frontend/src/contexts/HandsFreeVoiceContext.test.tsx
+++ b/frontend/src/contexts/HandsFreeVoiceContext.test.tsx
@@ -1,0 +1,163 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testState = vi.hoisted(() => ({
+  role: "admin",
+  send: vi.fn(),
+}));
+
+vi.mock("./AuthContext", () => ({
+  useAuth: () => ({
+    user: {
+      id: "00000000-0000-0000-0000-000000000001",
+      email: "manager@ironhousecontracting.com",
+      display_name: "Iron House Manager",
+      role: testState.role,
+      is_active: true,
+      password_reset_required: false,
+    },
+  }),
+}));
+
+vi.mock("../api/ironHouseChat", () => ({
+  ironHouseChatApi: {
+    send: testState.send,
+  },
+}));
+
+import { HandsFreeVoiceProvider, interpretVoiceTranscript } from "./HandsFreeVoiceContext";
+
+type ResultHandler = ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null;
+
+class MockSpeechRecognition {
+  static instances: MockSpeechRecognition[] = [];
+
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onresult: ResultHandler = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: { error?: string }) => void) | null = null;
+  start = vi.fn();
+  stop = vi.fn();
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
+
+  emit(transcript: string) {
+    this.onresult?.({ results: [{ 0: { transcript } }] });
+  }
+
+  end() {
+    this.onend?.();
+  }
+}
+
+class MockSpeechSynthesisUtterance {
+  lang = "";
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public text: string) {}
+}
+
+const spoken: string[] = [];
+
+describe("interpretVoiceTranscript", () => {
+  it("recognizes direct and two-step wake commands without reacting to ordinary speech", () => {
+    expect(interpretVoiceTranscript("Hey Chat, where are project costs?", false)).toEqual({
+      kind: "command",
+      command: "where are project costs?",
+    });
+    expect(interpretVoiceTranscript("hey chat", false)).toEqual({ kind: "wake" });
+    expect(interpretVoiceTranscript("Show me the safety page", true)).toEqual({
+      kind: "command",
+      command: "Show me the safety page",
+    });
+    expect(interpretVoiceTranscript("ordinary site conversation", false)).toEqual({ kind: "ignore" });
+  });
+});
+
+describe("HandsFreeVoiceProvider", () => {
+  beforeEach(() => {
+    testState.role = "admin";
+    testState.send.mockReset();
+    testState.send.mockResolvedValue({
+      conversation: { id: "conversation-1" },
+      user_message: { id: "message-1", role: "user", content: "Where are project costs?", status: "completed" },
+      assistant_message: {
+        id: "message-2",
+        role: "assistant",
+        content: "Open Financial Control from the main navigation.",
+        status: "completed",
+      },
+    });
+    MockSpeechRecognition.instances = [];
+    spoken.length = 0;
+    vi.stubGlobal("webkitSpeechRecognition", MockSpeechRecognition);
+    vi.stubGlobal("SpeechSynthesisUtterance", MockSpeechSynthesisUtterance);
+    vi.stubGlobal("speechSynthesis", {
+      cancel: vi.fn(),
+      speak: vi.fn((utterance: MockSpeechSynthesisUtterance) => {
+        spoken.push(utterance.text);
+        queueMicrotask(() => utterance.onend?.());
+      }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends a command spoken in the wake phrase and speaks the answer", async () => {
+    const user = userEvent.setup();
+    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+
+    await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
+    expect(MockSpeechRecognition.instances).toHaveLength(1);
+    expect(MockSpeechRecognition.instances[0].start).toHaveBeenCalledOnce();
+
+    act(() => MockSpeechRecognition.instances[0].emit("Hey Chat, where are project costs?"));
+
+    await waitFor(() => expect(testState.send).toHaveBeenCalledWith("where are project costs?", undefined));
+    await waitFor(() => expect(spoken).toContain("Open Financial Control from the main navigation."));
+    expect(screen.getByRole("button", { name: "Stop hands-free Hey Chat" })).toBeInTheDocument();
+  });
+
+  it("accepts the sentence after a wake-only phrase and automatically resumes listening", async () => {
+    const user = userEvent.setup();
+    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+
+    await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
+    act(() => MockSpeechRecognition.instances[0].emit("Hey Chat"));
+
+    await waitFor(() => expect(spoken).toContain("I’m listening."));
+    await waitFor(() => expect(MockSpeechRecognition.instances.length).toBeGreaterThan(1));
+    expect(await screen.findByText("Listening for your question")).toBeInTheDocument();
+
+    const resumedRecognition = MockSpeechRecognition.instances.at(-1);
+    act(() => resumedRecognition?.emit("Show me the safety page"));
+
+    await waitFor(() => expect(testState.send).toHaveBeenCalledWith("Show me the safety page", undefined));
+  });
+
+  it("restarts an interrupted recognition session while enabled", async () => {
+    const user = userEvent.setup();
+    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+
+    await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
+    act(() => MockSpeechRecognition.instances[0].end());
+
+    await waitFor(() => expect(MockSpeechRecognition.instances.length).toBeGreaterThan(1));
+    expect(MockSpeechRecognition.instances.at(-1)?.start).toHaveBeenCalledOnce();
+  });
+
+  it("does not expose the microphone control to non-management accounts", () => {
+    testState.role = "viewer";
+    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+
+    expect(screen.queryByRole("button", { name: /Hey Chat/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/contexts/HandsFreeVoiceContext.tsx
+++ b/frontend/src/contexts/HandsFreeVoiceContext.tsx
@@ -1,0 +1,405 @@
+import { Bot, LoaderCircle, Mic, MicOff, Volume2 } from "lucide-react";
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { ironHouseChatApi } from "../api/ironHouseChat";
+import { useAuth } from "./AuthContext";
+
+type SpeechRecognitionEventLike = {
+  results: ArrayLike<{ 0: { transcript: string } }>;
+};
+
+type SpeechRecognitionErrorEventLike = {
+  error?: string;
+};
+
+type SpeechRecognitionLike = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onend: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
+  start: () => void;
+  stop: () => void;
+};
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
+
+type SpeechWindow = typeof window & {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+};
+
+type VoicePhase = "off" | "listening" | "awaiting-command" | "thinking" | "speaking" | "error";
+
+type VoiceInterpretation =
+  | { kind: "ignore" }
+  | { kind: "wake" }
+  | { kind: "command"; command: string };
+
+type HandsFreeVoiceContextValue = {
+  enabled: boolean;
+  phase: VoicePhase;
+  speakAssistantResponse: (text: string) => void;
+};
+
+const HandsFreeVoiceContext = createContext<HandsFreeVoiceContextValue | null>(null);
+const RESTART_DELAY_MS = 250;
+
+export function interpretVoiceTranscript(transcript: string, awaitingCommand: boolean): VoiceInterpretation {
+  const clean = transcript.trim();
+  if (!clean) return { kind: "ignore" };
+
+  const wakeMatch = clean.match(/^hey\s+chat\b[\s,.:;!?-]*(.*)$/i);
+  if (wakeMatch) {
+    const command = wakeMatch[1].trim();
+    return command ? { kind: "command", command } : { kind: "wake" };
+  }
+
+  return awaitingCommand ? { kind: "command", command: clean } : { kind: "ignore" };
+}
+
+function recognitionConstructor(): SpeechRecognitionConstructor | undefined {
+  const speechWindow = window as SpeechWindow;
+  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition;
+}
+
+export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
+  const { user } = useAuth();
+  const allowed =
+    Boolean(user) &&
+    !user?.password_reset_required &&
+    (user?.role === "admin" || user?.role === "operations_manager");
+  const [enabled, setEnabled] = useState(false);
+  const [phase, setPhase] = useState<VoicePhase>("off");
+  const [error, setError] = useState<string | null>(null);
+  const enabledRef = useRef(false);
+  const awaitingCommandRef = useRef(false);
+  const busyRef = useRef(false);
+  const pausedForSpeechRef = useRef(false);
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const conversationIdRef = useRef<string | undefined>(undefined);
+  const restartTimerRef = useRef<number | null>(null);
+  const startRecognitionRef = useRef<() => void>(() => undefined);
+  const handleTranscriptRef = useRef<(transcript: string) => void>(() => undefined);
+
+  const clearRestartTimer = useCallback(() => {
+    if (restartTimerRef.current !== null) {
+      window.clearTimeout(restartTimerRef.current);
+      restartTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleRestart = useCallback(() => {
+    clearRestartTimer();
+    if (!enabledRef.current || pausedForSpeechRef.current) return;
+    restartTimerRef.current = window.setTimeout(() => {
+      restartTimerRef.current = null;
+      startRecognitionRef.current();
+    }, RESTART_DELAY_MS);
+  }, [clearRestartTimer]);
+
+  const stopRecognition = useCallback(() => {
+    const recognition = recognitionRef.current;
+    recognitionRef.current = null;
+    if (!recognition) return;
+    recognition.onend = null;
+    try {
+      recognition.stop();
+    } catch {
+      // A browser may already have ended the recognition session.
+    }
+  }, []);
+
+  const resumeListening = useCallback(
+    (resumePhase: "listening" | "awaiting-command" = "listening") => {
+      pausedForSpeechRef.current = false;
+      if (!enabledRef.current) return;
+      setPhase(resumePhase);
+      scheduleRestart();
+    },
+    [scheduleRestart],
+  );
+
+  const speak = useCallback(
+    (text: string, resumePhase: "listening" | "awaiting-command" = "listening") => {
+      if (!("speechSynthesis" in window) || typeof SpeechSynthesisUtterance === "undefined") {
+        resumeListening(resumePhase);
+        return;
+      }
+
+      clearRestartTimer();
+      pausedForSpeechRef.current = true;
+      stopRecognition();
+      if (enabledRef.current) setPhase("speaking");
+
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = "en-CA";
+      utterance.onend = () => resumeListening(resumePhase);
+      utterance.onerror = () => resumeListening(resumePhase);
+      window.speechSynthesis.speak(utterance);
+    },
+    [clearRestartTimer, resumeListening, stopRecognition],
+  );
+
+  const submitVoiceCommand = useCallback(
+    async (command: string) => {
+      const clean = command.trim();
+      if (!clean || busyRef.current) return;
+
+      busyRef.current = true;
+      awaitingCommandRef.current = false;
+      clearRestartTimer();
+      pausedForSpeechRef.current = true;
+      stopRecognition();
+      setError(null);
+      setPhase("thinking");
+
+      try {
+        const reply = await ironHouseChatApi.send(clean, conversationIdRef.current);
+        conversationIdRef.current = reply.conversation.id;
+        if (reply.assistant_message.status === "completed") {
+          speak(reply.assistant_message.content);
+        } else {
+          resumeListening();
+        }
+      } catch (reason) {
+        const message = reason instanceof Error ? reason.message : "Unable to reach Iron House Chat.";
+        setError(message);
+        speak("I couldn’t complete that request. Check Iron House Chat for details.");
+      } finally {
+        busyRef.current = false;
+      }
+    },
+    [clearRestartTimer, resumeListening, speak, stopRecognition],
+  );
+
+  const handleTranscript = useCallback(
+    (transcript: string) => {
+      if (!enabledRef.current || busyRef.current || pausedForSpeechRef.current) return;
+      const interpretation = interpretVoiceTranscript(transcript, awaitingCommandRef.current);
+      if (interpretation.kind === "ignore") return;
+      if (interpretation.kind === "wake") {
+        awaitingCommandRef.current = true;
+        setError(null);
+        speak("I’m listening.", "awaiting-command");
+        return;
+      }
+      void submitVoiceCommand(interpretation.command);
+    },
+    [speak, submitVoiceCommand],
+  );
+  handleTranscriptRef.current = handleTranscript;
+
+  const startRecognition = useCallback(() => {
+    if (!enabledRef.current || pausedForSpeechRef.current || recognitionRef.current) return;
+    const Recognition = recognitionConstructor();
+    if (!Recognition) {
+      enabledRef.current = false;
+      setEnabled(false);
+      setPhase("error");
+      setError("Voice recognition is not supported by this browser. Use a current Safari or Chrome device.");
+      return;
+    }
+
+    const recognition = new Recognition();
+    recognition.continuous = true;
+    recognition.interimResults = false;
+    recognition.lang = "en-CA";
+    recognition.onresult = (event) => {
+      const result = event.results[event.results.length - 1];
+      handleTranscriptRef.current(result[0].transcript);
+    };
+    recognition.onerror = (event) => {
+      if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+        enabledRef.current = false;
+        setEnabled(false);
+        setPhase("error");
+        setError("Microphone permission was denied. Allow microphone access in the browser, then enable Hey Chat again.");
+        return;
+      }
+      setError("Microphone listening was interrupted. Hey Chat will retry while this tab remains open.");
+    };
+    recognition.onend = () => {
+      if (recognitionRef.current === recognition) recognitionRef.current = null;
+      if (enabledRef.current && !pausedForSpeechRef.current) scheduleRestart();
+    };
+    recognitionRef.current = recognition;
+
+    try {
+      recognition.start();
+      setError(null);
+      setPhase(awaitingCommandRef.current ? "awaiting-command" : "listening");
+    } catch {
+      recognitionRef.current = null;
+      setError("Unable to start microphone listening. Hey Chat will retry while this tab remains open.");
+      scheduleRestart();
+    }
+  }, [scheduleRestart]);
+  startRecognitionRef.current = startRecognition;
+
+  const disable = useCallback(() => {
+    enabledRef.current = false;
+    awaitingCommandRef.current = false;
+    busyRef.current = false;
+    pausedForSpeechRef.current = false;
+    clearRestartTimer();
+    stopRecognition();
+    if ("speechSynthesis" in window) window.speechSynthesis.cancel();
+    setEnabled(false);
+    setPhase("off");
+    setError(null);
+  }, [clearRestartTimer, stopRecognition]);
+
+  const enable = useCallback(() => {
+    if (!allowed) return;
+    if (!recognitionConstructor()) {
+      setPhase("error");
+      setError("Voice recognition is not supported by this browser. Use a current Safari or Chrome device.");
+      return;
+    }
+    enabledRef.current = true;
+    awaitingCommandRef.current = false;
+    pausedForSpeechRef.current = false;
+    setEnabled(true);
+    setError(null);
+    setPhase("listening");
+    startRecognitionRef.current();
+  }, [allowed]);
+
+  const speakAssistantResponse = useCallback((text: string) => speak(text), [speak]);
+
+  useEffect(() => {
+    if (!allowed && enabledRef.current) disable();
+  }, [allowed, disable]);
+
+  useEffect(
+    () => () => {
+      enabledRef.current = false;
+      clearRestartTimer();
+      stopRecognition();
+      if ("speechSynthesis" in window) window.speechSynthesis.cancel();
+    },
+    [clearRestartTimer, stopRecognition],
+  );
+
+  const value = useMemo(
+    () => ({ enabled, phase, speakAssistantResponse }),
+    [enabled, phase, speakAssistantResponse],
+  );
+
+  return (
+    <HandsFreeVoiceContext.Provider value={value}>
+      {children}
+      {allowed ? (
+        <HandsFreeVoiceControl
+          enabled={enabled}
+          error={error}
+          phase={phase}
+          supported={Boolean(recognitionConstructor())}
+          onDisable={disable}
+          onEnable={enable}
+        />
+      ) : null}
+    </HandsFreeVoiceContext.Provider>
+  );
+}
+
+export function useHandsFreeVoice(): HandsFreeVoiceContextValue {
+  const context = useContext(HandsFreeVoiceContext);
+  if (context === null) throw new Error("useHandsFreeVoice must be used within HandsFreeVoiceProvider.");
+  return context;
+}
+
+function HandsFreeVoiceControl({
+  enabled,
+  error,
+  phase,
+  supported,
+  onDisable,
+  onEnable,
+}: {
+  enabled: boolean;
+  error: string | null;
+  phase: VoicePhase;
+  supported: boolean;
+  onDisable: () => void;
+  onEnable: () => void;
+}) {
+  if (!enabled) {
+    return (
+      <div className="fixed bottom-4 right-4 z-40 max-w-[calc(100vw-2rem)] text-right">
+        <button
+          type="button"
+          onClick={onEnable}
+          disabled={!supported}
+          className="inline-flex items-center gap-2 rounded-md bg-brand-gold px-4 py-3 text-sm font-semibold text-brand-black shadow-brand transition hover:bg-amber-400 disabled:cursor-not-allowed disabled:bg-iron-300"
+          aria-label="Enable hands-free Hey Chat"
+        >
+          <Mic className="h-4 w-4" aria-hidden="true" />
+          {supported ? "Enable Hey Chat" : "Voice unavailable"}
+        </button>
+        {error ? (
+          <div role="alert" className="mt-2 max-w-sm rounded-md border border-red-200 bg-white p-3 text-left text-xs text-red-700 shadow-md">
+            {error}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  const status =
+    phase === "awaiting-command"
+      ? "Listening for your question"
+      : phase === "thinking"
+        ? "Working on your request"
+        : phase === "speaking"
+          ? "Speaking the answer"
+          : "Listening for “Hey Chat”";
+  const StatusIcon = phase === "thinking" ? LoaderCircle : phase === "speaking" ? Volume2 : Bot;
+
+  return (
+    <section
+      aria-label="Hands-free Hey Chat"
+      className="fixed bottom-4 right-4 z-40 w-[min(22rem,calc(100vw-2rem))] rounded-md border border-brand-gold/40 bg-brand-black p-4 text-white shadow-brand"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="relative mt-0.5">
+            <StatusIcon className={`h-5 w-5 text-brand-gold ${phase === "thinking" ? "animate-spin" : ""}`} aria-hidden="true" />
+            {phase === "listening" || phase === "awaiting-command" ? (
+              <span className="absolute -right-1 -top-1 h-2 w-2 animate-pulse rounded-full bg-red-500" aria-hidden="true" />
+            ) : null}
+          </span>
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-brand-silver">Hey Chat is on</div>
+            <div className="mt-1 text-xs text-iron-100" aria-live="polite">{status}</div>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onDisable}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-white/20 px-2.5 py-1.5 text-xs font-semibold text-white transition hover:border-brand-gold hover:text-brand-gold"
+          aria-label="Stop hands-free Hey Chat"
+        >
+          <MicOff className="h-3.5 w-3.5" aria-hidden="true" />
+          Stop
+        </button>
+      </div>
+      {error ? <div role="alert" className="mt-3 rounded-md bg-red-950/70 p-2 text-xs text-red-100">{error}</div> : null}
+      <div className="mt-3 border-t border-white/10 pt-2 text-[11px] text-iron-300">
+        Open tab only • Management only • Read-only
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/IronHouseChatPage.tsx
+++ b/frontend/src/pages/IronHouseChatPage.tsx
@@ -1,18 +1,10 @@
-import { Bot, Brain, Mic, MicOff, Send, ShieldCheck, Upload, Volume2 } from "lucide-react";
-import { FormEvent, useEffect, useRef, useState } from "react";
+import { Bot, Brain, Send, ShieldCheck, Upload, Volume2 } from "lucide-react";
+import { FormEvent, useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 
 import { ChatMessage, ChatStatus, ironHouseChatApi } from "../api/ironHouseChat";
 import { useAuth } from "../contexts/AuthContext";
-
-type SpeechRecognitionEventLike = { results: ArrayLike<{ 0: { transcript: string } }> };
-type SpeechRecognitionLike = {
-  continuous: boolean; interimResults: boolean; lang: string;
-  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
-  onend: (() => void) | null; onerror: (() => void) | null;
-  start: () => void; stop: () => void;
-};
-type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
+import { useHandsFreeVoice } from "../contexts/HandsFreeVoiceContext";
 
 export function IronHouseChatPage() {
   const { user } = useAuth();
@@ -22,11 +14,9 @@ export function IronHouseChatPage() {
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
-  const [listening, setListening] = useState(false);
   const [importing, setImporting] = useState(false);
   const [importMessage, setImportMessage] = useState<string | null>(null);
-  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
-  const submitRef = useRef<(text: string) => void>(() => undefined);
+  const { speakAssistantResponse } = useHandsFreeVoice();
 
   useEffect(() => {
     ironHouseChatApi.status().then(setStatus).catch((reason) => setError(reason instanceof Error ? reason.message : "Unable to load Iron House Chat"));
@@ -40,36 +30,10 @@ export function IronHouseChatPage() {
       const reply = await ironHouseChatApi.send(clean, conversationId);
       setConversationId(reply.conversation.id);
       setMessages((current) => [...current, reply.user_message, reply.assistant_message]);
-      if ("speechSynthesis" in window && reply.assistant_message.status === "completed") {
-        window.speechSynthesis.cancel();
-        window.speechSynthesis.speak(new SpeechSynthesisUtterance(reply.assistant_message.content));
-      }
+      if (reply.assistant_message.status === "completed") speakAssistantResponse(reply.assistant_message.content);
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "Unable to send message");
     } finally { setSending(false); }
-  }
-  submitRef.current = (text) => void send(text);
-
-  function toggleListening() {
-    if (listening) { recognitionRef.current?.stop(); setListening(false); return; }
-    const speechWindow = window as typeof window & { SpeechRecognition?: SpeechRecognitionConstructor; webkitSpeechRecognition?: SpeechRecognitionConstructor };
-    const Recognition = speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition;
-    if (!Recognition) { setError("Voice recognition is not supported by this browser. Use text or a supported Safari/Chrome device."); return; }
-    const recognition = new Recognition();
-    recognition.continuous = true; recognition.interimResults = false; recognition.lang = "en-CA";
-    recognition.onresult = (event) => {
-      const transcript = event.results[event.results.length - 1][0].transcript.trim();
-      const wakeMatch = transcript.match(/hey\s+chat[,.]?\s*(.*)/i);
-      if (wakeMatch) {
-        const request = wakeMatch[1].trim();
-        if (request) submitRef.current(request);
-        else setDraft("");
-      }
-    };
-    recognition.onend = () => setListening(false);
-    recognition.onerror = () => { setListening(false); setError("Microphone listening stopped. Check browser microphone permission."); };
-    recognitionRef.current = recognition;
-    try { recognition.start(); setListening(true); setError(null); } catch { setError("Unable to start microphone listening."); }
   }
 
   async function importHistory(file: File | undefined) {
@@ -114,9 +78,7 @@ export function IronHouseChatPage() {
       <div className="rounded-md border border-iron-100 bg-white shadow-sm">
         <div className="flex items-center justify-between border-b border-iron-100 p-4">
           <div className="flex items-center gap-2 text-sm font-semibold"><ShieldCheck className="h-4 w-4" /> Audited management conversation</div>
-          <button type="button" onClick={toggleListening} className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold ${listening ? "bg-red-600 text-white" : "bg-brand-gold text-brand-black"}`} aria-pressed={listening}>
-            {listening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}{listening ? "Stop listening" : "Enable Hey Chat"}
-          </button>
+          <span className="text-xs font-medium text-iron-500">Global hands-free control</span>
         </div>
         <div className="min-h-[360px] space-y-4 p-4" aria-live="polite">
           {messages.length === 0 ? <div className="grid min-h-[300px] place-items-center text-center"><div><Volume2 className="mx-auto h-8 w-8 text-brand-gold" /><p className="mt-3 font-semibold">Ask how to use Iron House OS</p><p className="mt-1 text-sm text-iron-500">Try “Hey Chat, where do I review project costs?”</p></div></div> : messages.map((message) => <div key={message.id} className={`max-w-3xl rounded-md p-3 text-sm leading-6 ${message.role === "user" ? "ml-auto bg-brand-gold text-brand-black" : "bg-iron-50 text-iron-800"}`}><div className="mb-1 text-xs font-semibold uppercase tracking-wide opacity-70">{message.role === "user" ? "Management" : "Iron House Chat"}</div>{message.content}</div>)}
@@ -127,7 +89,7 @@ export function IronHouseChatPage() {
           <button type="submit" disabled={sending || !draft.trim()} className="self-stretch rounded-md bg-iron-950 px-4 text-white disabled:bg-iron-300" aria-label="Send message"><Send className="h-4 w-4" /></button>
         </form>
       </div>
-      <p className="text-xs text-iron-500">Voice listening works only while this page is open and microphone permission is active. Do not enter passwords, SINs, banking, medical, or payroll information.</p>
+      <p className="text-xs text-iron-500">Enable Hey Chat once from the global control to use it across Iron House OS while this browser tab remains open. Do not enter passwords, SINs, banking, medical, or payroll information.</p>
     </section>
   );
 }


### PR DESCRIPTION
## What changed

- Adds a management-only hands-free voice layer that persists across Iron House OS routes.
- Requires one explicit browser microphone-permission action, then listens for “Hey Chat”.
- Accepts either “Hey Chat, <command>” or “Hey Chat” followed by a second spoken sentence.
- Pauses recognition while working or speaking, then automatically resumes and recovers from interrupted browser recognition.
- Adds a persistent microphone/privacy state and stop control.
- Centralizes spoken responses so the Chat page and global listener cannot compete for the microphone.
- Preserves the existing audited, account-isolated, read-only Iron House Chat API boundary.

## Operational impact

Administrators and operations managers can use Iron House Chat hands-free from any page while the authenticated OS tab remains open. This is browser-scoped, not a device-level or lock-screen assistant. It introduces no write tools, approvals, or external actions.

## Validation

- 157 backend tests passed
- 26 frontend tests passed, including five focused voice-assistant tests
- 4 Playwright desktop/mobile/accessibility release-gate tests passed
- Ruff passed
- TypeScript passed
- Production frontend build passed
- Visual-design lock passed

## Visual design lock

- [x] This change preserves the approved Iron House OS production appearance.
- [x] No protected visual file changed.

## Approval gate

Draft only. Do not merge or deploy until the owner reviews the hands-free behaviour and explicitly approves Build 236.