### PR TITLE
Add label-driven GitHub issue intake

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -71,14 +71,16 @@ documented in [`docs/agent-platform.md`](../docs/agent-platform.md).
 ```bash
 iron-house-agent preflight
 iron-house-agent status
+iron-house-agent intake-once
 iron-house-agent smoke --project ihos --issue <issue-number>
 iron-house-agent enqueue --project ihos --role build --issue <issue-number> \
   --title "Approved task" --prompt-file /path/to/task.txt
 ```
 
 The default service runs four workers concurrently. SQLite provides atomic job claiming, and every
-job is prepared in a separate worktree before Codex starts. The dashboard listens only on
-`127.0.0.1:8787` and has no mutation routes.
+job is prepared in a separate worktree before Codex starts. Open GitHub issues labelled
+`agent:ready` plus exactly one supported `agent:<role>` label are ingested once per issue revision.
+The dashboard listens only on `127.0.0.1:8787` and has no mutation routes.
 
 ## Branch naming
 

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -8,7 +8,7 @@ Run reusable development agents for Iron House OS, Dumper, and future Iron House
 
 - Owner: Iron House development operations
 - Priority: High
-- Status: Ready for build-workspace installation after review
+- Status: Active on the shared non-production build workspace
 - Approval gate: Jeremie Peters must explicitly approve any production deployment; the agent platform cannot grant that approval
 - System of record: `ops/agent/projects.json`, the SQLite job database, GitHub issues, and draft pull requests
 - Production systems: out of scope
@@ -22,7 +22,8 @@ Run reusable development agents for Iron House OS, Dumper, and future Iron House
 | Logs | One private JSONL log per Codex job | `/var/lib/iron-house-agent/logs/` |
 | Worktrees | One isolated feature branch checkout per job | `/srv/iron-house-agents/worktrees/` |
 | Dashboard | Read-only queue, worker, history, and repository health | `http://127.0.0.1:8787` |
-| Service | Four concurrent worker loops plus dashboard | `iron-house-agent.service` |
+| GitHub intake | Explicitly labelled issue discovery and duplicate suppression | `iron-house-agent.service` |
+| Service | Four concurrent worker loops, issue intake, and dashboard | `iron-house-agent.service` |
 
 The dashboard binds to loopback and exposes no write endpoint. Access it remotely through an SSH tunnel rather than a public listener.
 
@@ -94,6 +95,33 @@ Supported roles:
 
 Standard jobs instruct Codex to work only on the generated feature branch, run relevant checks, commit and push the scoped change, and open a draft pull request. The agent is explicitly prohibited from merging or deploying production.
 
+## Queue work from GitHub
+
+The service polls registered repositories every 30 seconds without opening a public webhook. To approve an issue for intake, keep the issue open and apply:
+
+1. `agent:ready`
+2. exactly one role label:
+   - `agent:build`
+   - `agent:ci-repair`
+   - `agent:code-review`
+   - `agent:qa-browser`
+   - `agent:security-audit`
+   - `agent:dependency-update`
+   - `agent:documentation`
+   - `agent:issue-planning`
+
+The issue title becomes the job title and the body becomes the task prompt. Adding `agent:ready` authorizes feature-branch work only; it never authorizes merge, production deployment, payment, invitation, or owner-only actions.
+
+Each repository, issue number, and GitHub update revision is accepted at most once. Removing `agent:ready` stops new intake. To queue a corrected revision after a blocked or completed run, edit the issue and retain the required labels. The new GitHub update timestamp creates one new intake revision.
+
+Run one immediate check without waiting for the service interval:
+
+```bash
+sudo -u ih-agent -H iron-house-agent intake-once
+```
+
+Ambiguous roles, missing repository policy, secret-like issue text, prohibited production actions, and GitHub authentication failures are recorded as blocked. Issue bodies and job prompts never appear in dashboard JSON.
+
 ## Register a future project
 
 Before enrollment, the GitHub repository must contain an `AGENTS.md` file declaring its build/test commands, protected environments, forbidden actions, approval gates, staging instructions, and priorities.
@@ -130,6 +158,7 @@ Then open `http://127.0.0.1:8787`. The dashboard shows:
 - queued work;
 - completed and failed build history;
 - clean, dirty, blocked, missing, or unhealthy repository checkouts.
+- GitHub intake source health, accepted revisions, and blocked reasons.
 
 ## Recovery and controls
 
