### PR TITLE
Add zero-touch agent project registration

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -72,6 +72,8 @@ documented in [`docs/agent-platform.md`](../docs/agent-platform.md).
 iron-house-agent preflight
 iron-house-agent status
 iron-house-agent intake-once
+sudo iron-house-agent-register --dry-run --key future-project --name "Future Project" \
+  --repository iron-house-os/future-project --directory future-project
 iron-house-agent smoke --project ihos --issue <issue-number>
 iron-house-agent enqueue --project ihos --role build --issue <issue-number> \
   --title "Approved task" --prompt-file /path/to/task.txt

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -126,8 +126,10 @@ Ambiguous roles, missing repository policy, secret-like issue text, prohibited p
 
 Before enrollment, the GitHub repository must contain an `AGENTS.md` file declaring its build/test commands, protected environments, forbidden actions, approval gates, staging instructions, and priorities.
 
+Preview every validation without cloning, editing the registry, creating labels, or restarting the service:
+
 ```bash
-sudo -u ih-agent -H iron-house-agent register \
+sudo iron-house-agent-register --dry-run \
   --key future-project \
   --name "Future Project" \
   --repository iron-house-os/future-project \
@@ -135,13 +137,24 @@ sudo -u ih-agent -H iron-house-agent register \
   --default-branch main
 ```
 
-Registration clones the repository into the existing shared workspace, verifies `AGENTS.md`, and atomically adds it to the runtime registry. Re-running the exact same registration is safe. Production deployment is always recorded as disabled. The tracked `ops/agent/projects.json` file is an installation seed; runtime registration never dirties the central repository checkout.
-
-Restart the service after a successful registration so every worker loads the new registry:
+Run the same command without `--dry-run` to enroll and activate the project:
 
 ```bash
-sudo systemctl restart iron-house-agent.service
+sudo iron-house-agent-register \
+  --key future-project \
+  --name "Future Project" \
+  --repository iron-house-os/future-project \
+  --directory future-project \
+  --default-branch main
 ```
+
+The single registration command verifies saved GitHub access, repository identity, default branch,
+and the remote `AGENTS.md` before mutation. It clones through GitHub CLI, verifies the checkout
+origin, creates the standard intake labels, atomically updates the private runtime registry, marks
+intake health ready, restarts the non-production service, and checks the loopback health endpoint.
+Re-running the exact registration is safe. Production deployment is always disabled. The tracked
+`ops/agent/projects.json` remains an installation seed; runtime registration never dirties the
+central repository checkout.
 
 ## Dashboard access
 

--- a/ops/agent/install.sh
+++ b/ops/agent/install.sh
@@ -38,6 +38,8 @@ if [ ! -f "${RUNTIME_REGISTRY}" ]; then
     "${AGENT_REPOSITORY}/ops/agent/projects.json" "${RUNTIME_REGISTRY}"
 fi
 install -m 0755 "${AGENT_REPOSITORY}/ops/agent/iron-house-agent" /usr/local/bin/iron-house-agent
+install -m 0755 "${AGENT_REPOSITORY}/ops/agent/iron-house-agent-register" \
+  /usr/local/bin/iron-house-agent-register
 install -m 0644 "${AGENT_REPOSITORY}/ops/agent/iron-house-agent.service" \
   /etc/systemd/system/iron-house-agent.service
 
@@ -46,7 +48,8 @@ systemctl daemon-reload
 
 if [ "${START_SERVICE}" = "true" ]; then
   sudo -u "${AGENT_USER}" /usr/local/bin/iron-house-agent preflight
-  systemctl enable --now iron-house-agent.service
+  systemctl enable iron-house-agent.service
+  systemctl restart iron-house-agent.service
   systemctl --no-pager --full status iron-house-agent.service
 else
   echo "Installed but not started. Authenticate Codex for ih-agent, run preflight, then:"

