### PR TITLE
Fix Codex worker sandbox and false-success validation

### DIFF
--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -186,6 +186,15 @@ Do not delete the job database or worktrees during incident review. Stop the ser
 
 Key controls:
 
+- The service runs as the dedicated unprivileged `ih-agent` user with `ProtectSystem=strict`,
+  a private temporary directory, a restrictive umask, and only the agent workspace, state,
+  Codex configuration, and GitHub CLI configuration writable. `NoNewPrivileges` is deliberately
+  disabled because Codex must create its Bubblewrap user namespace; the service has no sudo access
+  or added Linux capabilities.
+- Build, CI repair, dependency, and documentation jobs are successful only after a new clean commit,
+  a pushed issue-linked branch, and a verifiable open draft pull request exist. An explicit blocked
+  Codex response fails the job even when the CLI exits zero.
+
 - The service runs as `ih-agent`, not root.
 - The dashboard is loopback-only and read-only.
 - Each job receives a separate worktree and issue-linked branch.

--- a/ops/agent/install.sh
+++ b/ops/agent/install.sh
@@ -43,11 +43,12 @@ install -m 0755 "${AGENT_REPOSITORY}/ops/agent/iron-house-agent-register" \
 install -m 0644 "${AGENT_REPOSITORY}/ops/agent/iron-house-agent.service" \
   /etc/systemd/system/iron-house-agent.service
 
-sudo -u "${AGENT_USER}" /usr/local/bin/iron-house-agent init
+sudo -u "${AGENT_USER}" -H /usr/local/bin/iron-house-agent init
 systemctl daemon-reload
 
 if [ "${START_SERVICE}" = "true" ]; then
-  sudo -u "${AGENT_USER}" /usr/local/bin/iron-house-agent preflight
+  sudo -u "${AGENT_USER}" -H gh auth setup-git
+  sudo -u "${AGENT_USER}" -H /usr/local/bin/iron-house-agent preflight
   systemctl enable iron-house-agent.service
   systemctl restart iron-house-agent.service
   systemctl --no-pager --full status iron-house-agent.service

--- a/ops/agent/iron-house-agent.service
+++ b/ops/agent/iron-house-agent.service
@@ -9,11 +9,14 @@ User=ih-agent
 Group=ih-agent
 WorkingDirectory=/srv/iron-house-agents/iron-house-os
 Environment=PYTHONPATH=/srv/iron-house-agents/iron-house-os
+Environment=HOME=/home/ih-agent
 ExecStart=/usr/bin/python3 -m ops.agent.iron_house_agent.cli --registry /var/lib/iron-house-agent/projects.json serve --workers 4
 Restart=on-failure
 RestartSec=10
 UMask=0077
-NoNewPrivileges=true
+# Codex uses Bubblewrap user namespaces. The service remains an unprivileged user with a strict
+# read-only system view and explicit writable paths, but must be allowed to construct that sandbox.
+NoNewPrivileges=false
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=read-only

--- a/ops/agent/iron_house_agent/runtime.py
+++ b/ops/agent/iron_house_agent/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -61,6 +62,12 @@ _ROLE_WORKFLOWS = {
         "Convert only the approved plan or findings into prioritized GitHub issues with acceptance "
         "criteria, risks, dependencies, and approval gates. Do not implement or merge the issues."
     ),
+}
+_PUBLISH_REQUIRED_ROLES = {
+    "build",
+    "ci-repair",
+    "dependency-update",
+    "documentation",
 }
 _SAFE_ENVIRONMENT_KEYS = {
     "HOME",
@@ -132,7 +139,8 @@ class AgentRuntime:
         )
 
     def run_once(self, worker_id: str, executor: Executor | None = None) -> dict[str, Any] | None:
-        if executor is None:
+        managed_execution = executor is None
+        if managed_execution:
             self.preflight()
         job = self.store.claim_next(worker_id)
         if job is None:
@@ -147,15 +155,102 @@ class AgentRuntime:
             )
             run = executor or self._execute_codex
             exit_code = run(job, worktree, branch, log_path)
-            summary = (
-                "Codex task completed"
-                if exit_code == 0
-                else "Codex task failed; inspect the job log"
-            )
-            self.store.finish(job["id"], exit_code=exit_code, summary=summary)
+            validation_error = None
+            if exit_code == 0 and managed_execution:
+                validation_error = self._validate_codex_outcome(
+                    project, job, worktree, branch, log_path
+                )
+            if validation_error:
+                self.store.fail(job["id"], validation_error, exit_code=2)
+            else:
+                summary = (
+                    "Codex task completed"
+                    if exit_code == 0
+                    else "Codex task failed; inspect the job log"
+                )
+                self.store.finish(job["id"], exit_code=exit_code, summary=summary)
         except Exception as error:  # noqa: BLE001 - a worker records task failures instead of dying
             self.store.fail(job["id"], f"{type(error).__name__}: {error}")
         return self.store.get_job(job["id"])
