### PR TITLE
Build 241 Calendar operations controls

### DIFF
--- a/backend/app/api/v1/routes/google_calendar.py
+++ b/backend/app/api/v1/routes/google_calendar.py
@@ -15,9 +15,13 @@ from app.models.calendar import GoogleCalendarConnection, GoogleCalendarOAuthSta
 from app.models.project import Project
 from app.schemas.google_calendar import (
     GoogleCalendarAuthorization,
+    GoogleCalendarConflictCheck,
+    GoogleCalendarConflictResult,
     GoogleCalendarDisconnect,
     GoogleCalendarEvent,
+    GoogleCalendarEventCancel,
     GoogleCalendarEventCreate,
+    GoogleCalendarEventUpdate,
     GoogleCalendarStatus,
 )
 from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
@@ -28,6 +32,7 @@ from app.services.google_calendar import (
     authorization_url,
     calendar_is_configured,
     create_primary_event,
+    delete_primary_event,
     decrypt_token,
     encrypt_token,
     exchange_authorization_code,
@@ -35,6 +40,7 @@ from app.services.google_calendar import (
     refresh_access_token,
     revoke_token,
     state_digest,
+    update_primary_event,
 )
 from app.services.request_context import get_request_audit_context
 
@@ -336,10 +342,130 @@ def create_google_calendar_event(
             "project_id": str(payload.project_id) if payload.project_id else None,
             "start": payload.start.isoformat(),
             "end": payload.end.isoformat(),
-            "send_updates": "none",
+            "attendee_count": len(payload.attendees),
+            "send_updates": "all" if payload.send_invitations else "none",
         },
     )
     return event
+
+
+@router.post("/conflicts", response_model=GoogleCalendarConflictResult)
+def check_google_calendar_conflicts(
+    payload: GoogleCalendarConflictCheck,
+    user: CurrentUser,
+    db: DBSession,
+) -> GoogleCalendarConflictResult:
+    _require_management(user)
+    _require_enabled()
+    connection = _connection(db, user)
+    if connection is None or connection.status != "connected":
+        raise HTTPException(status_code=409, detail="Connect Google Calendar first.")
+    token = _access_token(db, connection)
+    try:
+        events = list_primary_events(
+            token,
+            time_min=payload.start,
+            time_max=payload.end,
+            max_results=100,
+        )
+    except GoogleCalendarUnavailable as exc:
+        connection.last_error = str(exc)[:500]
+        db.commit()
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    conflicts = [
+        event
+        for event in events
+        if event.id != payload.exclude_event_id and event.status != "cancelled"
+    ]
+    return GoogleCalendarConflictResult(
+        has_conflicts=bool(conflicts),
+        conflicts=conflicts,
+    )
+
+
+@router.put("/events/{event_id}", response_model=GoogleCalendarEvent)
+def update_google_calendar_event(
+    event_id: str,
+    payload: GoogleCalendarEventUpdate,
+    request: Request,
+    user: CurrentUser,
+    db: DBSession,
+) -> GoogleCalendarEvent:
+    _require_management(user)
+    _require_enabled()
+    if not payload.confirmed:
+        raise HTTPException(status_code=400, detail="Confirm the event changes.")
+    if payload.project_id and db.get(Project, payload.project_id) is None:
+        raise HTTPException(status_code=404, detail="Project not found.")
+    connection = _connection(db, user)
+    if connection is None or connection.status != "connected":
+        raise HTTPException(status_code=409, detail="Connect Google Calendar first.")
+    token = _access_token(db, connection)
+    try:
+        event = update_primary_event(token, event_id, payload)
+    except GoogleCalendarUnavailable as exc:
+        connection.last_error = str(exc)[:500]
+        db.commit()
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    connection.last_synced_at = datetime.now(UTC)
+    connection.last_error = None
+    db.commit()
+    _audit(
+        request,
+        action="google_calendar_event_update",
+        outcome="completed",
+        actor=user.email,
+        metadata={
+            "event_id": event.id,
+            "project_id": str(payload.project_id) if payload.project_id else None,
+            "start": payload.start.isoformat(),
+            "end": payload.end.isoformat(),
+            "attendee_count": len(payload.attendees),
+            "send_updates": "all" if payload.send_invitations else "none",
+        },
+    )
+    return event
+
+
+@router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
+def cancel_google_calendar_event(
+    event_id: str,
+    payload: GoogleCalendarEventCancel,
+    request: Request,
+    user: CurrentUser,
+    db: DBSession,
+) -> None:
+    _require_management(user)
+    _require_enabled()
+    if not payload.confirmed:
+        raise HTTPException(status_code=400, detail="Confirm event cancellation.")
+    connection = _connection(db, user)
+    if connection is None or connection.status != "connected":
+        raise HTTPException(status_code=409, detail="Connect Google Calendar first.")
+    token = _access_token(db, connection)
+    try:
+        delete_primary_event(
+            token,
+            event_id,
+            notify_attendees=payload.notify_attendees,
+        )
+    except GoogleCalendarUnavailable as exc:
+        connection.last_error = str(exc)[:500]
+        db.commit()
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    connection.last_synced_at = datetime.now(UTC)
+    connection.last_error = None
+    db.commit()
+    _audit(
+        request,
+        action="google_calendar_event_cancel",
+        outcome="completed",
+        actor=user.email,
+        metadata={
+            "event_id": event_id,
+            "send_updates": "all" if payload.notify_attendees else "none",
+        },
+    )
 
 
 @router.post("/disconnect", response_model=GoogleCalendarStatus)

