### PR TITLE
Build 237: deterministic hands-free OS navigation

### DIFF
--- a/docs/builds/BUILD_237.md
+++ b/docs/builds/BUILD_237.md
@@ -1,0 +1,36 @@
+# Build 237 — Deterministic Hands-Free Navigation
+
+## Objective
+
+Extend the management-only “Hey Chat” layer with safe, deterministic navigation
+between Iron House OS modules while preserving the approved production appearance and
+the assistant’s read-only operating boundary.
+
+## Delivered
+
+- Explicit voice directions such as “Hey Chat, open Financial Control” navigate
+  directly to the requested module.
+- Common Iron House names and practical aliases are mapped to existing authenticated
+  routes, including projects, safety, estimating, documents, suppliers, RFQs,
+  takeoff, equipment, reporting and management portals.
+- Navigation is handled locally and does not send the direction to the AI service.
+- The assistant speaks a short destination confirmation, then automatically resumes
+  listening.
+- Ordinary questions continue through the existing audited Iron House Chat API.
+
+## Controls
+
+- A navigation verb is required, reducing accidental routing from normal site
+  conversation.
+- Only fixed, existing application routes can be opened; spoken text cannot create an
+  arbitrary URL.
+- Navigation does not create, edit, approve, submit, send or delete company records.
+- Access remains limited to administrators and operations managers.
+- Browser microphone permission, visible listening state and the stop control remain
+  unchanged.
+- No protected visual-design file is changed.
+
+## Approval gate
+
+Build 237 may be merged only after the full CI and Release Readiness workflows pass.
+Production deployment and authenticated acceptance remain separately controlled.

