### PR TITLE
Add controlled production deployment runner

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -63,8 +63,10 @@ jobs:
           [[ "$EVIDENCE_RUN_ID" =~ ^[0-9]+$ ]]
           run_sha=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" --jq .head_sha)
           run_result=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" --jq .conclusion)
+          run_name=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" --jq .name)
           [[ "$run_sha" == "$RELEASE_SHA" ]]
           [[ "$run_result" == "success" ]]
+          [[ "$run_name" == "Release readiness" ]]
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,0 +1,110 @@
+name: Production deploy
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/production-deploy.yml"
+      - "ops/digitalocean/install-production-runner.sh"
+      - "ops/digitalocean/production-deploy-wrapper.sh"
+      - "docs/operations/production-deploy-agent.md"
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact approved 40-character commit SHA on main
+        required: true
+        type: string
+      evidence_run_id:
+        description: Successful Release readiness run containing the release evidence
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: iron-house-os-production
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Production agent policy validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate production agent scripts
+        run: |
+          bash -n \
+            ops/digitalocean/install-production-runner.sh \
+            ops/digitalocean/production-deploy-wrapper.sh
+          if bash ops/digitalocean/production-deploy-wrapper.sh \
+            --release 0000000000000000000000000000000000000000 \
+            --evidence /missing/evidence.json; then
+            echo "Production wrapper accepted an unprivileged invalid request." >&2
+            exit 1
+          fi
+
+  deploy:
+    name: Approved production cutover
+    if: github.event_name == 'workflow_dispatch'
+    needs: validate
+    runs-on: [self-hosted, linux, ihos-production]
+    environment: production
+    timeout-minutes: 45
+    steps:
+      - name: Validate inputs
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          EVIDENCE_RUN_ID: ${{ inputs.evidence_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EVIDENCE_RUN_ID" =~ ^[0-9]+$ ]]
+          run_sha=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" --jq .head_sha)
+          run_result=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}" --jq .conclusion)
+          [[ "$run_sha" == "$RELEASE_SHA" ]]
+          [[ "$run_result" == "success" ]]
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_sha }}
+          clean: true
+          fetch-depth: 0
+
+      - name: Verify approved main release
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]
+          git fetch --quiet origin main
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
+          [[ -z "$(git status --porcelain)" ]]
+
+      - name: Download immutable release evidence
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          EVIDENCE_RUN_ID: ${{ inputs.evidence_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          rm -rf "$RUNNER_TEMP/release-evidence"
+          gh run download "$EVIDENCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "release-candidate-evidence-$RELEASE_SHA" \
+            --dir "$RUNNER_TEMP/release-evidence"
+          test -f "$RUNNER_TEMP/release-evidence/evidence.json"
+
+      - name: Execute restricted production cutover
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: >-
+          sudo /usr/local/sbin/ihos-production-deploy
+          --release "$RELEASE_SHA"
+          --evidence "$RUNNER_TEMP/release-evidence/evidence.json"
+
+      - name: Verify public production endpoints
+        run: |
+          curl --fail --silent --show-error https://os.ironhousecivil.com/ >/dev/null
+          curl --fail --silent --show-error https://os.ironhousecivil.com/health >/dev/null
+          curl --fail --silent --show-error https://os.ironhousecivil.com/readiness >/dev/null
+          echo "Production deployment and endpoint verification passed."

--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -1,0 +1,30 @@
+# Production deployment agent
+
+The production deployment agent removes routine command entry from the
+DigitalOcean web console.
+
+## Control boundary
+
+- The runner is registered only to `iron-house-os/iron-house-os`.
+- Production jobs require the `ihos-production` runner label.
+- The workflow accepts an exact 40-character release SHA and a successful
+  Release readiness run ID.
+- The deployment wrapper rejects the wrong host, repository, SHA, dirty
+  checkout, missing evidence, and commits not present on `origin/main`.
+- The runner account has passwordless sudo access only to the validated
+  production deployment wrapper.
+- The production workflow uses GitHub's `production` environment as the human
+  approval boundary.
+
+## One-time bootstrap
+
+Run the installer once on `iron-house-os-prod-1` from an approved `main`
+checkout:
+
+```bash
+sudo bash ops/digitalocean/install-production-runner.sh
+```
+
+After the service reports healthy, production releases are started through the
+manual `Production deploy` GitHub Actions workflow. Do not run arbitrary shell
+commands through the production runner.

--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -11,6 +11,8 @@ DigitalOcean web console.
   Release readiness run ID.
 - The deployment wrapper rejects the wrong host, repository, SHA, dirty
   checkout, missing evidence, and commits not present on `origin/main`.
+- The wrapper discovers and pins the running production Docker Compose project
+  name before cutover, preventing a parallel stack from being created.
 - The runner account has passwordless sudo access only to the validated
   production deployment wrapper.
 - The production workflow uses GitHub's `production` environment as the human

--- a/ops/digitalocean/install-production-runner.sh
+++ b/ops/digitalocean/install-production-runner.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository=iron-house-os/iron-house-os
+runner_user=ihos-runner
+runner_root=/opt/iron-house-os-actions-runner
+runner_name=iron-house-os-prod-1
+runner_label=ihos-production
+wrapper_source=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/production-deploy-wrapper.sh
+wrapper_target=/usr/local/sbin/ihos-production-deploy
+sudoers_target=/etc/sudoers.d/iron-house-os-production-runner
+
+if ((EUID != 0)); then
+  echo "Run this installer with sudo." >&2
+  exit 1
+fi
+if [[ "$(hostname)" != "$runner_name" ]]; then
+  echo "Refusing runner installation on unexpected host." >&2
+  exit 1
+fi
+if [[ ! -f /etc/iron-house-os/production.env || ! -f "$wrapper_source" ]]; then
+  echo "Production environment or deployment wrapper is missing." >&2
+  exit 1
+fi
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  echo "GitHub CLI must already be authenticated for $repository." >&2
+  exit 1
+fi
+
+install -o root -g root -m 0755 "$wrapper_source" "$wrapper_target"
+printf '%s\n' \
+  "$runner_user ALL=(root) NOPASSWD: $wrapper_target *" \
+  >"$sudoers_target"
+chmod 0440 "$sudoers_target"
+visudo -cf "$sudoers_target" >/dev/null
+
+if ! id "$runner_user" >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir "$runner_root" --shell /usr/sbin/nologin "$runner_user"
+fi
+install -d -o "$runner_user" -g "$runner_user" -m 0750 "$runner_root"
+
+if systemctl list-unit-files --type=service | grep -q '^actions.runner.iron-house-os-iron-house-os'; then
+  echo "Production deployment runner is already installed."
+  systemctl --no-pager --full status 'actions.runner.iron-house-os-iron-house-os*' || true
+  exit 0
+fi
+
+runner_version=$(gh api repos/actions/runner/releases/latest --jq '.tag_name | ltrimstr("v")')
+runner_arch=x64
+case "$(uname -m)" in
+  x86_64) runner_arch=x64 ;;
+  aarch64|arm64) runner_arch=arm64 ;;
+  *)
+    echo "Unsupported runner architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+archive="actions-runner-linux-${runner_arch}-${runner_version}.tar.gz"
+download_url="https://github.com/actions/runner/releases/download/v${runner_version}/${archive}"
+checksum_url="https://github.com/actions/runner/releases/download/v${runner_version}/sha256_checksums.txt"
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+curl -fsSL "$download_url" -o "$temp_dir/$archive"
+curl -fsSL "$checksum_url" -o "$temp_dir/sha256_checksums.txt"
+expected_checksum=$(awk -v archive="$archive" '$2 == archive {print $1}' "$temp_dir/sha256_checksums.txt")
+if [[ -z "$expected_checksum" ]]; then
+  echo "Runner checksum was not published for $archive." >&2
+  exit 1
+fi
+printf '%s  %s\n' "$expected_checksum" "$temp_dir/$archive" | sha256sum -c -
+
+tar -xzf "$temp_dir/$archive" -C "$runner_root"
+chown -R "$runner_user:$runner_user" "$runner_root"
+registration_token=$(gh api --method POST "repos/$repository/actions/runners/registration-token" --jq .token)
+
+sudo -u "$runner_user" "$runner_root/config.sh" \
+  --unattended \
+  --url "https://github.com/$repository" \
+  --token "$registration_token" \
+  --name "$runner_name" \
+  --labels "$runner_label" \
+  --work _work \
+  --replace
+
+"$runner_root/svc.sh" install "$runner_user"
+"$runner_root/svc.sh" start
+"$runner_root/svc.sh" status
+echo "Production deployment runner installed: $runner_name [$runner_label]"