@@ -158,6 +187,9 @@ Key controls:
 | --- | --- | --- |
 | Codex or GitHub login expires | Workers report `blocked`; queued jobs remain queued | Re-authenticate as `ih-agent`, run `preflight`, restart service |
 | Repository lacks `AGENTS.md` | Job or registration fails closed | Add and review the project policy before retrying |
+| GitHub intake is blocked | No issue is enqueued from the affected repository | Review the dashboard reason, repair authentication or labels, then edit the issue to create a new revision |
+| Issue has no role or multiple roles | The issue revision is retained as `blocked` | Apply exactly one supported role label and edit the issue before retrying |
+| Issue contains secret-like or prohibited production text | The issue revision is retained as `blocked` | Remove the sensitive or prohibited instruction; use saved credentials and the separate owner-approved production workflow |
 | Worker task fails | Job is retained as `failed` with branch and log path | Inspect evidence and queue a narrow follow-up issue-linked job |
 | Checkout is dirty | Dashboard reports `dirty` | Review ownership of the changes; do not discard them automatically |
 | Dashboard unavailable | Workers may continue; health endpoint fails | Check service status and journal; dashboard has no job-control authority |

--- a/ops/agent/iron_house_agent/cli.py
+++ b/ops/agent/iron_house_agent/cli.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from .config import Project, load_settings, register_project
 from .dashboard import build_state, create_dashboard_server, start_dashboard_thread
+from .intake import GitHubIssueIntake, IssueIntakePoller
 from .runtime import AgentRuntime, WorkerPool, supported_roles
 from .store import JobStore
 
@@ -29,6 +30,7 @@ def _parser() -> argparse.ArgumentParser:
     subparsers.add_parser("run-once", help="Run the next queued job").add_argument(
         "--worker-id", default="manual-worker"
     )
+    subparsers.add_parser("intake-once", help="Poll explicitly labelled GitHub issues once")
 
     enqueue = subparsers.add_parser("enqueue", help="Add an issue-linked job to the queue")
     enqueue.add_argument("--project", required=True)
@@ -115,6 +117,10 @@ def main(argv: list[str] | None = None) -> int:
                 else {k: v for k, v in job.items() if k != "prompt"}
             )
             return 0 if job is None or job["status"] == "succeeded" else 1
+        if arguments.command == "intake-once":
+            summary = GitHubIssueIntake(runtime.settings, runtime.store).poll_once()
+            _print(summary)
+            return 0 if summary["sources_blocked"] == 0 else 1
         if arguments.command == "smoke":
             runtime.preflight()
             queued = runtime.enqueue_smoke_test(arguments.project, arguments.issue)
@@ -144,7 +150,9 @@ def main(argv: list[str] | None = None) -> int:
             workers = arguments.workers or runtime.settings.max_parallel_jobs
             server, dashboard_thread = start_dashboard_thread(runtime.settings, runtime.store)
             pool = WorkerPool(runtime, workers)
+            intake_poller = IssueIntakePoller(GitHubIssueIntake(runtime.settings, runtime.store))
             pool.start()