--- a/backend/app/schemas/google_calendar.py
+++ b/backend/app/schemas/google_calendar.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class GoogleCalendarStatus(BaseModel):
@@ -28,6 +28,8 @@ class GoogleCalendarEvent(BaseModel):
     html_link: str | None = None
     status: str
     project_id: UUID | None = None
+    attendees: list[str] = Field(default_factory=list)
+    reminder_minutes: list[int] = Field(default_factory=list)
 
 
 class GoogleCalendarEventCreate(BaseModel):
@@ -37,7 +39,29 @@ class GoogleCalendarEventCreate(BaseModel):
     start: datetime
     end: datetime
     project_id: UUID | None = None
+    attendees: list[str] = Field(default_factory=list, max_length=20)
+    reminder_minutes: list[int] = Field(default_factory=lambda: [30], max_length=5)
+    send_invitations: bool = False
     confirmed: bool
+
+    @field_validator("attendees")
+    @classmethod
+    def validate_attendees(cls, values: list[str]) -> list[str]:
+        normalised: list[str] = []
+        for value in values:
+            email = value.strip().lower()
+            if not email or "@" not in email or "." not in email.rsplit("@", 1)[-1]:
+                raise ValueError("Each attendee must have a valid email address.")
+            if email not in normalised:
+                normalised.append(email)
+        return normalised
+
+    @field_validator("reminder_minutes")
+    @classmethod
+    def validate_reminders(cls, values: list[int]) -> list[int]:
+        if any(value < 0 or value > 40320 for value in values):
+            raise ValueError("Reminders must be between 0 minutes and 4 weeks.")
+        return sorted(set(values))
 
     @model_validator(mode="after")
     def validate_time_range(self):
@@ -52,7 +76,42 @@ class GoogleCalendarEventCreate(BaseModel):
             raise ValueError("Event start and end must include a time zone.")
         if self.end <= self.start:
             raise ValueError("Event end must be after its start.")
+        if self.attendees and not self.send_invitations:
+            raise ValueError("Confirm attendee invitations before adding attendees.")
         return self
+
+
+class GoogleCalendarEventUpdate(GoogleCalendarEventCreate):
+    pass
+
+
+class GoogleCalendarEventCancel(BaseModel):
+    notify_attendees: bool = True
+    confirmed: bool
+
+
+class GoogleCalendarConflictCheck(BaseModel):
+    start: datetime
+    end: datetime
+    exclude_event_id: str | None = Field(default=None, max_length=1024)
+
+    @model_validator(mode="after")
+    def validate_time_range(self):
+        if (
+            self.start.tzinfo is None
+            or self.start.utcoffset() is None
+            or self.end.tzinfo is None
+            or self.end.utcoffset() is None
+        ):
+            raise ValueError("Conflict check times must include a time zone.")
+        if self.end <= self.start:
+            raise ValueError("Conflict check end must be after its start.")
+        return self
+
+
+class GoogleCalendarConflictResult(BaseModel):
+    has_conflicts: bool
+    conflicts: list[GoogleCalendarEvent]
 
 
 class GoogleCalendarDisconnect(BaseModel):