--- a/ops/digitalocean/production-deploy-wrapper.sh
+++ b/ops/digitalocean/production-deploy-wrapper.sh
@@ -35,15 +35,19 @@ if [[ "$(hostname)" != "iron-house-os-prod-1" ]]; then
   exit 1
 fi
 
-workflow_root=$(git -C "$(pwd -P)" rev-parse --show-toplevel 2>/dev/null || true)
-if [[ -z "$workflow_root" ]]; then
+workflow_root=$(pwd -P)
+git_workflow() {
+  git -c "safe.directory=$workflow_root" -C "$workflow_root" "$@"
+}
+
+resolved_workflow_root=$(git_workflow rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$resolved_workflow_root" || "$(cd "$resolved_workflow_root" && pwd -P)" != "$workflow_root" ]]; then
   echo "Current directory is not an Iron House OS checkout." >&2
   exit 1
 fi
 
-workflow_root=$(cd "$workflow_root" && pwd -P)
 evidence_file=$(cd "$(dirname "$evidence_file")" && pwd -P)/$(basename "$evidence_file")
-remote_url=$(git -C "$workflow_root" remote get-url origin)
+remote_url=$(git_workflow remote get-url origin)
 
 case "$remote_url" in
   https://github.com/iron-house-os/iron-house-os|https://github.com/iron-house-os/iron-house-os.git|git@github.com:iron-house-os/iron-house-os.git)
@@ -54,17 +58,17 @@ case "$remote_url" in
     ;;
 esac
 
-if [[ "$(git -C "$workflow_root" rev-parse HEAD)" != "$release_sha" ]]; then
+if [[ "$(git_workflow rev-parse HEAD)" != "$release_sha" ]]; then
   echo "Checked-out release does not match the approved SHA." >&2
   exit 1
 fi
-if [[ -n "$(git -C "$workflow_root" status --porcelain)" ]]; then
+if [[ -n "$(git_workflow status --porcelain)" ]]; then
   echo "Refusing deployment from a dirty release checkout." >&2
   exit 1
 fi
 
-git -C "$workflow_root" fetch --quiet origin main
-if ! git -C "$workflow_root" merge-base --is-ancestor "$release_sha" origin/main; then
+git_workflow fetch --quiet origin main
+if ! git_workflow merge-base --is-ancestor "$release_sha" origin/main; then
   echo "Approved release is not present on origin/main." >&2
   exit 1
 fi
@@ -91,7 +95,7 @@ fi
 release_root="/opt/iron-house-os-releases/$release_sha"
 if [[ ! -d "$release_root/.git" ]]; then
   install -d -o root -g root -m 0750 "$(dirname "$release_root")"
-  git clone --quiet --no-checkout --no-local --no-hardlinks "$workflow_root" "$release_root"
+  git -c "safe.directory=$workflow_root" clone --quiet --no-checkout --no-local --no-hardlinks "$workflow_root" "$release_root"
   git -C "$release_root" remote set-url origin https://github.com/iron-house-os/iron-house-os.git
   git -C "$release_root" checkout --quiet --detach "$release_sha"
 fi

--- a/ops/digitalocean/production-deploy-wrapper.sh
+++ b/ops/digitalocean/production-deploy-wrapper.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_sha=
+evidence_file=
+
+usage() {
+  echo "Usage: ihos-production-deploy --release 40_HEX_SHA --evidence evidence.json" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --release)
+      release_sha=${2:-}
+      shift 2
+      ;;
+    --evidence)
+      evidence_file=${2:-}
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ((EUID != 0)) || [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]] || [[ ! -f "$evidence_file" ]]; then
+  usage
+  exit 2
+fi
+
+if [[ "$(hostname)" != "iron-house-os-prod-1" ]]; then
+  echo "Refusing production deployment on unexpected host." >&2
+  exit 1
+fi
+
+repo_root=$(git -C "$(pwd -P)" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$repo_root" || ! -f "$repo_root/ops/digitalocean/cutover.sh" ]]; then
+  echo "Current directory is not an Iron House OS checkout." >&2
+  exit 1
+fi
+
+repo_root=$(cd "$repo_root" && pwd -P)
+evidence_file=$(cd "$(dirname "$evidence_file")" && pwd -P)/$(basename "$evidence_file")
+remote_url=$(git -C "$repo_root" remote get-url origin)
+
+case "$remote_url" in
+  https://github.com/iron-house-os/iron-house-os|https://github.com/iron-house-os/iron-house-os.git|git@github.com:iron-house-os/iron-house-os.git)
+    ;;
+  *)
+    echo "Unexpected repository remote: $remote_url" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$(git -C "$repo_root" rev-parse HEAD)" != "$release_sha" ]]; then
+  echo "Checked-out release does not match the approved SHA." >&2
+  exit 1
+fi
+if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+  echo "Refusing deployment from a dirty release checkout." >&2
+  exit 1
+fi
+
+git -C "$repo_root" fetch --quiet origin main
+if ! git -C "$repo_root" merge-base --is-ancestor "$release_sha" origin/main; then
+  echo "Approved release is not present on origin/main." >&2
+  exit 1
+fi
+
+exec "$repo_root/ops/digitalocean/cutover.sh" \
+  --release "$release_sha" \
+  --evidence "$evidence_file" \
+  --confirm-go