+
+    def _validate_codex_outcome(
+        self,
+        project: Project,
+        job: dict[str, Any],
+        worktree: Path,
+        branch: str,
+        log_path: Path,
+    ) -> str | None:
+        message = self._last_agent_message(log_path)
+        normalized = message.strip().casefold()
+        if normalized.startswith(("blocked", "i am blocked", "i'm blocked")):
+            return "Codex reported the task blocked; inspect the job log"
+        if job["mode"] == "smoke" or job["role"] not in _PUBLISH_REQUIRED_ROLES:
+            return None
+
+        if self._git_output(worktree, "status", "--porcelain"):
+            return "Codex left uncommitted changes; inspect the job worktree"
+        head = self._git_output(worktree, "rev-parse", "HEAD")
+        base = self._git_output(worktree, "rev-parse", f"origin/{project.default_branch}")
+        if head == base:
+            return "Codex did not create a new commit"
+        try:
+            remote_ref = self._git_output(
+                worktree,
+                "ls-remote",
+                "--exit-code",
+                "origin",
+                f"refs/heads/{branch}",
+            )
+        except subprocess.CalledProcessError:
+            return "Codex did not push the issue-linked feature branch"
+        remote_head = remote_ref.partition("\t")[0]
+        if remote_head != head:
+            return "Codex pushed branch does not contain the completed local commit"
+
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    branch,
+                    "--repo",
+                    project.repository,
+                    "--json",
+                    "isDraft,state,headRefName,baseRefName,url",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=self._safe_environment(),
+            )
+            pull_request = json.loads(completed.stdout)
+        except (OSError, subprocess.SubprocessError, ValueError):
+            return "Codex did not open a verifiable draft pull request"
+        if (
+            pull_request.get("state") != "OPEN"
+            or pull_request.get("isDraft") is not True
+            or pull_request.get("headRefName") != branch
+            or pull_request.get("baseRefName") != project.default_branch
+        ):
+            return "Codex pull request does not match the required open draft workflow"
+        return None
+
+    @staticmethod
+    def _last_agent_message(log_path: Path) -> str:
+        last_message = ""
+        with log_path.open(encoding="utf-8") as log:
+            for line in log:
+                try:
+                    event = json.loads(line)
+                except ValueError:
+                    continue
+                item = event.get("item") or {}
+                if event.get("type") == "item.completed" and item.get("type") == "agent_message":
+                    last_message = str(item.get("text") or "")
+        return last_message
 
     def prepare_worktree(self, project: Project, job: dict[str, Any]) -> tuple[str, Path]:
         checkout = (self.settings.workspace / project.directory).resolve()
@@ -290,7 +385,11 @@ class AgentRuntime:
 
     @staticmethod
     def _git(checkout: Path, *arguments: str) -> None:
-        subprocess.run(
+        AgentRuntime._git_output(checkout, *arguments)
+
+    @staticmethod
+    def _git_output(checkout: Path, *arguments: str) -> str:
+        completed = subprocess.run(
             ["git", "-C", str(checkout), *arguments],
             check=True,
             capture_output=True,
@@ -298,6 +397,7 @@ class AgentRuntime:
             timeout=120,
             env=AgentRuntime._safe_environment(),
         )
+        return completed.stdout.strip()
 
     @contextmanager
     def _project_lock(self, project_key: str):

--- a/tests/agent/test_installation.py
+++ b/tests/agent/test_installation.py
@@ -8,3 +8,14 @@ def test_start_installation_restarts_already_active_service() -> None:
     assert "systemctl enable iron-house-agent.service" in commands
     assert "systemctl restart iron-house-agent.service" in commands
     assert "systemctl enable --now iron-house-agent.service" not in commands
+    assert 'sudo -u "${AGENT_USER}" -H gh auth setup-git' in commands
+
+
+def test_service_allows_codex_sandbox_without_removing_filesystem_hardening() -> None:
+    unit = Path("ops/agent/iron-house-agent.service").read_text(encoding="utf-8")
+
+    assert "User=ih-agent" in unit
+    assert "NoNewPrivileges=false" in unit
+    assert "ProtectSystem=strict" in unit
+    assert "PrivateTmp=true" in unit
+    assert "ReadWritePaths=/srv/iron-house-agents /var/lib/iron-house-agent" in unit

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import threading
 import time
@@ -123,3 +124,113 @@ def test_codex_command_is_noninteractive_and_disables_smoke_network() -> None:
     assert "--ask-for-approval" not in smoke
     assert "sandbox_workspace_write.network_access=false" in smoke
     assert "sandbox_workspace_write.network_access=true" in standard
+
+
+def test_zero_exit_blocked_agent_message_fails_managed_job(settings, monkeypatch) -> None:
+    create_test_repository(settings)
+    store = JobStore(settings.database_path)
+    runtime = AgentRuntime(settings, store)
+    runtime.initialize()
+    store.enqueue(
+        project_key="test-project",
+        role="build",
+        issue_number=112,
+        title="Blocked autonomous build",
+        prompt="Build the approved feature.",
+    )
+    monkeypatch.setattr(runtime, "preflight", dict)
+
+    def blocked_executor(job: dict, worktree: Path, branch: str, log_path: Path) -> int:
+        log_path.write_text(
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "agent_message",
+                        "text": "Blocked by the execution sandbox before repository access.",
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return 0
+
+    monkeypatch.setattr(runtime, "_execute_codex", blocked_executor)
+
+    completed = runtime.run_once("managed-worker")
+
+    assert completed is not None
+    assert completed["status"] == "failed"
+    assert completed["exit_code"] == 2
+    assert "reported the task blocked" in completed["result_summary"]
+
+
+def test_build_outcome_rejects_no_commit(settings) -> None:
+    create_test_repository(settings)
+    store = JobStore(settings.database_path)
+    runtime = AgentRuntime(settings, store)
+    runtime.initialize()
+    job = store.enqueue(
+        project_key="test-project",
+        role="build",
+        issue_number=112,
+        title="No-op build",
+        prompt="Build the approved feature.",
+    )
+    branch, worktree = runtime.prepare_worktree(settings.project("test-project"), job)
+    log_path = settings.state_directory / "logs" / "noop.jsonl"
+    log_path.write_text('{"type":"turn.completed"}\n', encoding="utf-8")
+
+    error = runtime._validate_codex_outcome(
+        settings.project("test-project"), job, worktree, branch, log_path
+    )
+
+    assert error == "Codex did not create a new commit"
+
+
+def test_build_outcome_accepts_pushed_branch_and_draft_pr(settings, monkeypatch) -> None:
+    create_test_repository(settings)
+    store = JobStore(settings.database_path)
+    runtime = AgentRuntime(settings, store)
+    runtime.initialize()
+    job = store.enqueue(
+        project_key="test-project",
+        role="build",
+        issue_number=112,
+        title="Published build",
+        prompt="Build the approved feature.",
+    )
+    project = settings.project("test-project")
+    branch, worktree = runtime.prepare_worktree(project, job)
+    (worktree / "FEATURE.md").write_text("# Feature\n", encoding="utf-8")
+    subprocess.run(["git", "add", "FEATURE.md"], cwd=worktree, check=True)
+    subprocess.run(["git", "commit", "-m", "Add feature"], cwd=worktree, check=True)
+    subprocess.run(["git", "push", "-u", "origin", branch], cwd=worktree, check=True)
+    log_path = settings.state_directory / "logs" / "published.jsonl"
+    log_path.write_text('{"type":"turn.completed"}\n', encoding="utf-8")
+    original_run = subprocess.run
+
+    def command_runner(command, **kwargs):
+        if command[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "isDraft": True,
+                        "state": "OPEN",
+                        "headRefName": branch,
+                        "baseRefName": "main",
+                        "url": "https://github.com/iron-house-os/test-project/pull/1",
+                    }
+                ),
+                stderr="",
+            )
+        return original_run(command, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", command_runner)
+
+    error = runtime._validate_codex_outcome(project, job, worktree, branch, log_path)
+
+    assert error is None


### PR DESCRIPTION
Addresses #117.

## Root cause
The service unit set `NoNewPrivileges=true`, which blocked the Bubblewrap user namespace used by Codex (`bwrap: setting up uid map: Permission denied`). Codex emitted an explicit blocked message but exited zero, and the orchestrator trusted that exit code without checking artifacts.

## Changes
- allow Codex to construct its sandbox while retaining the dedicated unprivileged user, `ProtectSystem=strict`, private temp, restrictive umask, explicit writable paths, no sudo, and no added capabilities
- configure saved GitHub CLI credentials as the git credential helper during approved installation
- fail explicit blocked messages even with exit code zero
- require build-like roles to produce a clean new commit, matching pushed branch, and verifiable open draft PR
- preserve no-change behavior for smoke and review-only roles

## Validation
- 30 agent tests passed
- Ruff lint and format passed
- Python compileall passed
- shell syntax passed
- systemd unit verification passed
- diff check passed

## Safety
No production mutation or deployment. The service remains an unprivileged non-production process with filesystem isolation. Activation requires owner approval.

## Retry
After activation, issue #112 will be given a new intake revision and retried automatically.