--- a/frontend/src/contexts/HandsFreeVoiceContext.test.tsx
+++ b/frontend/src/contexts/HandsFreeVoiceContext.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, useLocation } from "react-router-dom";
 
 const testState = vi.hoisted(() => ({
   role: "admin",
@@ -27,6 +28,7 @@ vi.mock("../api/ironHouseChat", () => ({
 }));
 
 import { HandsFreeVoiceProvider, interpretVoiceTranscript } from "./HandsFreeVoiceContext";
+import { resolveVoiceNavigation } from "../utils/voiceNavigation";
 
 type ResultHandler = ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null;
 
@@ -80,6 +82,35 @@ describe("interpretVoiceTranscript", () => {
   });
 });
 
+describe("resolveVoiceNavigation", () => {
+  it("accepts explicit navigation requests and rejects ordinary questions", () => {
+    expect(resolveVoiceNavigation("Open financial control")).toEqual({
+      label: "Financial Control",
+      path: "/finance",
+    });
+    expect(resolveVoiceNavigation("Hey, what are the project costs?")).toBeNull();
+    expect(resolveVoiceNavigation("Show me the safety page")).toEqual({
+      label: "Safety Program",
+      path: "/safety-program",
+    });
+  });
+});
+
+function LocationProbe() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
+}
+
+function renderProvider() {
+  return render(
+    <MemoryRouter initialEntries={["/dashboard"]}>
+      <HandsFreeVoiceProvider>
+        <div>OS workspace</div>
+        <LocationProbe />
+      </HandsFreeVoiceProvider>
+    </MemoryRouter>,
+  );
+}
+
 describe("HandsFreeVoiceProvider", () => {
   beforeEach(() => {
     testState.role = "admin";
@@ -113,7 +144,7 @@ describe("HandsFreeVoiceProvider", () => {
 
   it("sends a command spoken in the wake phrase and speaks the answer", async () => {
     const user = userEvent.setup();
-    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+    renderProvider();
 
     await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
     expect(MockSpeechRecognition.instances).toHaveLength(1);
@@ -126,9 +157,9 @@ describe("HandsFreeVoiceProvider", () => {
     expect(screen.getByRole("button", { name: "Stop hands-free Hey Chat" })).toBeInTheDocument();
   });
 
-  it("accepts the sentence after a wake-only phrase and automatically resumes listening", async () => {
+  it("accepts a navigation direction after a wake-only phrase and automatically resumes listening", async () => {
     const user = userEvent.setup();
-    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+    renderProvider();
 
     await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
     act(() => MockSpeechRecognition.instances[0].emit("Hey Chat"));
@@ -140,12 +171,14 @@ describe("HandsFreeVoiceProvider", () => {
     const resumedRecognition = MockSpeechRecognition.instances.at(-1);
     act(() => resumedRecognition?.emit("Show me the safety page"));
 
-    await waitFor(() => expect(testState.send).toHaveBeenCalledWith("Show me the safety page", undefined));
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/safety-program"));
+    expect(testState.send).not.toHaveBeenCalled();
+    expect(spoken).toContain("Opening Safety Program.");
   });
 
   it("restarts an interrupted recognition session while enabled", async () => {
     const user = userEvent.setup();
-    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+    renderProvider();
 
     await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
     act(() => MockSpeechRecognition.instances[0].end());
@@ -156,8 +189,20 @@ describe("HandsFreeVoiceProvider", () => {
 
   it("does not expose the microphone control to non-management accounts", () => {
     testState.role = "viewer";
-    render(<HandsFreeVoiceProvider><div>OS workspace</div></HandsFreeVoiceProvider>);
+    renderProvider();
 
     expect(screen.queryByRole("button", { name: /Hey Chat/i })).not.toBeInTheDocument();
+  });
+
+  it("opens a requested OS module without sending the command to the AI", async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
+    act(() => MockSpeechRecognition.instances[0].emit("Hey Chat, open financial control"));
+
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/finance"));
+    expect(testState.send).not.toHaveBeenCalled();
+    expect(spoken).toContain("Opening Financial Control.");
   });
 });

--- a/frontend/src/contexts/HandsFreeVoiceContext.tsx
+++ b/frontend/src/contexts/HandsFreeVoiceContext.tsx
@@ -9,8 +9,10 @@ import {
   useRef,
   useState,
 } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { ironHouseChatApi } from "../api/ironHouseChat";
+import { resolveVoiceNavigation } from "../utils/voiceNavigation";
 import { useAuth } from "./AuthContext";
 
 type SpeechRecognitionEventLike = {
@@ -75,6 +77,7 @@ function recognitionConstructor(): SpeechRecognitionConstructor | undefined {
 
 export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const allowed =
     Boolean(user) &&
     !user?.password_reset_required &&
@@ -157,6 +160,15 @@ export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
       const clean = command.trim();
       if (!clean || busyRef.current) return;
 
+      const navigation = resolveVoiceNavigation(clean);
+      if (navigation) {
+        awaitingCommandRef.current = false;
+        setError(null);
+        navigate(navigation.path);
+        speak(`Opening ${navigation.label}.`);
+        return;
+      }
+
       busyRef.current = true;
       awaitingCommandRef.current = false;
       clearRestartTimer();
@@ -181,7 +193,7 @@ export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
         busyRef.current = false;
       }
     },
-    [clearRestartTimer, resumeListening, speak, stopRecognition],
+    [clearRestartTimer, navigate, resumeListening, speak, stopRecognition],
   );
 
   const handleTranscript = useCallback(
@@ -398,7 +410,7 @@ function HandsFreeVoiceControl({
       </div>
       {error ? <div role="alert" className="mt-3 rounded-md bg-red-950/70 p-2 text-xs text-red-100">{error}</div> : null}
       <div className="mt-3 border-t border-white/10 pt-2 text-[11px] text-iron-300">
-        Open tab only • Management only • Read-only
+        Open tab only • Management only • Navigation and read-only answers
       </div>
     </section>
   );

--- a/frontend/src/utils/voiceNavigation.ts
+++ b/frontend/src/utils/voiceNavigation.ts
@@ -1,0 +1,60 @@
+export type VoiceNavigationTarget = {
+  label: string;
+  path: string;
+};
+
+const TARGETS: Array<VoiceNavigationTarget & { aliases: string[] }> = [
+  { label: "Iron House Chat", path: "/iron-house-chat", aliases: ["iron house chat", "chat"] },
+  { label: "Safety Operations", path: "/safety-operations", aliases: ["safety operations", "safety controls"] },
+  { label: "Safety Program", path: "/safety-program", aliases: ["safety program", "safety page", "safety"] },
+  { label: "Project Operations", path: "/project-operations", aliases: ["project operations"] },
+  { label: "Projects", path: "/projects", aliases: ["project workspace", "projects"] },
+  { label: "Document Operations", path: "/document-operations", aliases: ["document operations"] },
+  { label: "Document Library", path: "/documents", aliases: ["document library", "documents"] },
+  { label: "RFQ Automation", path: "/rfq-automation", aliases: ["rfq automation"] },
+  { label: "RFQ Builder", path: "/rfq-builder", aliases: ["rfq builder", "rfqs", "rfq"] },
+  { label: "Bid Package", path: "/bid-package", aliases: ["bid package generator", "bid package"] },
+  { label: "Supplier Database", path: "/suppliers", aliases: ["supplier database", "suppliers"] },
+  { label: "Drawing Intelligence", path: "/drawing-intelligence", aliases: ["drawing intelligence", "drawings"] },
+  { label: "Quantity Takeoff", path: "/quantity-takeoff", aliases: ["quantity takeoff engine", "quantity takeoff", "takeoff"] },
+  {
+    label: "Municipality Intelligence",
+    path: "/municipality-intelligence",
+    aliases: ["municipality intelligence", "municipal standards"],
+  },
+  { label: "Quote Comparison", path: "/quotes", aliases: ["quote comparison", "quotes"] },
+  { label: "Tender Tracker", path: "/tenders", aliases: ["tender tracker", "tenders"] },
+  { label: "Financial Control", path: "/finance", aliases: ["financial control", "finances", "finance"] },
+  { label: "Vehicle Tracking", path: "/vehicle-tracking", aliases: ["vehicle tracking", "vehicles"] },
+  { label: "Employee Portal", path: "/employee-portal", aliases: ["employee portal"] },
+  { label: "Foreman Portal", path: "/foreman-portal", aliases: ["foreman portal"] },
+  { label: "Operator Portal", path: "/operator-portal", aliases: ["operator portal"] },
+  { label: "MVP Workflow", path: "/mvp-workflow", aliases: ["mvp workflow", "bid workflow", "workflow"] },
+  { label: "Estimating", path: "/estimating", aliases: ["estimating", "estimate builder", "estimates"] },
+  { label: "Equipment", path: "/equipment", aliases: ["equipment"] },
+  { label: "Reporting", path: "/reporting", aliases: ["reporting", "reports"] },
+  { label: "Settings", path: "/settings", aliases: ["settings"] },
+  { label: "Dashboard", path: "/dashboard", aliases: ["dashboard", "home"] },
+];
+
+const NAVIGATION_PREFIX =
+  /^(?:please\s+)?(?:open|show(?:\s+me)?|go\s+to|take\s+me\s+to|navigate\s+to|bring\s+me\s+to)\s+(?:the\s+)?/;
+
+function normalize(command: string): string {
+  return command
+    .trim()
+    .toLocaleLowerCase("en-CA")
+    .replace(/[.,!?;:]+$/g, "")
+    .replace(/\s+/g, " ");
+}
+
+export function resolveVoiceNavigation(command: string): VoiceNavigationTarget | null {
+  const normalized = normalize(command);
+  if (!NAVIGATION_PREFIX.test(normalized)) return null;
+
+  const destination = normalized.replace(NAVIGATION_PREFIX, "").replace(/\s+page$/, "").trim();
+  for (const target of TARGETS) {
+    if (target.aliases.includes(destination)) return { label: target.label, path: target.path };
+  }
+  return null;
+}


### PR DESCRIPTION
## What changed

- Adds deterministic hands-free navigation for explicit commands such as “Hey Chat, open Financial Control”.
- Maps practical Iron House module names and aliases to fixed authenticated OS routes.
- Handles navigation locally without sending the direction to the AI service.
- Speaks a short destination confirmation and resumes listening automatically.
- Keeps ordinary questions on the existing audited, read-only Iron House Chat API.

## Safety and operational controls

- A navigation verb is required to avoid reacting to ordinary site conversation.
- Spoken text cannot create arbitrary URLs; only fixed existing application routes are available.
- Voice navigation cannot create, edit, approve, submit, send, or delete company records.
- Access remains limited to administrators and operations managers.
- The approved visual design remains unchanged.

## Local verification

- 157 backend tests passed
- 28 frontend tests passed
- 7 focused hands-free voice/navigation tests passed
- 4 Playwright desktop/mobile/accessibility tests passed
- Ruff passed
- TypeScript passed
- Production frontend build passed
- 13-file visual-design lock passed
- `git diff --check` passed

## Approval gate

Draft release candidate only. Do not merge or deploy until GitHub CI and Release Readiness pass and the owner explicitly approves Build 237.