### PR TITLE
Build 238: hands-free session controls

### DIFF
--- a/docs/builds/BUILD_238.md
+++ b/docs/builds/BUILD_238.md
@@ -1,0 +1,37 @@
+# Build 238 — Hands-Free Session Controls
+
+## Objective
+
+Complete the management-only hands-free operating layer with deterministic local
+session controls while preserving the approved production appearance and the
+assistant's read-only boundary.
+
+## Delivered
+
+- "Hey Chat, go back" returns to the previous OS route.
+- "Hey Chat, go home" opens the authenticated dashboard.
+- "Hey Chat, repeat that" repeats the most recent spoken response without another API request.
+- "Hey Chat, what can I say?" explains the available read-only voice capabilities.
+- "Hey Chat, stop listening" turns off the microphone without requiring the screen control.
+- Approved controls are resolved locally before navigation or Iron House Chat requests.
+
+## Controls
+
+- Voice controls cannot create, edit, approve, submit, send or delete company records.
+- Only explicit, fixed phrases resolve as session controls.
+- Unrecognized commands continue through the existing audited, read-only Iron House Chat API.
+- Access remains limited to administrators and operations managers.
+- Browser microphone permission, visible listening state and the manual stop control remain available.
+- No protected visual-design file is changed.
+
+## Verification
+
+- Pure resolver tests cover every approved control and reject an unsafe mutation phrase.
+- Provider tests prove repeat does not create a second API request.
+- Provider tests prove voice stop disables microphone listening locally.
+- Full CI and Release Readiness remain required before merge.
+
+## Approval gate
+
+Build 238 may be merged only after the full CI and Release Readiness workflows pass.
+Production deployment and authenticated acceptance remain separately controlled.

--- a/frontend/src/contexts/HandsFreeVoiceContext.test.tsx
+++ b/frontend/src/contexts/HandsFreeVoiceContext.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../api/ironHouseChat", () => ({
 }));
 
 import { HandsFreeVoiceProvider, interpretVoiceTranscript } from "./HandsFreeVoiceContext";
+import { resolveVoiceControl } from "../utils/voiceControls";
 import { resolveVoiceNavigation } from "../utils/voiceNavigation";
 
 type ResultHandler = ((event: { results: ArrayLike<{ 0: { transcript: string } }> }) => void) | null;
@@ -79,6 +80,17 @@ describe("interpretVoiceTranscript", () => {
       command: "Show me the safety page",
     });
     expect(interpretVoiceTranscript("ordinary site conversation", false)).toEqual({ kind: "ignore" });
+  });
+});
+
+describe("resolveVoiceControl", () => {
+  it("recognizes only the approved local hands-free controls", () => {
+    expect(resolveVoiceControl("Go back")).toBe("back");
+    expect(resolveVoiceControl("Go home")).toBe("home");
+    expect(resolveVoiceControl("What can I say?")).toBe("help");
+    expect(resolveVoiceControl("Say that again")).toBe("repeat");
+    expect(resolveVoiceControl("Stop listening")).toBe("stop");
+    expect(resolveVoiceControl("Delete the project")).toBeNull();
   });
 });
 
@@ -204,5 +216,37 @@ describe("HandsFreeVoiceProvider", () => {
     await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent("/finance"));
     expect(testState.send).not.toHaveBeenCalled();
     expect(spoken).toContain("Opening Financial Control.");
+  });
+
+  it("repeats the previous answer locally without another API request", async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
+    act(() => MockSpeechRecognition.instances[0].emit("Hey Chat, where are project costs?"));
+
+    await waitFor(() => expect(spoken).toContain("Open Financial Control from the main navigation."));
+    await waitFor(() => expect(MockSpeechRecognition.instances.length).toBeGreaterThan(1));
+    const resumedRecognition = MockSpeechRecognition.instances.at(-1);
+    act(() => resumedRecognition?.emit("Hey Chat, repeat that"));
+
+    await waitFor(() =>
+      expect(spoken.filter((text) => text === "Open Financial Control from the main navigation.")).toHaveLength(2),
+    );
+    expect(testState.send).toHaveBeenCalledOnce();
+  });
+
+  it("stops hands-free listening by voice without an API request", async () => {
+    const user = userEvent.setup();
+    renderProvider();
+
+    await user.click(screen.getByRole("button", { name: "Enable hands-free Hey Chat" }));
+    act(() => MockSpeechRecognition.instances[0].emit("Hey Chat, stop listening"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Enable hands-free Hey Chat" })).toBeInTheDocument(),
+    );
+    expect(testState.send).not.toHaveBeenCalled();
+    expect(spoken).toContain("Hey Chat is off.");
   });
 });