--- a/ops/agent/iron-house-agent-register
+++ b/ops/agent/iron-house-agent-register
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${EUID}" -ne 0 ]; then
+  echo "Run as root: sudo iron-house-agent-register [registration options]" >&2
+  exit 1
+fi
+
+DRY_RUN="false"
+PROJECT_KEY=""
+ARGUMENTS=("$@")
+for ((index = 0; index < ${#ARGUMENTS[@]}; index++)); do
+  argument="${ARGUMENTS[index]}"
+  if [ "${argument}" = "--dry-run" ]; then
+    DRY_RUN="true"
+  elif [ "${argument}" = "--key" ] && [ $((index + 1)) -lt ${#ARGUMENTS[@]} ]; then
+    PROJECT_KEY="${ARGUMENTS[index + 1]}"
+  elif [[ "${argument}" == --key=* ]]; then
+    PROJECT_KEY="${argument#--key=}"
+  fi
+done
+
+sudo -u ih-agent -H /usr/local/bin/iron-house-agent register "$@"
+
+if [ "${DRY_RUN}" = "false" ]; then
+  systemctl restart iron-house-agent.service
+  systemctl is-active --quiet iron-house-agent.service
+  STATE=""
+  for _attempt in $(seq 1 20); do
+    if STATE="$(curl --fail --silent http://127.0.0.1:8787/api/state 2>/dev/null)"; then
+      break
+    fi
+    sleep 0.25
+  done
+  if [ -z "${STATE}" ]; then
+    echo "Agent dashboard did not become healthy after registration" >&2
+    exit 1
+  fi
+  jq -e --arg key "${PROJECT_KEY}" '
+    any(.repositories[]; .key == $key) and
+    any(.intake_sources[]; .project_key == $key and .state == "ready") and
+    .production_locked == true
+  ' <<<"${STATE}" >/dev/null
+  jq -cn --arg project "${PROJECT_KEY}" \
+    '{status:"active", project:$project, intake:"ready", production_locked:true}'
+fi

--- a/ops/agent/iron_house_agent/cli.py
+++ b/ops/agent/iron_house_agent/cli.py
@@ -7,9 +7,10 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
-from .config import Project, load_settings, register_project
+from .config import Project, load_settings
 from .dashboard import build_state, create_dashboard_server, start_dashboard_thread
 from .intake import GitHubIssueIntake, IssueIntakePoller
+from .registration import ProjectRegistrar
 from .runtime import AgentRuntime, WorkerPool, supported_roles
 from .store import JobStore
 
@@ -58,6 +59,7 @@ def _parser() -> argparse.ArgumentParser:
     register.add_argument("--repository", required=True, help="GitHub owner/name")
     register.add_argument("--directory", required=True)
     register.add_argument("--default-branch", default="main")
+    register.add_argument("--dry-run", action="store_true")
     return parser
 
 
@@ -83,6 +85,28 @@ def _print(payload: Any) -> None:
 def main(argv: list[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
     try:
+        if arguments.command == "register":
+            settings = load_settings(arguments.registry)
+            if arguments.state_directory:
+                settings = replace(
+                    settings, state_directory=Path(arguments.state_directory).resolve()
+                )
+            database = (
+                Path(arguments.database).resolve() if arguments.database else settings.database_path
+            )
+            project = Project(
+                key=arguments.key,
+                name=arguments.name,
+                repository=arguments.repository,
+                directory=arguments.directory,
+                default_branch=arguments.default_branch,
+            )
+            result = ProjectRegistrar(settings, JobStore(database)).register(
+                project, dry_run=arguments.dry_run
+            )
+            _print(result)
+            return 0
+
         runtime = _runtime(arguments)
         if arguments.command == "init":
             _print({"status": "initialized", "database": runtime.store.database_path})
@@ -164,27 +188,6 @@ def main(argv: list[str] | None = None) -> int:
                 pool.stop()
                 server.shutdown()
                 dashboard_thread.join(timeout=5)
-            return 0
-        if arguments.command == "register":
-            project = Project(
-                key=arguments.key,
-                name=arguments.name,
-                repository=arguments.repository,
-                directory=arguments.directory,
-                default_branch=arguments.default_branch,
-            )
-            project.validate()
-            checkout = runtime.clone_registered_project(project)
-            updated = register_project(runtime.settings.registry_path, project)
-            _print(
-                {
-                    "status": "registered",
-                    "project": project.key,
-                    "checkout": checkout,
-                    "project_count": len(updated.projects),
-                    "production_deploy_allowed": False,
-                }
-            )
             return 0
     except (OSError, RuntimeError, ValueError, KeyError) as error:
         print(f"error: {error}", file=sys.stderr)

--- a/ops/agent/iron_house_agent/registration.py
+++ b/ops/agent/iron_house_agent/registration.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .config import AgentSettings, Project, register_project
+from .intake import READY_LABEL, ROLE_LABELS
+from .runtime import AgentRuntime
+from .store import JobStore, reject_embedded_secrets
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+_PRODUCTION_PATH_TOKEN = re.compile(
+    r"(?:^|[-_.])(?:prod|production|live)(?:$|[-_.])", re.IGNORECASE
+)
+_GITHUB_HTTPS_REMOTE = re.compile(
+    r"^https://github\.com/(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?$",
+    re.IGNORECASE,
+)
+_GITHUB_SSH_REMOTE = re.compile(
+    r"^(?:git@github\.com:|ssh://git@github\.com/)(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?)(?:\.git)?$",
+    re.IGNORECASE,
+)
+_SAFE_ENVIRONMENT_KEYS = {
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "TERM",
+    "TMPDIR",
+    "USER",
+    "XDG_CONFIG_HOME",
+}
+
+
+def _remote_repository(remote: str) -> str:
+    for pattern in (_GITHUB_HTTPS_REMOTE, _GITHUB_SSH_REMOTE):
+        match = pattern.fullmatch(remote.strip())
+        if match:
+            return match.group("repository")
+    raise ValueError("Project checkout origin must be a GitHub repository")
+
+
+class ProjectRegistrar:
+    def __init__(
+        self,
+        settings: AgentSettings,
+        store: JobStore,
+        *,
+        command_runner: CommandRunner = subprocess.run,
+    ):
+        self.settings = settings
+        self.store = store
+        self.command_runner = command_runner
+
+    def register(self, project: Project, *, dry_run: bool = False) -> dict[str, Any]:
+        self._validate_request(project)
+        already_registered = self._validate_conflicts(project)
+        repository = self._verify_github_repository(project)
+        self._verify_remote_policy(project)
+        destination = (self.settings.workspace / project.directory).resolve()
+
+        if dry_run:
+            return {
+                "status": "planned",
+                "project": project.key,
+                "repository": repository,
+                "checkout": str(destination),
+                "labels": [READY_LABEL, *ROLE_LABELS],
+                "already_registered": already_registered,
+                "production_deploy_allowed": False,
+                "mutations": False,
+            }
+
+        runtime = AgentRuntime(self.settings, self.store)
+        checkout = runtime.clone_registered_project(project)
+        self._verify_checkout_identity(project, checkout)
+        self._ensure_labels(project)
+        updated = register_project(self.settings.registry_path, project)
+        self.store.initialize()
+        self.store.update_intake_source(
+            project.key,
+            "ready",
+            "Registration verified; awaiting the next scheduled GitHub issue poll",
+        )
+        return {
+            "status": "already-registered" if already_registered else "registered",
+            "project": project.key,
+            "repository": repository,
+            "checkout": str(checkout),
+            "labels": [READY_LABEL, *ROLE_LABELS],
+            "project_count": len(updated.projects),
+            "intake_state": "ready",
+            "production_deploy_allowed": False,
+            "mutations": True,
+        }
+
+    def _validate_request(self, project: Project) -> None:
+        project.validate()
+        for value in (
+            project.key,
+            project.name,
+            project.repository,
+            project.directory,
+            project.default_branch,
+        ):
+            reject_embedded_secrets(value)
+        if _PRODUCTION_PATH_TOKEN.search(project.directory):
+            raise ValueError("Production or live checkout paths cannot be registered")
+        owner, _separator, _name = project.repository.partition("/")
+        if owner.casefold() != "iron-house-os":
+            raise ValueError("Only repositories in the trusted iron-house-os organization qualify")
+
+    def _validate_conflicts(self, project: Project) -> bool:
+        same_key = [item for item in self.settings.projects if item.key == project.key]
+        if same_key:
+            if same_key[0] == project:
+                return True
+            raise ValueError(f"Project key is already registered: {project.key}")
+        if any(
+            item.repository.casefold() == project.repository.casefold()
+            for item in self.settings.projects
+        ):
+            raise ValueError(f"Repository is already registered: {project.repository}")
+        if any(
+            item.directory.casefold() == project.directory.casefold()
+            for item in self.settings.projects
+        ):
+            raise ValueError(f"Directory is already registered: {project.directory}")
+        return False
+
+    def _verify_github_repository(self, project: Project) -> str:
+        completed = self._run(
+            [
+                "gh",
+                "repo",
+                "view",
+                project.repository,
+                "--json",
+                "nameWithOwner,defaultBranchRef",
+            ]
+        )
+        payload = json.loads(completed.stdout)
+        repository = str(payload.get("nameWithOwner", ""))
+        if repository.casefold() != project.repository.casefold():
+            raise ValueError("GitHub returned a different repository identity")
+        default_branch = payload.get("defaultBranchRef") or {}
+        if str(default_branch.get("name", "")) != project.default_branch:
+            raise ValueError(
+                f"Configured default branch does not match GitHub: {project.default_branch}"
+            )
+        return repository
+
+    def _verify_remote_policy(self, project: Project) -> None:
+        completed = self._run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "GET",
+                f"repos/{project.repository}/contents/AGENTS.md",
+                "-f",
+                f"ref={project.default_branch}",
+                "--jq",
+                ".type",
+            ]
+        )
+        if completed.stdout.strip() != "file":
+            raise ValueError("Repository must contain AGENTS.md before enrollment")
+
+    def _verify_checkout_identity(self, project: Project, checkout: Path) -> None:
+        completed = self._run(["git", "-C", str(checkout), "remote", "get-url", "origin"])
+        actual = _remote_repository(completed.stdout)
+        if actual.casefold() != project.repository.casefold():
+            raise ValueError(f"Checkout origin does not match registered repository: {actual}")
+        if not (checkout / "AGENTS.md").is_file():
+            raise ValueError("Project checkout is missing AGENTS.md")
+
+    def _ensure_labels(self, project: Project) -> None:
+        labels = {
+            READY_LABEL: ("0E8A16", "Approved for autonomous agent intake"),
+            **{
+                label: ("1D76DB", f"Route to the {role} agent")
+                for label, role in ROLE_LABELS.items()
+            },
+        }
+        for label, (color, description) in labels.items():
+            self._run(
+                [
+                    "gh",
+                    "label",
+                    "create",
+                    label,
+                    "--repo",
+                    project.repository,
+                    "--color",
+                    color,
+                    "--description",
+                    description,
+                    "--force",
+                ]
+            )
+
+    def _run(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+        try:
+            return self.command_runner(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env=self._safe_environment(),
+            )
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError(f"Registration command timed out: {command[0]}") from error
+        except subprocess.CalledProcessError as error:
+            raise RuntimeError(f"Registration command failed: {command[0]}") from error
+
+    @staticmethod
+    def _safe_environment() -> dict[str, str]:
+        environment = {
+            key: value for key, value in os.environ.items() if key in _SAFE_ENVIRONMENT_KEYS
+        }
+        environment.setdefault("PATH", "/usr/local/bin:/usr/bin:/bin")
+        environment.setdefault("LANG", "C.UTF-8")
+        return environment

--- a/ops/agent/iron_house_agent/runtime.py
+++ b/ops/agent/iron_house_agent/runtime.py
@@ -207,7 +207,17 @@ class AgentRuntime:
             raise RuntimeError(f"Registration staging directory already exists: {temporary}")
         try:
             subprocess.run(
-                ["git", "clone", f"https://github.com/{project.repository}.git", str(temporary)],
+                [
+                    "gh",
+                    "repo",
+                    "clone",
+                    project.repository,
+                    str(temporary),
+                    "--",
+                    "--branch",
+                    project.default_branch,
+                    "--single-branch",
+                ],
                 check=True,
                 timeout=300,
                 env=self._safe_environment(),
@@ -215,6 +225,10 @@ class AgentRuntime:
             if not (temporary / "AGENTS.md").is_file():
                 raise RuntimeError("Repository must contain AGENTS.md before enrollment")
             temporary.rename(destination)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as error:
+            if temporary.exists() and temporary.parent == self.settings.workspace.resolve():
+                shutil.rmtree(temporary)
+            raise RuntimeError("GitHub repository clone failed") from error
         except Exception:
             if temporary.exists() and temporary.parent == self.settings.workspace.resolve():
                 shutil.rmtree(temporary)

--- a/tests/agent/test_installation.py
+++ b/tests/agent/test_installation.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_start_installation_restarts_already_active_service() -> None:
+    installer = Path("ops/agent/install.sh").read_text(encoding="utf-8")
+    commands = {line.strip() for line in installer.splitlines()}
+
+    assert "systemctl enable iron-house-agent.service" in commands
+    assert "systemctl restart iron-house-agent.service" in commands
+    assert "systemctl enable --now iron-house-agent.service" not in commands

--- a/tests/agent/test_registration.py
+++ b/tests/agent/test_registration.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ops.agent.iron_house_agent.config import Project, load_settings
+from ops.agent.iron_house_agent.registration import ProjectRegistrar
+from ops.agent.iron_house_agent.store import JobStore
+
+
+class GitHubRunner:
+    def __init__(self, project: Project, *, policy_type: str = "file"):
+        self.project = project
+        self.policy_type = policy_type
+        self.calls: list[tuple[list[str], dict]] = []
+
+    def __call__(self, command: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        self.calls.append((command, kwargs))
+        if command[:3] == ["gh", "repo", "view"]:
+            stdout = json.dumps(
+                {
+                    "nameWithOwner": self.project.repository,
+                    "defaultBranchRef": {"name": self.project.default_branch},
+                }
+            )
+        elif command[:2] == ["gh", "api"]:
+            stdout = f"{self.policy_type}\n"
+        elif command[:4] == ["git", "-C", command[2], "remote"]:
+            stdout = f"https://github.com/{self.project.repository}.git\n"
+        else:
+            stdout = ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+
+def future_project(directory: str = "future-project") -> Project:
+    return Project(
+        key="future-project",
+        name="Future Project",
+        repository="iron-house-os/future-project",
+        directory=directory,
+    )
+
+
+def create_existing_checkout(workspace: Path, project: Project) -> Path:
+    checkout = workspace / project.directory
+    checkout.mkdir()
+    subprocess.run(["git", "init"], cwd=checkout, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", f"https://github.com/{project.repository}.git"],
+        cwd=checkout,
+        check=True,
+    )
+    (checkout / "AGENTS.md").write_text("# Project policy\n", encoding="utf-8")
+    return checkout
+
+
+def test_dry_run_validates_without_mutating_registry_or_state(settings) -> None:
+    project = future_project()
+    runner = GitHubRunner(project)
+    original_registry = settings.registry_path.read_bytes()
+    registrar = ProjectRegistrar(settings, JobStore(settings.database_path), command_runner=runner)
+
+    result = registrar.register(project, dry_run=True)
+
+    assert result["status"] == "planned"
+    assert result["mutations"] is False
+    assert result["production_deploy_allowed"] is False
+    assert settings.registry_path.read_bytes() == original_registry
+    assert not settings.database_path.exists()
+    assert not (settings.workspace / project.directory).exists()
+    assert not any(call[0][:3] == ["gh", "label", "create"] for call in runner.calls)
+
+
+def test_registration_is_atomic_idempotent_and_creates_standard_labels(settings) -> None:
+    project = future_project()
+    create_existing_checkout(settings.workspace, project)
+    runner = GitHubRunner(project)
+    store = JobStore(settings.database_path)
+
+    first = ProjectRegistrar(settings, store, command_runner=runner).register(project)
+    updated = load_settings(settings.registry_path)
+    second_runner = GitHubRunner(project)
+    second = ProjectRegistrar(updated, store, command_runner=second_runner).register(project)
+    snapshot = store.snapshot()
+
+    assert first["status"] == "registered"
+    assert second["status"] == "already-registered"
+    assert len(updated.projects) == 2
+    assert len(load_settings(settings.registry_path).projects) == 2
+    label_calls = [call for call, _kwargs in runner.calls if call[:3] == ["gh", "label", "create"]]
+    assert len(label_calls) == 9
+    assert {call[3] for call in label_calls} == set(first["labels"])
+    assert snapshot["intake_sources"][0]["project_key"] == project.key
+    assert snapshot["intake_sources"][0]["state"] == "ready"
+
+
+def test_registration_rejects_production_path_before_external_commands(settings) -> None:
+    project = future_project("future-production")
+    runner = GitHubRunner(project)
+
+    with pytest.raises(ValueError, match="Production or live"):
+        ProjectRegistrar(
+            settings, JobStore(settings.database_path), command_runner=runner
+        ).register(project, dry_run=True)
+
+    assert runner.calls == []
+
+
+def test_registration_rejects_repository_outside_trusted_organization(settings) -> None:
+    project = Project(
+        key="external-project",
+        name="External Project",
+        repository="outside-owner/external-project",
+        directory="external-project",
+    )
+    runner = GitHubRunner(project)
+
+    with pytest.raises(ValueError, match="trusted iron-house-os"):
+        ProjectRegistrar(
+            settings, JobStore(settings.database_path), command_runner=runner
+        ).register(project, dry_run=True)
+
+    assert runner.calls == []
+
+
+def test_registration_rejects_missing_remote_policy(settings) -> None:
+    project = future_project()
+    runner = GitHubRunner(project, policy_type="directory")
+
+    with pytest.raises(ValueError, match="AGENTS.md"):
+        ProjectRegistrar(
+            settings, JobStore(settings.database_path), command_runner=runner
+        ).register(project, dry_run=True)
+
+    assert not (settings.workspace / project.directory).exists()
+
+
+def test_registration_uses_saved_auth_without_inheriting_token(monkeypatch, settings) -> None:
+    project = future_project()
+    runner = GitHubRunner(project)
+    monkeypatch.setenv("GH_TOKEN", "must-not-be-inherited")
+
+    ProjectRegistrar(settings, JobStore(settings.database_path), command_runner=runner).register(
+        project, dry_run=True
+    )
+
+    assert runner.calls
+    assert all("GH_TOKEN" not in kwargs["env"] for _command, kwargs in runner.calls)
+
+
+def test_github_failure_returns_redacted_operational_error(settings) -> None:
+    project = future_project()
+
+    def failed_runner(command: list[str], **kwargs):
+        raise subprocess.CalledProcessError(
+            1,
+            command,
+            stderr="authentication failed with GH_TOKEN=must-not-leak",
+        )
+
+    with pytest.raises(RuntimeError, match="Registration command failed: gh") as error:
+        ProjectRegistrar(
+            settings,
+            JobStore(settings.database_path),
+            command_runner=failed_runner,
+        ).register(project, dry_run=True)
+
+    assert "must-not-leak" not in str(error.value)


### PR DESCRIPTION
Addresses #111.

## Summary
- add one idempotent root registration command for future Iron House repositories
- add a true no-mutation dry run
- restrict enrollment to the trusted `iron-house-os` organization
- verify saved GitHub access, canonical repository identity, default branch, and remote `AGENTS.md`
- clone through authenticated GitHub CLI and verify checkout origin
- create the standard intake labels and atomically update the private runtime registry
- restart the non-production service and verify repository plus intake health on the loopback dashboard
- make approved installer runs restart already-active services so new code is actually loaded

## Validation
- `26 passed` (`tests/agent`)
- Ruff lint and formatting passed
- Python compileall passed
- shell syntax checks passed
- systemd unit verification passed
- CLI help and GitHub remote parsing smoke checks passed
- `git diff --check` passed

## Safety
Dry run performs no mutations. Registration rejects production/live paths, secret-like input, conflicting identities, repositories outside the trusted organization, missing policy, mismatched checkout origins, and GitHub failures. Production deployment remains disabled.

## Rollback
Revert this commit and reinstall the prior non-production agent wrapper. Runtime registry changes remain private and atomic; production is not involved.

This remains a draft feature-branch PR. Merge and non-production service activation require owner approval.