--- a/ops/digitalocean/production-deploy-wrapper.sh
+++ b/ops/digitalocean/production-deploy-wrapper.sh
@@ -35,15 +35,15 @@ if [[ "$(hostname)" != "iron-house-os-prod-1" ]]; then
   exit 1
 fi
 
-repo_root=$(git -C "$(pwd -P)" rev-parse --show-toplevel 2>/dev/null || true)
-if [[ -z "$repo_root" || ! -f "$repo_root/ops/digitalocean/cutover.sh" ]]; then
+workflow_root=$(git -C "$(pwd -P)" rev-parse --show-toplevel 2>/dev/null || true)
+if [[ -z "$workflow_root" ]]; then
   echo "Current directory is not an Iron House OS checkout." >&2
   exit 1
 fi
 
-repo_root=$(cd "$repo_root" && pwd -P)
+workflow_root=$(cd "$workflow_root" && pwd -P)
 evidence_file=$(cd "$(dirname "$evidence_file")" && pwd -P)/$(basename "$evidence_file")
-remote_url=$(git -C "$repo_root" remote get-url origin)
+remote_url=$(git -C "$workflow_root" remote get-url origin)
 
 case "$remote_url" in
   https://github.com/iron-house-os/iron-house-os|https://github.com/iron-house-os/iron-house-os.git|git@github.com:iron-house-os/iron-house-os.git)