--- a/frontend/src/contexts/HandsFreeVoiceContext.tsx
+++ b/frontend/src/contexts/HandsFreeVoiceContext.tsx
@@ -12,6 +12,7 @@ import {
 import { useNavigate } from "react-router-dom";
 
 import { ironHouseChatApi } from "../api/ironHouseChat";
+import { resolveVoiceControl } from "../utils/voiceControls";
 import { resolveVoiceNavigation } from "../utils/voiceNavigation";
 import { useAuth } from "./AuthContext";
 
@@ -94,6 +95,7 @@ export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
   const restartTimerRef = useRef<number | null>(null);
   const startRecognitionRef = useRef<() => void>(() => undefined);
   const handleTranscriptRef = useRef<(transcript: string) => void>(() => undefined);
+  const lastSpokenRef = useRef<string | null>(null);
 
   const clearRestartTimer = useCallback(() => {
     if (restartTimerRef.current !== null) {
@@ -135,6 +137,7 @@ export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
 
   const speak = useCallback(
     (text: string, resumePhase: "listening" | "awaiting-command" = "listening") => {
+      lastSpokenRef.current = text;
       if (!("speechSynthesis" in window) || typeof SpeechSynthesisUtterance === "undefined") {
         resumeListening(resumePhase);
         return;
@@ -159,6 +162,42 @@ export function HandsFreeVoiceProvider({ children }: PropsWithChildren) {
     async (command: string) => {
       const clean = command.trim();
       if (!clean || busyRef.current) return;
+
+      const control = resolveVoiceControl(clean);
+      if (control) {
+        awaitingCommandRef.current = false;
+        setError(null);
+
+        if (control === "back") {
+          navigate(-1);
+          speak("Going back.");
+          return;
+        }
+        if (control === "home") {
+          navigate("/dashboard");
+          speak("Opening Dashboard.");
+          return;
+        }
+        if (control === "help") {
+          speak("You can ask a read-only question, open an OS module, go back, go home, repeat the last answer, or stop listening.");
+          return;
+        }
+        if (control === "repeat") {
+          const previous = lastSpokenRef.current;
+          speak(previous ?? "There is no previous response to repeat.");
+          return;
+        }
+
+        enabledRef.current = false;
+        busyRef.current = false;
+        pausedForSpeechRef.current = false;
+        clearRestartTimer();
+        stopRecognition();
+        setEnabled(false);
+        setPhase("off");
+        speak("Hey Chat is off.");
+        return;
+      }
 
       const navigation = resolveVoiceNavigation(clean);
       if (navigation) {

--- a/frontend/src/utils/voiceControls.ts
+++ b/frontend/src/utils/voiceControls.ts
@@ -1,0 +1,27 @@
+export type VoiceControlAction = "back" | "home" | "help" | "repeat" | "stop";
+
+function normalize(command: string): string {
+  return command
+    .trim()
+    .toLocaleLowerCase("en-CA")
+    .replace(/[.,!?;:]+$/g, "")
+    .replace(/\s+/g, " ");
+}
+
+export function resolveVoiceControl(command: string): VoiceControlAction | null {
+  const normalized = normalize(command);
+
+  if (/^(?:go\s+)?back$|^(?:open\s+the\s+)?previous\s+page$/.test(normalized)) return "back";
+  if (/^(?:go\s+)?home$|^(?:return\s+to|open)\s+(?:the\s+)?dashboard$/.test(normalized)) return "home";
+  if (/^help$|^voice\s+commands$|^what\s+can\s+i\s+say$/.test(normalized)) return "help";
+  if (/^repeat(?:\s+that|\s+the\s+(?:last\s+)?answer)?$|^say\s+that\s+again$/.test(normalized)) {
+    return "repeat";
+  }
+  if (
+    /^stop$|^stop\s+listening$|^(?:turn\s+off|disable|stop)\s+(?:hey\s+)?chat$/.test(normalized)
+  ) {
+    return "stop";
+  }
+
+  return null;
+}


### PR DESCRIPTION
## What changed

- Adds deterministic local hands-free commands for back, home, help, repeat and stop.
- Repeats the last spoken answer without creating another Iron House Chat API request.
- Allows management users to turn off microphone listening entirely by voice.
- Preserves fixed-route navigation, management-only access and the audited read-only AI boundary.
- Does not change protected visual-design files.

## Controls

- Explicit fixed phrases only.
- No voice command can create, edit, approve, submit, send or delete company records.
- Unrecognized requests continue through the existing audited, read-only Iron House Chat API.
- Manual microphone controls and browser permission boundaries remain in place.

## Verification added

- Pure resolver coverage for all five controls.
- Unsafe mutation phrase rejection.
- Provider proof that repeat does not duplicate API requests.
- Provider proof that spoken stop disables listening locally.

## Approval gate

Draft release candidate. Do not merge or deploy until GitHub CI and Release Readiness pass and the owner explicitly approves Build 238.