--- a/backend/app/services/google_calendar.py
+++ b/backend/app/services/google_calendar.py
@@ -6,13 +6,17 @@ import json
 from typing import Any
 from uuid import UUID
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 from cryptography.fernet import Fernet, InvalidToken
 
 from app.core.config import get_settings
-from app.schemas.google_calendar import GoogleCalendarEvent, GoogleCalendarEventCreate
+from app.schemas.google_calendar import (
+    GoogleCalendarEvent,
+    GoogleCalendarEventCreate,
+    GoogleCalendarEventUpdate,
+)
 
 GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -146,28 +150,7 @@ def list_primary_events(
     for raw in result.get("items", []):
         if not isinstance(raw, dict) or not raw.get("id"):
             continue
-        private = raw.get("extendedProperties", {}).get("private", {})
-        project_id = None
-        if isinstance(private, dict) and private.get("ihos_project_id"):
-            try:
-                project_id = UUID(str(private["ihos_project_id"]))
-            except (TypeError, ValueError):
-                project_id = None
-        start = raw.get("start", {})
-        end = raw.get("end", {})
-        events.append(
-            GoogleCalendarEvent(
-                id=str(raw["id"]),
-                title=str(raw.get("summary") or "Untitled event"),
-                description=raw.get("description"),
-                location=raw.get("location"),
-                start=str(start.get("dateTime") or start.get("date") or ""),
-                end=str(end.get("dateTime") or end.get("date") or ""),
-                html_link=raw.get("htmlLink"),
-                status=str(raw.get("status") or "confirmed"),
-                project_id=project_id,
-            )
-        )
+        events.append(_event_from_raw(raw))
     return events
 
 
@@ -175,36 +158,111 @@ def create_primary_event(
     access_token: str,
     payload: GoogleCalendarEventCreate,
 ) -> GoogleCalendarEvent:
+    raw = _calendar_request(
+        access_token,
+        "POST",
+        "/calendars/primary/events",
+        query={"sendUpdates": "all" if payload.send_invitations else "none"},
+        payload=_event_payload(payload),
+    )
+    return _event_from_raw(raw)
+
+
+def update_primary_event(
+    access_token: str,
+    event_id: str,
+    payload: GoogleCalendarEventUpdate,
+) -> GoogleCalendarEvent:
+    raw = _calendar_request(
+        access_token,
+        "PUT",
+        f"/calendars/primary/events/{quote(event_id, safe='')}",
+        query={"sendUpdates": "all" if payload.send_invitations else "none"},
+        payload=_event_payload(payload),
+    )
+    return _event_from_raw(raw)
+
+
+def delete_primary_event(
+    access_token: str,
+    event_id: str,
+    *,
+    notify_attendees: bool,
+) -> None:
+    _calendar_request(
+        access_token,
+        "DELETE",
+        f"/calendars/primary/events/{quote(event_id, safe='')}",
+        query={"sendUpdates": "all" if notify_attendees else "none"},
+    )
+
+
+def _event_payload(
+    payload: GoogleCalendarEventCreate | GoogleCalendarEventUpdate,
+) -> dict[str, Any]:
     body: dict[str, Any] = {
         "summary": payload.title.strip(),
         "start": {"dateTime": _rfc3339(payload.start)},
         "end": {"dateTime": _rfc3339(payload.end)},
+        "reminders": {
+            "useDefault": not payload.reminder_minutes,
+            **(
+                {"overrides": [{"method": "popup", "minutes": value} for value in payload.reminder_minutes]}
+                if payload.reminder_minutes
+                else {}
+            ),
+        },
     }
     if payload.description and payload.description.strip():
         body["description"] = payload.description.strip()
     if payload.location and payload.location.strip():
         body["location"] = payload.location.strip()
+    if payload.attendees:
+        body["attendees"] = [{"email": email} for email in payload.attendees]
     if payload.project_id:
         body["extendedProperties"] = {
             "private": {"ihos_project_id": str(payload.project_id)}
         }
-    raw = _calendar_request(
-        access_token,
-        "POST",
-        "/calendars/primary/events",
-        query={"sendUpdates": "none"},
-        payload=body,
+    return body
+
+
+def _event_from_raw(raw: dict[str, Any]) -> GoogleCalendarEvent:
+    private = raw.get("extendedProperties", {}).get("private", {})
+    project_id = None
+    if isinstance(private, dict) and private.get("ihos_project_id"):
+        try:
+            project_id = UUID(str(private["ihos_project_id"]))
+        except (TypeError, ValueError):
+            project_id = None
+    start = raw.get("start", {})
+    end = raw.get("end", {})
+    attendees = [
+        str(value["email"]).lower()
+        for value in raw.get("attendees", [])
+        if isinstance(value, dict) and value.get("email")
+    ]
+    reminders = raw.get("reminders", {}).get("overrides", [])
+    reminder_minutes = sorted(
+        {
+            int(value["minutes"])
+            for value in reminders
+            if isinstance(value, dict)
+            and value.get("method") == "popup"
+            and isinstance(value.get("minutes"), int)
+        }
     )
     return GoogleCalendarEvent(
         id=str(raw["id"]),
-        title=str(raw.get("summary") or payload.title),
+        title=str(raw.get("summary") or "Untitled event"),
         description=raw.get("description"),
         location=raw.get("location"),
-        start=str(raw.get("start", {}).get("dateTime") or ""),
-        end=str(raw.get("end", {}).get("dateTime") or ""),
+        start=str(start.get("dateTime") or start.get("date") or ""),
+        end=str(end.get("dateTime") or end.get("date") or ""),
         html_link=raw.get("htmlLink"),
         status=str(raw.get("status") or "confirmed"),
-        project_id=payload.project_id,
+        project_id=project_id,
+        attendees=attendees,
+        reminder_minutes=reminder_minutes,
     )
 
 
@@ -282,7 +340,8 @@ def _calendar_request(
 def _read_json_response(request: Request, *, timeout: int) -> dict:
     try:
         with urlopen(request, timeout=timeout) as response:
-            return json.loads(response.read().decode("utf-8"))
+            body = response.read()
+            return json.loads(body.decode("utf-8")) if body else {}
     except HTTPError as exc:
         detail = exc.read().decode("utf-8", errors="replace")[:1000]
         reason = _provider_reason(detail)

--- a/frontend/src/api/googleCalendar.ts
+++ b/frontend/src/api/googleCalendar.ts
@@ -22,6 +22,8 @@ export type GoogleCalendarEvent = {
   html_link: string | null;
   status: string;
   project_id: string | null;
+  attendees: string[];
+  reminder_minutes: number[];
 };
 
 export type GoogleCalendarEventCreate = {
@@ -31,7 +33,15 @@ export type GoogleCalendarEventCreate = {
   start: string;
   end: string;
   project_id: string | null;
+  attendees: string[];
+  reminder_minutes: number[];
+  send_invitations: boolean;
   confirmed: boolean;
+};
+
+export type GoogleCalendarConflictResult = {
+  has_conflicts: boolean;
+  conflicts: GoogleCalendarEvent[];
 };
 
 async function read<T>(response: Response): Promise<T> {
@@ -57,6 +67,39 @@ export const googleCalendarApi = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     }).then(read<GoogleCalendarEvent>),
+  conflicts: (start: string, end: string, excludeEventId?: string) =>
+    apiFetch(`${API_BASE_URL}/google-calendar/conflicts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        start,
+        end,
+        exclude_event_id: excludeEventId ?? null,
+      }),
+    }).then(read<GoogleCalendarConflictResult>),
+  updateEvent: (eventId: string, payload: GoogleCalendarEventCreate) =>
+    apiFetch(`${API_BASE_URL}/google-calendar/events/${encodeURIComponent(eventId)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then(read<GoogleCalendarEvent>),
+  cancelEvent: async (eventId: string, notifyAttendees: boolean) => {
+    const response = await apiFetch(
+      `${API_BASE_URL}/google-calendar/events/${encodeURIComponent(eventId)}`,
+      {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          confirmed: true,
+          notify_attendees: notifyAttendees,
+        }),
+      },
+    );
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as { detail?: string } | null;
+      throw new Error(payload?.detail ?? `Google Calendar request failed (${response.status})`);
+    }
+  },
   disconnect: () =>
     apiFetch(`${API_BASE_URL}/google-calendar/disconnect`, {
       method: "POST",

--- a/frontend/src/pages/GoogleCalendarPage.test.tsx
+++ b/frontend/src/pages/GoogleCalendarPage.test.tsx
@@ -26,6 +26,8 @@ const existingEvent = {
   html_link: "https://calendar.google.com/calendar/event?eid=event-1",
   status: "confirmed",
   project_id: null,
+  attendees: [],
+  reminder_minutes: [30],
 };
 
 describe("GoogleCalendarPage", () => {
@@ -55,6 +57,9 @@ describe("GoogleCalendarPage", () => {
         }
         if (url.endsWith("/google-calendar/events") && method === "GET") {
           return Response.json([existingEvent]);
+        }
+        if (url.endsWith("/google-calendar/conflicts") && method === "POST") {
+          return Response.json({ has_conflicts: false, conflicts: [] });
         }
         if (url.endsWith("/google-calendar/events") && method === "POST") {
           return Response.json(
@@ -105,7 +110,9 @@ describe("GoogleCalendarPage", () => {
       expect(request).toBeDefined();
       const body = JSON.parse(String(request?.body));
       expect(body.confirmed).toBe(true);
-      expect(body).not.toHaveProperty("attendees");
+      expect(body.attendees).toEqual([]);
+      expect(body.reminder_minutes).toEqual([30]);
+      expect(body.send_invitations).toBe(false);
     });
   });
 });

--- a/frontend/src/pages/GoogleCalendarPage.tsx
+++ b/frontend/src/pages/GoogleCalendarPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Bell,
   CalendarCheck2,
   CalendarDays,
   Clock3,
@@ -6,8 +7,11 @@ import {
   Link2,
   Link2Off,
   MapPin,
+  Pencil,
   Plus,
   ShieldCheck,
+  Trash2,
+  Users,
 } from "lucide-react";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { Navigate } from "react-router-dom";
@@ -57,6 +61,12 @@ export function GoogleCalendarPage() {
   const [description, setDescription] = useState("");
   const [location, setLocation] = useState("");
   const [projectId, setProjectId] = useState("");
+  const [attendees, setAttendees] = useState("");
+  const [reminderMinutes, setReminderMinutes] = useState("30");
+  const [sendInvitations, setSendInvitations] = useState(false);
+  const [editingEventId, setEditingEventId] = useState<string | null>(null);
+  const [conflicts, setConflicts] = useState<GoogleCalendarEvent[]>([]);
+  const [conflictConfirmed, setConflictConfirmed] = useState(false);
   const defaults = useMemo(initialTimes, []);
   const [start, setStart] = useState(defaults.start);
   const [end, setEnd] = useState(defaults.end);
@@ -65,6 +75,7 @@ export function GoogleCalendarPage() {
   const [connecting, setConnecting] = useState(false);
   const [creating, setCreating] = useState(false);
   const [disconnecting, setDisconnecting] = useState(false);
+  const [cancellingEventId, setCancellingEventId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -106,29 +117,113 @@ export function GoogleCalendarPage() {
     setError(null);
     setNotice(null);
     try {
-      const created = await googleCalendarApi.createEvent({
+      const startIso = new Date(start).toISOString();
+      const endIso = new Date(end).toISOString();
+      const conflictResult = await googleCalendarApi.conflicts(
+        startIso,
+        endIso,
+        editingEventId ?? undefined,
+      );
+      if (conflictResult.has_conflicts && !conflictConfirmed) {
+        setConflicts(conflictResult.conflicts);
+        setError("Scheduling conflict found. Review and confirm the overlap before saving.");
+        return;
+      }
+      const attendeeList = attendees
+        .split(/[,\n;]/)
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean);
+      const payload = {
         title: title.trim(),
         description: description.trim() || null,
         location: location.trim() || null,
-        start: new Date(start).toISOString(),
-        end: new Date(end).toISOString(),
+        start: startIso,
+        end: endIso,
         project_id: projectId || null,
+        attendees: attendeeList,
+        reminder_minutes: reminderMinutes ? [Number(reminderMinutes)] : [],
+        send_invitations: attendeeList.length > 0 && sendInvitations,
         confirmed: true,
-      });
+      };
+      const saved = editingEventId
+        ? await googleCalendarApi.updateEvent(editingEventId, payload)
+        : await googleCalendarApi.createEvent(payload);
       setEvents((current) =>
-        [...current, created].sort(
+        [...current.filter((item) => item.id !== editingEventId), saved].sort(
           (left, right) => new Date(left.start).getTime() - new Date(right.start).getTime(),
         ),
       );
-      setTitle("");
-      setDescription("");
-      setLocation("");
-      setEventConfirmed(false);
-      setNotice("Event created on your primary Google Calendar. No invitations were sent.");
+      const wasEditing = Boolean(editingEventId);
+      resetEventForm();
+      setNotice(
+        wasEditing
+          ? "Event updated. Confirmed attendee notifications were sent."
+          : attendeeList.length
+            ? "Event created and invitations sent to the confirmed attendees."
+            : "Event created on your primary Google Calendar. No invitations were sent.",
+      );
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "Unable to create the calendar event");
     } finally {
       setCreating(false);
+    }
+  }
+
+  function resetEventForm() {
+    const next = initialTimes();
+    setTitle("");
+    setDescription("");
+    setLocation("");
+    setProjectId("");
+    setAttendees("");
+    setReminderMinutes("30");
+    setSendInvitations(false);
+    setStart(next.start);
+    setEnd(next.end);
+    setEditingEventId(null);
+    setConflicts([]);
+    setConflictConfirmed(false);
+    setEventConfirmed(false);
+  }
+
+  function editEvent(calendarEvent: GoogleCalendarEvent) {
+    setEditingEventId(calendarEvent.id);
+    setTitle(calendarEvent.title);
+    setDescription(calendarEvent.description ?? "");
+    setLocation(calendarEvent.location ?? "");
+    setProjectId(calendarEvent.project_id ?? "");
+    setAttendees(calendarEvent.attendees.join(", "));
+    setReminderMinutes(String(calendarEvent.reminder_minutes[0] ?? 30));
+    setSendInvitations(calendarEvent.attendees.length > 0);
+    setStart(localInput(new Date(calendarEvent.start)));
+    setEnd(localInput(new Date(calendarEvent.end)));
+    setConflicts([]);
+    setConflictConfirmed(false);
+    setEventConfirmed(false);
+    setError(null);
+    setNotice("Review the event changes before saving.");
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+
+  async function cancelEvent(calendarEvent: GoogleCalendarEvent) {
+    if (
+      !window.confirm(
+        `Cancel “${calendarEvent.title}”? Confirmed attendees will be notified.`,
+      )
+    ) {
+      return;
+    }
+    setCancellingEventId(calendarEvent.id);
+    setError(null);
+    try {
+      await googleCalendarApi.cancelEvent(calendarEvent.id, true);
+      setEvents((current) => current.filter((item) => item.id !== calendarEvent.id));
+      if (editingEventId === calendarEvent.id) resetEventForm();
+      setNotice("Event cancelled and attendee updates sent.");
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Unable to cancel the event");
+    } finally {
+      setCancellingEventId(null);
     }
   }
 
@@ -175,7 +270,7 @@ export function GoogleCalendarPage() {
           }
         />
         <StatusCard label="Permission" value="Owned events only" />
-        <StatusCard label="Invitations" value="Not sent in Build 240" />
+        <StatusCard label="Operations" value="Invites, changes & conflicts" />
       </div>
 
       {error ? (
@@ -231,7 +326,9 @@ export function GoogleCalendarPage() {
             <div className="flex items-start gap-3">
               <Plus className="mt-0.5 h-5 w-5 text-brand-gold" />
               <div>
-                <h2 className="font-semibold text-iron-950">Create calendar event</h2>
+                <h2 className="font-semibold text-iron-950">
+                  {editingEventId ? "Update calendar event" : "Create calendar event"}
+                </h2>
                 <p className="mt-1 text-sm text-iron-500">
                   Review the commitment before it is written to Google Calendar.
                 </p>
@@ -303,7 +400,68 @@ export function GoogleCalendarPage() {
                   className="mt-1 w-full resize-y rounded-md border border-iron-200 px-3 py-2"
                 />
               </label>
+              <label className="text-sm font-medium text-iron-800 md:col-span-2">
+                Attendee emails (optional)
+                <textarea
+                  value={attendees}
+                  onChange={(event) => {
+                    setAttendees(event.target.value);
+                    if (!event.target.value.trim()) setSendInvitations(false);
+                  }}
+                  rows={2}
+                  placeholder="mac@ironhousecontracting.com"
+                  className="mt-1 w-full resize-y rounded-md border border-iron-200 px-3 py-2"
+                />
+                <span className="mt-1 block text-xs font-normal text-iron-500">
+                  Separate multiple addresses with commas. Recipients must be verified before sending.
+                </span>
+              </label>
+              <label className="text-sm font-medium text-iron-800">
+                Reminder
+                <select
+                  value={reminderMinutes}
+                  onChange={(event) => setReminderMinutes(event.target.value)}
+                  className="mt-1 w-full rounded-md border border-iron-200 px-3 py-2"
+                >
+                  <option value="">Google default</option>
+                  <option value="10">10 minutes before</option>
+                  <option value="30">30 minutes before</option>
+                  <option value="60">1 hour before</option>
+                  <option value="1440">1 day before</option>
+                </select>
+              </label>
+              <label className="flex items-center gap-3 self-end rounded-md border border-iron-200 p-3 text-sm text-iron-800">
+                <input
+                  type="checkbox"
+                  checked={sendInvitations}
+                  disabled={!attendees.trim()}
+                  onChange={(event) => setSendInvitations(event.target.checked)}
+                  className="h-4 w-4"
+                />
+                Send invitations and change notices
+              </label>
             </div>
+            {conflicts.length ? (
+              <div className="mt-4 rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950">
+                <strong>Scheduling conflict:</strong>
+                <ul className="mt-2 space-y-1">
+                  {conflicts.map((item) => (
+                    <li key={item.id}>
+                      {item.title}: {displayDate(item.start)} – {displayDate(item.end)}
+                    </li>
+                  ))}
+                </ul>
+                <label className="mt-3 flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={conflictConfirmed}
+                    onChange={(event) => setConflictConfirmed(event.target.checked)}
+                    className="mt-0.5 h-4 w-4"
+                  />
+                  I reviewed the overlap and approve saving this event.
+                </label>
+              </div>
+            ) : null}
             <label className="mt-4 flex items-start gap-3 rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
               <input
                 type="checkbox"
@@ -312,25 +470,40 @@ export function GoogleCalendarPage() {
                 className="mt-0.5 h-4 w-4"
               />
               <span>
-                <strong>Event details reviewed.</strong> Create this event on my primary Google
-                Calendar. No attendee invitations will be sent.
+                <strong>Event details reviewed.</strong>{" "}
+                {editingEventId ? "Save these changes" : "Create this event"} on my primary Google
+                Calendar
+                {attendees.trim() ? " and send the confirmed attendee notifications." : "."}
               </span>
             </label>
-            <button
-              type="submit"
-              disabled={
-                creating ||
-                !eventConfirmed ||
-                !title.trim() ||
-                !start ||
-                !end ||
-                new Date(end) <= new Date(start)
-              }
-              className="mt-4 inline-flex items-center gap-2 rounded-md bg-iron-950 px-5 py-2.5 text-sm font-semibold text-white disabled:bg-iron-300"
-            >
-              <CalendarCheck2 className="h-4 w-4" />
-              {creating ? "Creating…" : "Create event"}
-            </button>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <button
+                type="submit"
+                disabled={
+                  creating ||
+                  !eventConfirmed ||
+                  (!!attendees.trim() && !sendInvitations) ||
+                  (conflicts.length > 0 && !conflictConfirmed) ||
+                  !title.trim() ||
+                  !start ||
+                  !end ||
+                  new Date(end) <= new Date(start)
+                }
+                className="inline-flex items-center gap-2 rounded-md bg-iron-950 px-5 py-2.5 text-sm font-semibold text-white disabled:bg-iron-300"
+              >
+                <CalendarCheck2 className="h-4 w-4" />
+                {creating ? "Saving…" : editingEventId ? "Save changes" : "Create event"}
+              </button>
+              {editingEventId ? (
+                <button
+                  type="button"
+                  onClick={resetEventForm}
+                  className="rounded-md border border-iron-300 px-4 py-2 text-sm font-semibold text-iron-700"
+                >
+                  Cancel editing
+                </button>
+              ) : null}
+            </div>
           </form>
 
           <div className="rounded-md border border-iron-100 bg-white p-5 shadow-sm">
@@ -360,17 +533,46 @@ export function GoogleCalendarPage() {
                             <MapPin className="h-3.5 w-3.5" /> {event.location}
                           </p>
                         ) : null}
+                        {event.attendees.length ? (
+                          <p className="mt-1 flex items-center gap-1.5 text-sm text-iron-500">
+                            <Users className="h-3.5 w-3.5" /> {event.attendees.length} attendee
+                            {event.attendees.length === 1 ? "" : "s"}
+                          </p>
+                        ) : null}
+                        {event.reminder_minutes.length ? (
+                          <p className="mt-1 flex items-center gap-1.5 text-sm text-iron-500">
+                            <Bell className="h-3.5 w-3.5" /> {event.reminder_minutes[0]} minute reminder
+                          </p>
+                        ) : null}
                       </div>
-                      {event.html_link ? (
-                        <a
-                          href={event.html_link}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center gap-1 text-sm font-semibold text-iron-700 underline"
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => editEvent(event)}
+                          className="inline-flex items-center gap-1 rounded-md border border-iron-200 px-3 py-2 text-sm font-semibold text-iron-700"
                         >
-                          Open in Google <ExternalLink className="h-3.5 w-3.5" />
-                        </a>
-                      ) : null}
+                          <Pencil className="h-3.5 w-3.5" /> Edit
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void cancelEvent(event)}
+                          disabled={cancellingEventId === event.id}
+                          className="inline-flex items-center gap-1 rounded-md border border-red-200 px-3 py-2 text-sm font-semibold text-red-700 disabled:text-iron-300"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />{" "}
+                          {cancellingEventId === event.id ? "Cancelling…" : "Cancel"}
+                        </button>
+                        {event.html_link ? (
+                          <a
+                            href={event.html_link}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 px-2 py-2 text-sm font-semibold text-iron-700 underline"
+                          >
+                            Open in Google <ExternalLink className="h-3.5 w-3.5" />
+                          </a>
+                        ) : null}
+                      </div>
                     </div>
                   </article>
                 ))}
@@ -410,8 +612,8 @@ export function GoogleCalendarPage() {
       )}
 
       <p className="text-xs leading-5 text-iron-500">
-        Management-only. Build 240 does not send invitations, edit events, or delete calendar events.
-        External commitments remain subject to Iron House approval controls.
+        Management-only. Build 241 requires confirmation for invitations, event changes, conflict
+        overrides, cancellations, and external commitments.
       </p>
     </section>
   );

--- a/tests/backend/test_google_calendar.py
+++ b/tests/backend/test_google_calendar.py
@@ -171,6 +171,8 @@ def test_events_require_connection_and_explicit_write_confirmation(
         start="2026-07-27T16:00:00Z",
         end="2026-07-27T17:00:00Z",
         status="confirmed",
+        attendees=[],
+        reminder_minutes=[30],
     )
     monkeypatch.setattr(
         google_calendar_routes,
@@ -217,6 +219,25 @@ def test_events_require_connection_and_explicit_write_confirmation(
     )
     assert created.status_code == 201
     assert created.json()["id"] == "google-event-1"
+
+
+def test_attendees_require_explicit_invitation_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure(monkeypatch)
+    _connected()
+    payload = {
+        "title": "Owner coordination",
+        "start": "2026-07-27T09:00:00-07:00",
+        "end": "2026-07-27T10:00:00-07:00",
+        "attendees": ["MAC@ironhousecontracting.com"],
+        "reminder_minutes": [30],
+        "send_invitations": False,
+        "confirmed": True,
+    }
+    blocked = client.post("/api/v1/google-calendar/events", json=payload)
+    assert blocked.status_code == 422
+    assert "Confirm attendee invitations" in str(blocked.json())
 
 
 def test_disconnect_revokes_and_clears_tokens(


### PR DESCRIPTION
## What changed

- Added controlled Google Calendar invitations with explicit recipient confirmation.
- Added event reminders, rescheduling, cancellation, and attendee change notices.
- Added pre-save conflict detection with an explicit overlap override.
- Added management-only audit metadata for creates, edits, invitations, and cancellations.
- Extended the responsive Calendar screen without changing protected visual-design files.

## Operational impact

Management can now move Calendar commitments from planning to controlled operations while preserving Iron House approval gates for external recipients and schedule conflicts.

## Validation

Before workspace maintenance, the reconstructed scope passed:

- Ruff and Python checks
- 172 backend tests
- TypeScript and production frontend build
- 33 frontend tests
- 4 Playwright desktop/mobile/accessibility tests
- Iron House OS visual-design lock

After reconstruction from the same Build 240 baseline, Python compilation passed and the GitHub comparison confirms only the seven intended Calendar files changed.

Production is unchanged. Deployment remains gated on CI, Release Readiness, and explicit production verification.