@@ -54,22 +54,60 @@ case "$remote_url" in
     ;;
 esac
 
-if [[ "$(git -C "$repo_root" rev-parse HEAD)" != "$release_sha" ]]; then
+if [[ "$(git -C "$workflow_root" rev-parse HEAD)" != "$release_sha" ]]; then
   echo "Checked-out release does not match the approved SHA." >&2
   exit 1
 fi
-if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+if [[ -n "$(git -C "$workflow_root" status --porcelain)" ]]; then
   echo "Refusing deployment from a dirty release checkout." >&2
   exit 1
 fi
 
-git -C "$repo_root" fetch --quiet origin main
-if ! git -C "$repo_root" merge-base --is-ancestor "$release_sha" origin/main; then
+git -C "$workflow_root" fetch --quiet origin main
+if ! git -C "$workflow_root" merge-base --is-ancestor "$release_sha" origin/main; then
   echo "Approved release is not present on origin/main." >&2
   exit 1
 fi
 
-exec "$repo_root/ops/digitalocean/cutover.sh" \
+production_container=
+production_project=
+while IFS= read -r container_id; do
+  config_files=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}' "$container_id")
+  if [[ "$config_files" == *docker-compose.production.yml* ]]; then
+    if [[ -n "$production_container" ]]; then
+      echo "Multiple running production frontend containers were found." >&2
+      exit 1
+    fi
+    production_container=$container_id
+    production_project=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$container_id")
+  fi
+done < <(docker ps --filter label=com.docker.compose.service=frontend --format '{{.ID}}')
+
+if [[ -z "$production_container" || -z "$production_project" ]]; then
+  echo "Running production Compose project could not be identified." >&2
+  exit 1
+fi
+
+release_root="/opt/iron-house-os-releases/$release_sha"
+if [[ ! -d "$release_root/.git" ]]; then
+  install -d -o root -g root -m 0750 "$(dirname "$release_root")"
+  git clone --quiet --no-checkout --no-local --no-hardlinks "$workflow_root" "$release_root"
+  git -C "$release_root" remote set-url origin https://github.com/iron-house-os/iron-house-os.git
+  git -C "$release_root" checkout --quiet --detach "$release_sha"
+fi
+
+if [[ "$(git -C "$release_root" rev-parse HEAD)" != "$release_sha" ]] || [[ -n "$(git -C "$release_root" status --porcelain)" ]]; then
+  echo "Immutable production release checkout is missing, dirty, or has the wrong SHA." >&2
+  exit 1
+fi
+if [[ ! -f "$release_root/ops/digitalocean/cutover.sh" ]]; then
+  echo "Approved release does not contain the guarded cutover script." >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME="$production_project"
+cd "$release_root"
+exec "$release_root/ops/digitalocean/cutover.sh" \
   --release "$release_sha" \
   --evidence "$evidence_file" \
   --confirm-go


### PR DESCRIPTION
## Objective
Remove routine copy/paste work from the DigitalOcean web console by installing a repository-scoped production deployment runner.

## Controls
- Manual workflow dispatch only
- Exact approved 40-character SHA on `main`
- Matching successful Release readiness run and immutable evidence artifact
- Dedicated `ihos-production` runner label
- Correct-host, correct-repository, clean-checkout, and release-identity checks
- Restricted sudo access only to the validated production deploy wrapper
- Existing guarded `cutover.sh` remains the only cutover implementation
- GitHub `production` environment remains the approval boundary

## Validation
- Local `bash -n` passed for both shell scripts
- Workflow YAML parsed and policy assertions passed
- PR validation job checks shell syntax and confirms invalid unprivileged deploy requests are rejected

## Rollout
No production changes are made by this PR. After CI and explicit merge approval, one short bootstrap command must be run once on `iron-house-os-prod-1`; subsequent approved deployments run through GitHub Actions.