+            intake_poller.start()
             print(
                 f"Workers: {workers}; dashboard: http://{runtime.settings.dashboard_host}:"
                 f"{runtime.settings.dashboard_port}"
@@ -152,6 +160,7 @@ def main(argv: list[str] | None = None) -> int:
             try:
                 pool.wait()
             finally:
+                intake_poller.stop()
                 pool.stop()
                 server.shutdown()
                 dashboard_thread.join(timeout=5)

--- a/ops/agent/iron_house_agent/dashboard.py
+++ b/ops/agent/iron_house_agent/dashboard.py
@@ -54,7 +54,7 @@ _DASHBOARD_HTML = """<!doctype html>
     tr:last-child td { border-bottom:0; }
     .pill { display:inline-flex; border:1px solid var(--line); border-radius:999px;
       padding:3px 8px; font-size:11px; font-weight:700; text-transform:uppercase; }
-    .succeeded,.healthy,.running { color:var(--green); }
+    .succeeded,.healthy,.running,.accepted,.ready { color:var(--green); }
     .failed,.error,.blocked,.missing { color:var(--red); }
     .queued,.dirty { color:var(--gold); }
     .role-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; }
@@ -92,6 +92,7 @@ _DASHBOARD_HTML = """<!doctype html>
     <aside>
       <div class="panel"><h2>Agent roles</h2><div class="panel-body role-grid" id="roles"></div></div>
       <div class="panel"><h2>Repository health</h2><div class="panel-body" id="repos"></div></div>
+      <div class="panel"><h2>GitHub intake</h2><div class="panel-body" id="intake"></div></div>
     </aside>
   </section>
 </main>
@@ -105,6 +106,18 @@ function jobsTable(rows) {
     <tbody>${rows.map(job => `<tr><td><strong>${esc(job.title)}</strong><br><code>${shortId(job.id)} · #${esc(job.issue_number)}</code></td>
     <td>${esc(job.project_key)}</td><td>${esc(job.role)}</td><td><span class="pill ${esc(job.status)}">${esc(job.status)}</span></td>
     <td><code>${esc(job.branch || 'pending')}</code></td></tr>`).join('')}</tbody></table>`;
+}
+function intakePanel(state) {
+  const sources = state.intake_sources || [];
+  const history = state.intake_history || [];
+  const sourceRows = sources.map(source => `<div class="repo"><div class="repo-head">
+    <strong>${esc(source.project_key)}</strong><span class="pill ${esc(source.state)}">${esc(source.state)}</span></div>
+    <div class="muted">${esc(source.detail)}</div></div>`).join('');
+  const historyRows = history.slice(0, 8).map(item => `<div class="repo"><div class="repo-head">
+    <strong>${esc(item.project_key)} #${esc(item.issue_number)}</strong>
+    <span class="pill ${esc(item.status)}">${esc(item.status)}</span></div>
+    <div class="muted">${esc(item.role || 'no role')} · ${esc(item.detail)}</div></div>`).join('');
+  return sourceRows + historyRows || '<div class="empty">Waiting for first intake check</div>';
 }
 function render(state) {
   document.getElementById('active').textContent = state.current_jobs.length;
@@ -120,6 +133,7 @@ function render(state) {
     `<div class="repo"><div class="repo-head"><strong>${esc(repo.name)}</strong>
     <span class="pill ${esc(repo.status)}">${esc(repo.status)}</span></div>
     <div class="muted">${esc(repo.detail)}</div><code>${esc(repo.branch || '—')} · ${esc(repo.commit || '—')}</code></div>`).join('');
+  document.getElementById('intake').innerHTML = intakePanel(state);
   document.getElementById('updated').textContent = `Updated ${new Date(state.generated_at).toLocaleString()}`;
 }
 async function refresh() {

--- a/ops/agent/iron_house_agent/intake.py
+++ b/ops/agent/iron_house_agent/intake.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from .config import AgentSettings, Project
+from .store import AGENT_ROLES, JobStore, reject_embedded_secrets
+
+IssueSource = Callable[[Project], list[dict[str, Any]]]
+READY_LABEL = "agent:ready"
+ROLE_LABELS = {f"agent:{role}": role for role in AGENT_ROLES}
+_UNSAFE_ACTION_PATTERNS = (
+    re.compile(
+        r"\b(?:deploy|release|push)\b.{0,60}\b(?:to|into|on)\s+(?:live|production)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:modify|delete|reset|migrate|rotate)\b.{0,60}\b(?:production|live)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:bypass|disable|remove|weaken)\b.{0,60}\b(?:approval|payment|owner|launch|production|safety)\s+gate\b",
+        re.IGNORECASE,
+    ),
+)
+_SAFE_ENVIRONMENT_KEYS = {
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "TERM",
+    "TMPDIR",
+    "USER",
+    "XDG_CONFIG_HOME",
+}
+
+
+def reject_unsafe_issue_text(value: str) -> None:
+    reject_embedded_secrets(value)
+    if any(pattern.search(value) for pattern in _UNSAFE_ACTION_PATTERNS):
+        raise ValueError("Issue requests a prohibited production or approval-gate action")
+
+
+def safe_error_detail(error: Exception) -> str:
+    detail = f"{type(error).__name__}: {error}"
+    try:
+        reject_embedded_secrets(detail)
+    except ValueError:
+        return "GitHub intake failed; sensitive detail redacted"
+    return detail
+
+
+class GitHubIssueIntake:
+    def __init__(
+        self,
+        settings: AgentSettings,
+        store: JobStore,
+        source: IssueSource | None = None,
+    ):
+        self.settings = settings
+        self.store = store
+        self.source = source or self._list_issues
+
+    def poll_once(self) -> dict[str, Any]:
+        summary = {"accepted": 0, "blocked": 0, "duplicates": 0, "sources_blocked": 0}
+        for project in self.settings.projects:
+            try:
+                issues = self.source(project)
+                for issue in issues:
+                    result = self._process_issue(project, issue)
+                    if result["duplicate"]:
+                        summary["duplicates"] += 1
+                    elif result["status"] == "accepted":
+                        summary["accepted"] += 1
+                    else:
+                        summary["blocked"] += 1
+                self.store.update_intake_source(
+                    project.key, "ready", f"Checked {len(issues)} explicitly labelled issue(s)"
+                )
+            except Exception as error:  # noqa: BLE001 - fail one repository closed, keep polling others
+                summary["sources_blocked"] += 1
+                self.store.update_intake_source(project.key, "blocked", safe_error_detail(error))
+        return summary
+
+    def _process_issue(self, project: Project, issue: dict[str, Any]) -> dict[str, Any]:
+        number = int(issue.get("number", 0))
+        title = str(issue.get("title", "")).strip()
+        body = str(issue.get("body") or "").strip()
+        revision = str(issue.get("updatedAt") or "missing-updated-at").strip()
+        labels = self._label_names(issue.get("labels", []))
+        role_matches = [ROLE_LABELS[label] for label in labels if label in ROLE_LABELS]
+        role = role_matches[0] if len(role_matches) == 1 else None
+        block_reason = None
+
+        if READY_LABEL not in labels:
+            block_reason = f"Missing required label: {READY_LABEL}"
+        elif len(role_matches) != 1:
+            block_reason = "Issue must have exactly one supported agent role label"
+        elif not (self.settings.workspace / project.directory / "AGENTS.md").is_file():
+            block_reason = "Registered project checkout is missing AGENTS.md"
+        else:
+            try:
+                reject_unsafe_issue_text(f"{title}\n{body}")
+            except ValueError as error:
+                block_reason = str(error)
+
+        try:
+            return self.store.record_issue_intake(
+                source="github-label-poller",
+                project_key=project.key,
+                repository=project.repository,
+                issue_number=number,
+                revision=revision,
+                title=title,
+                prompt=body,
+                role=role,
+                block_reason=block_reason,
+            )
+        except ValueError as error:
+            return self.store.record_issue_intake(
+                source="github-label-poller",
+                project_key=project.key,
+                repository=project.repository,
+                issue_number=number,
+                revision=revision,
+                title=title or f"Blocked GitHub issue #{number}",
+                prompt=body,
+                role=role,
+                block_reason=str(error),
+            )
+
+    @staticmethod
+    def _label_names(labels: object) -> set[str]:
+        if not isinstance(labels, list):
+            return set()
+        names = set()
+        for label in labels:
+            if isinstance(label, str):
+                names.add(label)
+            elif isinstance(label, dict) and isinstance(label.get("name"), str):
+                names.add(label["name"])
+        return names
+
+    @staticmethod
+    def _safe_environment() -> dict[str, str]:
+        environment = {
+            key: value for key, value in os.environ.items() if key in _SAFE_ENVIRONMENT_KEYS
+        }
+        environment.setdefault("PATH", "/usr/local/bin:/usr/bin:/bin")
+        environment.setdefault("LANG", "C.UTF-8")
+        return environment
+
+    def _list_issues(self, project: Project) -> list[dict[str, Any]]:
+        completed = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                project.repository,
+                "--state",
+                "open",
+                "--label",
+                READY_LABEL,
+                "--limit",
+                "100",
+                "--json",
+                "number,title,body,updatedAt,labels",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=self._safe_environment(),
+        )
+        payload = json.loads(completed.stdout)
+        if not isinstance(payload, list):
+            raise TypeError("GitHub issue list returned an unexpected payload")
+        return payload
+
+
+class IssueIntakePoller:
+    def __init__(self, intake: GitHubIssueIntake, interval_seconds: float = 30):
+        if interval_seconds <= 0:
+            raise ValueError("Issue intake interval must be positive")
+        self.intake = intake
+        self.interval_seconds = interval_seconds
+        self.stop_event = threading.Event()
+        self.thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.thread = threading.Thread(target=self._loop, name="github-intake", daemon=True)
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join(timeout=5)
+
+    def _loop(self) -> None:
+        while not self.stop_event.is_set():
+            self.intake.poll_once()
+            self.stop_event.wait(self.interval_seconds)

--- a/ops/agent/iron_house_agent/store.py
+++ b/ops/agent/iron_house_agent/store.py
@@ -88,19 +88,34 @@ class JobStore:
                     created_at TEXT NOT NULL,
                     FOREIGN KEY(job_id) REFERENCES jobs(id)
                 );
+                CREATE TABLE IF NOT EXISTS intake_sources (
+                    project_key TEXT PRIMARY KEY,
+                    state TEXT NOT NULL CHECK (state IN ('ready', 'blocked')),
+                    detail TEXT NOT NULL,
+                    checked_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS issue_intake (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source TEXT NOT NULL,
+                    project_key TEXT NOT NULL,
+                    repository TEXT NOT NULL,
+                    issue_number INTEGER NOT NULL CHECK (issue_number > 0),
+                    revision TEXT NOT NULL,
+                    role TEXT,
+                    status TEXT NOT NULL CHECK (status IN ('accepted', 'blocked')),
+                    detail TEXT NOT NULL,
+                    job_id TEXT,
+                    discovered_at TEXT NOT NULL,
+                    UNIQUE(source, repository, issue_number, revision),
+                    FOREIGN KEY(job_id) REFERENCES jobs(id)
+                );
+                CREATE INDEX IF NOT EXISTS issue_intake_recent_idx
+                    ON issue_intake(discovered_at DESC);
                 """
             )
 
-    def enqueue(
-        self,
-        *,
-        project_key: str,
-        role: str,
-        issue_number: int,
-        title: str,
-        prompt: str,
-        mode: str = "standard",
-    ) -> dict[str, Any]:
+    @staticmethod
+    def _validate_job(*, role: str, issue_number: int, title: str, prompt: str, mode: str) -> None:
         if role not in AGENT_ROLES:
             raise ValueError(f"Unsupported agent role: {role}")
         if issue_number <= 0:
@@ -113,6 +128,24 @@ class JobStore:
             raise ValueError(f"Unsupported job mode: {mode}")
         reject_embedded_secrets(title)
         reject_embedded_secrets(prompt)
+
+    def enqueue(
+        self,
+        *,
+        project_key: str,
+        role: str,
+        issue_number: int,
+        title: str,
+        prompt: str,
+        mode: str = "standard",
+    ) -> dict[str, Any]:
+        self._validate_job(
+            role=role,
+            issue_number=issue_number,
+            title=title,
+            prompt=prompt,
+            mode=mode,
+        )
         job_id = str(uuid.uuid4())
         queued_at = utc_now()
         with self.connect() as connection:
@@ -135,6 +168,111 @@ class JobStore:
             )
             self._event(connection, job_id, "queued", f"role={role}")
         return self.get_job(job_id)
+
+    def record_issue_intake(
+        self,
+        *,
+        source: str,
+        project_key: str,
+        repository: str,
+        issue_number: int,
+        revision: str,
+        title: str,
+        prompt: str,
+        role: str | None,
+        block_reason: str | None = None,
+    ) -> dict[str, Any]:
+        if not source.strip() or not repository.strip() or not revision.strip():
+            raise ValueError("Issue intake source, repository, and revision are required")
+        if issue_number <= 0:
+            raise ValueError("Issue intake requires a positive issue number")
+        if block_reason is None:
+            if role is None:
+                raise ValueError("Accepted issue intake requires an agent role")
+            self._validate_job(
+                role=role,
+                issue_number=issue_number,
+                title=title,
+                prompt=prompt,
+                mode="standard",
+            )
+        discovered_at = utc_now()
+        with self.connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            existing = connection.execute(
+                """
+                SELECT * FROM issue_intake
+                WHERE source = ? AND repository = ? AND issue_number = ? AND revision = ?
+                """,
+                (source, repository, issue_number, revision),
+            ).fetchone()
+            if existing is not None:
+                connection.execute("COMMIT")
+                return {**dict(existing), "duplicate": True}
+
+            job_id = None
+            status = "blocked" if block_reason else "accepted"
+            detail = (block_reason or "Queued from explicitly labelled GitHub issue")[:1000]
+            if block_reason is None:
+                job_id = str(uuid.uuid4())
+                connection.execute(
+                    """
+                    INSERT INTO jobs (
+                        id, project_key, role, issue_number, title, prompt, mode, status, queued_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, 'standard', 'queued', ?)
+                    """,
+                    (
+                        job_id,
+                        project_key,
+                        role,
+                        issue_number,
+                        title.strip(),
+                        prompt.strip(),
+                        discovered_at,
+                    ),
+                )
+                self._event(connection, job_id, "queued", f"role={role}; source=github-intake")
+            cursor = connection.execute(
+                """
+                INSERT INTO issue_intake (
+                    source, project_key, repository, issue_number, revision, role,
+                    status, detail, job_id, discovered_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    source,
+                    project_key,
+                    repository,
+                    issue_number,
+                    revision,
+                    role,
+                    status,
+                    detail,
+                    job_id,
+                    discovered_at,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM issue_intake WHERE id = ?", (cursor.lastrowid,)
+            ).fetchone()
+            connection.execute("COMMIT")
+        return {**dict(row), "duplicate": False}
+
+    def update_intake_source(self, project_key: str, state: str, detail: str) -> None:
+        if state not in {"ready", "blocked"}:
+            raise ValueError(f"Unsupported intake source state: {state}")
+        with self.connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO intake_sources (project_key, state, detail, checked_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(project_key) DO UPDATE SET
+                    state = excluded.state,
+                    detail = excluded.detail,
+                    checked_at = excluded.checked_at
+                """,
+                (project_key, state, detail[:1000], utc_now()),
+            )
 
     def claim_next(self, worker_id: str) -> dict[str, Any] | None:
         now = utc_now()
@@ -245,11 +383,30 @@ class JobStore:
                 dict(row)
                 for row in connection.execute("SELECT * FROM workers ORDER BY id").fetchall()
             ]
+            intake_sources = [
+                dict(row)
+                for row in connection.execute(
+                    "SELECT * FROM intake_sources ORDER BY project_key"
+                ).fetchall()
+            ]
+            intake_history = [
+                dict(row)
+                for row in connection.execute(
+                    """
+                    SELECT project_key, repository, issue_number, revision, role, status,
+                           detail, job_id, discovered_at
+                    FROM issue_intake ORDER BY discovered_at DESC, id DESC LIMIT ?
+                    """,
+                    (history_limit,),
+                ).fetchall()
+            ]
         return {
             "workers": workers,
             "current_jobs": running,
             "queue": queued,
             "history": history,
+            "intake_sources": intake_sources,
+            "intake_history": intake_history,
         }
 
     @staticmethod

--- a/tests/agent/test_dashboard.py
+++ b/tests/agent/test_dashboard.py
@@ -40,6 +40,8 @@ def test_dashboard_is_read_only_and_does_not_expose_prompts(settings) -> None:
             payload = json.load(response)
         assert payload["production_locked"] is True
         assert "prompt" not in payload["queue"][0]
+        assert payload["intake_sources"] == []
+        assert payload["intake_history"] == []
 
         request = urllib.request.Request(f"{base_url}/api/state", method="POST")
         try:

--- a/tests/agent/test_intake.py
+++ b/tests/agent/test_intake.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import subprocess
+
+from ops.agent.iron_house_agent.intake import GitHubIssueIntake
+from ops.agent.iron_house_agent.store import JobStore
+from tests.agent.conftest import create_test_repository
+
+
+def issue(
+    *,
+    labels: list[str],
+    body: str = "Update the approved documentation and open a draft pull request.",
+    updated_at: str = "2026-07-31T12:00:00Z",
+) -> dict:
+    return {
+        "number": 109,
+        "title": "Document the GitHub issue intake workflow",
+        "body": body,
+        "updatedAt": updated_at,
+        "labels": [{"name": label} for label in labels],
+    }
+
+
+def test_explicitly_labelled_issue_is_enqueued_once(settings) -> None:
+    create_test_repository(settings)
+    store = JobStore(settings.database_path)
+    store.initialize()
+    payload = issue(labels=["agent:ready", "agent:documentation"])
+    intake = GitHubIssueIntake(settings, store, source=lambda project: [payload])
+
+    first = intake.poll_once()
+    second = intake.poll_once()
+    snapshot = store.snapshot()
+
+    assert first == {"accepted": 1, "blocked": 0, "duplicates": 0, "sources_blocked": 0}
+    assert second == {"accepted": 0, "blocked": 0, "duplicates": 1, "sources_blocked": 0}
+    assert len(snapshot["queue"]) == 1
+    assert snapshot["queue"][0]["role"] == "documentation"
+    assert snapshot["intake_history"][0]["status"] == "accepted"
+    assert "prompt" not in snapshot["intake_history"][0]
+
+
+def test_ambiguous_or_unsupported_role_labels_are_blocked(settings) -> None:
+    create_test_repository(settings)
+    store = JobStore(settings.database_path)
+    store.initialize()
+    ambiguous = issue(labels=["agent:ready", "agent:build", "agent:documentation"])
+    unsupported = {
+        **issue(
+            labels=["agent:ready", "agent:unknown"],
+            updated_at="2026-07-31T12:01:00Z",
+        ),
+        "number": 110,
+    }
+    intake = GitHubIssueIntake(settings, store, source=lambda project: [ambiguous, unsupported])
+
+    summary = intake.poll_once()
+    snapshot = store.snapshot()
+
+    assert summary["blocked"] == 2
+    assert snapshot["queue"] == []
+    assert all("exactly one" in item["detail"] for item in snapshot["intake_history"])
+
+
+def test_secret_and_production_requests_are_blocked(settings) -> None:
+    create_test_repository(settings)
+    store = JobStore(settings.database_path)
+    store.initialize()
+    candidates = [
+        issue(
+            labels=["agent:ready", "agent:build"],
+            body="Use OPENAI_API_KEY=secret-value to complete this task.",
+        ),
+        {
+            **issue(
+                labels=["agent:ready", "agent:build"],
+                body="Deploy these changes to production now.",
+                updated_at="2026-07-31T12:01:00Z",
+            ),
+            "number": 110,
+        },
+    ]
+    intake = GitHubIssueIntake(settings, store, source=lambda project: candidates)
+
+    summary = intake.poll_once()
+    snapshot = store.snapshot()
+
+    assert summary["blocked"] == 2
+    assert snapshot["queue"] == []
+    assert {item["status"] for item in snapshot["intake_history"]} == {"blocked"}
+    assert any("secret" in item["detail"] for item in snapshot["intake_history"])
+    assert any("production" in item["detail"] for item in snapshot["intake_history"])
+
+
+def test_github_failure_blocks_source_without_enqueuing(settings) -> None:
+    store = JobStore(settings.database_path)
+    store.initialize()
+
+    def unavailable(project):
+        raise RuntimeError("GitHub authentication unavailable")
+
+    summary = GitHubIssueIntake(settings, store, source=unavailable).poll_once()
+    snapshot = store.snapshot()
+
+    assert summary["sources_blocked"] == 1
+    assert snapshot["queue"] == []
+    assert snapshot["intake_sources"][0]["state"] == "blocked"
+    assert "authentication unavailable" in snapshot["intake_sources"][0]["detail"]
+
+
+def test_github_source_uses_exact_ready_label_and_saved_auth(monkeypatch, settings) -> None:
+    observed = {}
+
+    def fake_run(command, **kwargs):
+        observed["command"] = command
+        observed["environment"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0, stdout="[]", stderr="")
+
+    monkeypatch.setenv("GH_TOKEN", "must-not-be-inherited")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    store = JobStore(settings.database_path)
+    store.initialize()
+    intake = GitHubIssueIntake(settings, store)
+
+    assert intake._list_issues(settings.project("test-project")) == []
+    assert observed["command"][0:3] == ["gh", "issue", "list"]
+    label_index = observed["command"].index("--label")
+    assert observed["command"][label_index + 1] == "agent:ready"
+    assert "GH_TOKEN" not in observed["environment"]


### PR DESCRIPTION
Addresses #109.

## Summary
- poll registered repositories for open issues carrying the exact `agent:ready` label
- require exactly one supported `agent:<role>` label before queueing
- record accepted, blocked, and duplicate revisions atomically
- show intake health and blocked reasons on the loopback-only dashboard
- keep prompts out of dashboard snapshots and preserve secret, production, owner, worktree, and `AGENTS.md` gates
- use saved GitHub CLI authentication with no inbound listener or public webhook

## Validation
- `18 passed` (`tests/agent`)
- Ruff lint passed
- Ruff formatting passed
- Python compileall passed
- shell syntax checks passed
- systemd unit verification passed
- `git diff --check` passed

## Safety and rollout
This is a draft feature-branch PR. It does not deploy or modify production. Merging and restarting the non-production build service require owner approval.