### PR TITLE
Fix Ubuntu 24.04 Codex sandbox setup

### DIFF
--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -195,6 +195,22 @@ Key controls:
   a pushed issue-linked branch, and a verifiable open draft pull request exist. An explicit blocked
   Codex response fails the job even when the CLI exits zero.
 
+### Ubuntu 24.04 Codex sandbox support
+
+The installer uses the distribution `bubblewrap` package. On Ubuntu 24.04 it also installs
+`apparmor-profiles` and `apparmor-utils`, copies the packaged `bwrap-userns-restrict` profile into
+`/etc/apparmor.d`, and loads it with `apparmor_parser`. This allows Bubblewrap to create the
+unprivileged user namespace required by Codex without disabling Ubuntu's AppArmor restriction
+globally. The agent preflight executes a minimal Bubblewrap user-namespace probe and fails with a
+specific recovery instruction before any job is claimed when the profile is missing or inactive.
+
+To repair or verify the supported configuration on the non-production build droplet, update the
+repository and rerun `sudo bash ops/agent/install.sh --start`. Do not set
+`kernel.apparmor_restrict_unprivileged_userns=0`; the packaged executable-specific profile keeps the
+exception limited to Bubblewrap. If rollback is required, stop the service, remove
+`/etc/apparmor.d/bwrap-userns-restrict`, reload AppArmor, and reinstall the last approved agent
+revision before restarting the service.
+
 - The service runs as `ih-agent`, not root.
 - The dashboard is loopback-only and read-only.
 - Each job receives a separate worktree and issue-linked branch.

--- a/docs/agent-platform.md
+++ b/docs/agent-platform.md
@@ -198,18 +198,21 @@ Key controls:
 ### Ubuntu 24.04 Codex sandbox support
 
 The installer uses the distribution `bubblewrap` package. On Ubuntu 24.04 it also installs
-`apparmor-profiles` and `apparmor-utils`, copies the packaged `bwrap-userns-restrict` profile into
-`/etc/apparmor.d`, and loads it with `apparmor_parser`. This allows Bubblewrap to create the
+`apparmor-profiles` and `apparmor-utils`, prepares the packaged `bwrap-userns-restrict` profile with
+deleted-dentry mediation required by real temporary-file workloads, clears any stale disable marker,
+copies the validated profile into `/etc/apparmor.d`, and loads it with `apparmor_parser`. This allows Bubblewrap to create the
 unprivileged user namespace required by Codex without disabling Ubuntu's AppArmor restriction
 globally. The agent preflight executes a minimal Bubblewrap user-namespace probe and fails with a
 specific recovery instruction before any job is claimed when the profile is missing or inactive.
+During `--start` activation, an existing worker is stopped before the repair begins and remains
+stopped if profile setup or preflight fails, preventing the old process from claiming more jobs.
 
 To repair or verify the supported configuration on the non-production build droplet, update the
 repository and rerun `sudo bash ops/agent/install.sh --start`. Do not set
 `kernel.apparmor_restrict_unprivileged_userns=0`; the packaged executable-specific profile keeps the
-exception limited to Bubblewrap. If rollback is required, stop the service, remove
-`/etc/apparmor.d/bwrap-userns-restrict`, reload AppArmor, and reinstall the last approved agent
-revision before restarting the service.
+exception limited to Bubblewrap. If rollback is required, stop the service, run
+`apparmor_parser -R /etc/apparmor.d/bwrap-userns-restrict`, remove the profile file, reload AppArmor,
+and reinstall the last approved agent revision before restarting the service.
 
 - The service runs as `ih-agent`, not root.
 - The dashboard is loopback-only and read-only.

--- a/ops/agent/install.sh
+++ b/ops/agent/install.sh
@@ -13,6 +13,49 @@ WORKTREES_DIRECTORY="/srv/iron-house-agents/worktrees"
 RUNTIME_REGISTRY="${STATE_DIRECTORY}/projects.json"
 START_SERVICE="false"
 
+install_codex_sandbox_prerequisites() {
+  if [ ! -r /etc/os-release ]; then
+    echo "Cannot identify the operating system required for Codex sandbox setup" >&2
+    exit 1
+  fi
+
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  if [ "${ID:-}" != "ubuntu" ]; then
+    if ! command -v bwrap >/dev/null 2>&1; then
+      echo "Missing Bubblewrap. Install the distribution package before starting the agent." >&2
+      exit 1
+    fi
+    return
+  fi
+
+  local packages=(bubblewrap)
+  if [ "${VERSION_ID:-}" = "24.04" ]; then
+    packages+=(apparmor-profiles apparmor-utils)
+  fi
+  if ! dpkg -s "${packages[@]}" >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
+  fi
+
+  if [ "${VERSION_ID:-}" != "24.04" ]; then
+    return
+  fi
+  if [ ! -r /sys/module/apparmor/parameters/enabled ] || \
+    ! grep -q '^Y' /sys/module/apparmor/parameters/enabled; then
+    return
+  fi
+
+  local source_profile="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
+  local installed_profile="/etc/apparmor.d/bwrap-userns-restrict"
+  if [ ! -f "${source_profile}" ]; then
+    echo "Ubuntu 24.04 Bubblewrap AppArmor profile is unavailable: ${source_profile}" >&2
+    exit 1
+  fi
+  install -m 0644 "${source_profile}" "${installed_profile}"
+  apparmor_parser -r "${installed_profile}"
+}
+
 if [ "${1:-}" = "--start" ]; then
   START_SERVICE="true"
 elif [ "$#" -gt 0 ]; then
@@ -29,6 +72,8 @@ if [ ! -f "${AGENT_REPOSITORY}/ops/agent/projects.json" ]; then
   echo "Missing agent repository at ${AGENT_REPOSITORY}" >&2
   exit 1
 fi
+
+install_codex_sandbox_prerequisites
 
 install -d -m 0700 -o "${AGENT_USER}" -g "${AGENT_USER}" "${STATE_DIRECTORY}"
 install -d -m 0700 -o "${AGENT_USER}" -g "${AGENT_USER}" "${STATE_DIRECTORY}/logs"

--- a/ops/agent/install.sh
+++ b/ops/agent/install.sh
@@ -48,11 +48,21 @@ install_codex_sandbox_prerequisites() {
 
   local source_profile="/usr/share/apparmor/extra-profiles/bwrap-userns-restrict"
   local installed_profile="/etc/apparmor.d/bwrap-userns-restrict"
+  local disabled_profile="/etc/apparmor.d/disable/bwrap-userns-restrict"
   if [ ! -f "${source_profile}" ]; then
     echo "Ubuntu 24.04 Bubblewrap AppArmor profile is unavailable: ${source_profile}" >&2
     exit 1
   fi
-  install -m 0644 "${source_profile}" "${installed_profile}"
+  local prepared_profile
+  prepared_profile="$(mktemp)"
+  if ! python3 "${AGENT_REPOSITORY}/ops/agent/iron_house_agent/apparmor.py" \
+    "${source_profile}" "${prepared_profile}"; then
+    rm -f "${prepared_profile}"
+    exit 1
+  fi
+  install -m 0644 "${prepared_profile}" "${installed_profile}"
+  rm -f "${prepared_profile}"
+  rm -f "${disabled_profile}"
   apparmor_parser -r "${installed_profile}"
 }
 
@@ -71,6 +81,11 @@ fi
 if [ ! -f "${AGENT_REPOSITORY}/ops/agent/projects.json" ]; then
   echo "Missing agent repository at ${AGENT_REPOSITORY}" >&2
   exit 1
+fi
+
+if [ "${START_SERVICE}" = "true" ] && systemctl is-active --quiet iron-house-agent.service; then
+  # Fail closed: an old worker must not keep claiming jobs if repair or preflight fails.
+  systemctl stop iron-house-agent.service
 fi
 
 install_codex_sandbox_prerequisites

--- a/ops/agent/install.sh
+++ b/ops/agent/install.sh
@@ -83,7 +83,11 @@ if [ ! -f "${AGENT_REPOSITORY}/ops/agent/projects.json" ]; then
   exit 1
 fi
 
-if [ "${START_SERVICE}" = "true" ] && systemctl is-active --quiet iron-house-agent.service; then
+if systemctl is-active --quiet iron-house-agent.service; then
+  if [ "${START_SERVICE}" != "true" ]; then
+    echo "Agent service is active; rerun with --start to update it safely." >&2
+    exit 1
+  fi
   # Fail closed: an old worker must not keep claiming jobs if repair or preflight fails.
   systemctl stop iron-house-agent.service
 fi

--- a/ops/agent/iron_house_agent/apparmor.py
+++ b/ops/agent/iron_house_agent/apparmor.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+_PROFILE_NAMES = ("bwrap", "unpriv_bwrap")
+
+
+def prepare_bwrap_profile(source: Path, destination: Path) -> None:
+    profile = source.read_text(encoding="utf-8")
+    for name in _PROFILE_NAMES:
+        pattern = re.compile(
+            rf"^(profile\s+{re.escape(name)}(?:\s+/usr/bin/bwrap)?\s+flags=\()([^)]*)(\)\s*\{{)",
+            re.MULTILINE,
+        )
+        match = pattern.search(profile)
+        if match is None:
+            raise ValueError(f"Required AppArmor profile declaration is missing: {name}")
+        flags = [flag.strip() for flag in match.group(2).split(",") if flag.strip()]
+        if "mediate_deleted" not in flags:
+            flags.append("mediate_deleted")
+            replacement = f"{match.group(1)}{','.join(flags)}{match.group(3)}"
+            profile = profile[: match.start()] + replacement + profile[match.end() :]
+    destination.write_text(profile, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare Ubuntu's Bubblewrap AppArmor profile for reliable Codex workloads"
+    )
+    parser.add_argument("source", type=Path)
+    parser.add_argument("destination", type=Path)
+    arguments = parser.parse_args()
+    prepare_bwrap_profile(arguments.source, arguments.destination)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/agent/iron_house_agent/runtime.py
+++ b/ops/agent/iron_house_agent/runtime.py
@@ -113,7 +113,15 @@ class AgentRuntime:
                 "--ro-bind",
                 "/",
                 "/",
-                "/usr/bin/true",
+                "--tmpfs",
+                "/tmp",
+                "/usr/bin/python3",
+                "-c",
+                (
+                    "import os; "
+                    "fd = os.open('/tmp', os.O_TMPFILE | os.O_RDWR, 0o600); "
+                    "os.write(fd, b'codex-sandbox-probe'); os.close(fd)"
+                ),
             ],
         }
         results: dict[str, str] = {}

--- a/ops/agent/iron_house_agent/runtime.py
+++ b/ops/agent/iron_house_agent/runtime.py
@@ -103,6 +103,18 @@ class AgentRuntime:
             "codex_auth": ["codex", "login", "status"],
             "git": ["git", "--version"],
             "github_auth": ["gh", "auth", "status"],
+            "codex_sandbox": [
+                "bwrap",
+                "--unshare-user",
+                "--uid",
+                "0",
+                "--gid",
+                "0",
+                "--ro-bind",
+                "/",
+                "/",
+                "/usr/bin/true",
+            ],
         }
         results: dict[str, str] = {}
         for name, command in checks.items():
@@ -119,8 +131,14 @@ class AgentRuntime:
                 raise RuntimeError(f"Required command is missing: {command[0]}") from error
             except subprocess.CalledProcessError as error:
                 detail = (error.stdout or error.stderr or "authentication failed").strip()
+                if name == "codex_sandbox":
+                    raise RuntimeError(
+                        "codex_sandbox preflight failed: Bubblewrap cannot create its user "
+                        f"namespace ({detail}). Re-run the agent installer as root."
+                    ) from error
                 raise RuntimeError(f"{name} preflight failed: {detail}") from error
-            results[name] = (completed.stdout or completed.stderr).strip().splitlines()[0]
+            output = (completed.stdout or completed.stderr).strip().splitlines()
+            results[name] = output[0] if output else "ok"
         return results
 
     def enqueue_smoke_test(self, project_key: str, issue_number: int) -> dict[str, Any]:

--- a/tests/agent/test_apparmor.py
+++ b/tests/agent/test_apparmor.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from ops.agent.iron_house_agent.apparmor import prepare_bwrap_profile
+
+STOCK_NOBLE_PROFILE = """\
+profile bwrap /usr/bin/bwrap flags=(attach_disconnected) {
+  allow userns,
+}
+profile unpriv_bwrap flags=(attach_disconnected) {
+  allow userns,
+}
+"""
+
+
+def test_prepare_bwrap_profile_adds_deleted_dentry_mediation(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    source.write_text(STOCK_NOBLE_PROFILE, encoding="utf-8")
+
+    prepare_bwrap_profile(source, first)
+    prepare_bwrap_profile(first, second)
+
+    prepared = first.read_text(encoding="utf-8")
+    assert prepared.count("mediate_deleted") == 2
+    assert second.read_text(encoding="utf-8") == prepared
+
+
+def test_prepare_bwrap_profile_rejects_unexpected_package_profile(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.write_text("profile something_else flags=(attach_disconnected) {}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="bwrap"):
+        prepare_bwrap_profile(source, destination)
+
+    assert not destination.exists()

--- a/tests/agent/test_installation.py
+++ b/tests/agent/test_installation.py
@@ -11,6 +11,17 @@ def test_start_installation_restarts_already_active_service() -> None:
     assert 'sudo -u "${AGENT_USER}" -H gh auth setup-git' in commands
 
 
+def test_installer_configures_ubuntu_2404_bubblewrap_apparmor_profile() -> None:
+    installer = Path("ops/agent/install.sh").read_text(encoding="utf-8")
+
+    assert "bubblewrap" in installer
+    assert "apparmor-profiles" in installer
+    assert "apparmor-utils" in installer
+    assert "/usr/share/apparmor/extra-profiles/bwrap-userns-restrict" in installer
+    assert 'apparmor_parser -r "${installed_profile}"' in installer
+    assert "kernel.apparmor_restrict_unprivileged_userns=0" not in installer
+
+
 def test_service_allows_codex_sandbox_without_removing_filesystem_hardening() -> None:
     unit = Path("ops/agent/iron-house-agent.service").read_text(encoding="utf-8")
 

--- a/tests/agent/test_installation.py
+++ b/tests/agent/test_installation.py
@@ -19,7 +19,19 @@ def test_installer_configures_ubuntu_2404_bubblewrap_apparmor_profile() -> None:
     assert "apparmor-utils" in installer
     assert "/usr/share/apparmor/extra-profiles/bwrap-userns-restrict" in installer
     assert 'apparmor_parser -r "${installed_profile}"' in installer
+    assert 'rm -f "${disabled_profile}"' in installer
     assert "kernel.apparmor_restrict_unprivileged_userns=0" not in installer
+
+
+def test_start_activation_stops_old_worker_before_repair_and_preflight() -> None:
+    installer = Path("ops/agent/install.sh").read_text(encoding="utf-8")
+
+    stop = installer.index("systemctl stop iron-house-agent.service")
+    sandbox_setup = installer.index("install_codex_sandbox_prerequisites", stop)
+    preflight = installer.index("/usr/local/bin/iron-house-agent preflight", sandbox_setup)
+    restart = installer.index("systemctl restart iron-house-agent.service", preflight)
+
+    assert stop < sandbox_setup < preflight < restart
 
 
 def test_service_allows_codex_sandbox_without_removing_filesystem_hardening() -> None:

--- a/tests/agent/test_installation.py
+++ b/tests/agent/test_installation.py
@@ -34,6 +34,15 @@ def test_start_activation_stops_old_worker_before_repair_and_preflight() -> None
     assert stop < sandbox_setup < preflight < restart
 
 
+def test_installer_rejects_partial_update_while_worker_is_active() -> None:
+    installer = Path("ops/agent/install.sh").read_text(encoding="utf-8")
+
+    assert "Agent service is active; rerun with --start to update it safely." in installer
+    assert installer.index('if [ "${START_SERVICE}" != "true" ]') < installer.index(
+        "systemctl stop iron-house-agent.service"
+    )
+
+
 def test_service_allows_codex_sandbox_without_removing_filesystem_hardening() -> None:
     unit = Path("ops/agent/iron-house-agent.service").read_text(encoding="utf-8")
 

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -14,6 +14,51 @@ from ops.agent.iron_house_agent.store import JobStore
 from tests.agent.conftest import create_test_repository
 
 
+def test_preflight_verifies_bubblewrap_user_namespace(settings, monkeypatch) -> None:
+    store = JobStore(settings.database_path)
+    runtime = AgentRuntime(settings, store)
+    commands: list[list[str]] = []
+
+    def command_runner(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", command_runner)
+
+    checks = runtime.preflight()
+
+    assert checks["codex_sandbox"] == "ok"
+    assert [
+        "bwrap",
+        "--unshare-user",
+        "--uid",
+        "0",
+        "--gid",
+        "0",
+        "--ro-bind",
+        "/",
+        "/",
+        "/usr/bin/true",
+    ] in commands
+
+
+def test_preflight_explains_bubblewrap_failure(settings, monkeypatch) -> None:
+    store = JobStore(settings.database_path)
+    runtime = AgentRuntime(settings, store)
+
+    def command_runner(command, **kwargs):
+        if command[0] == "bwrap":
+            raise subprocess.CalledProcessError(
+                1, command, stderr="bwrap: setting up uid map: Permission denied"
+            )
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", command_runner)
+
+    with pytest.raises(RuntimeError, match="Re-run the agent installer as root"):
+        runtime.preflight()
+
+
 def test_job_runs_in_issue_linked_isolated_worktree(settings) -> None:
     create_test_repository(settings)
     store = JobStore(settings.database_path)

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -38,7 +38,14 @@ def test_preflight_verifies_bubblewrap_user_namespace(settings, monkeypatch) -> 
         "--ro-bind",
         "/",
         "/",
-        "/usr/bin/true",
+        "--tmpfs",
+        "/tmp",
+        "/usr/bin/python3",
+        "-c",
+        (
+            "import os; fd = os.open('/tmp', os.O_TMPFILE | os.O_RDWR, 0o600); "
+            "os.write(fd, b'codex-sandbox-probe'); os.close(fd)"
+        ),
     ] in commands
 
 


### PR DESCRIPTION
Addresses #119.

## Root cause
Ubuntu 24.04's AppArmor restriction denied Bubblewrap's unprivileged user namespace before Codex could execute even `pwd`. PR #118 fixed the false-success handling, but systemd `NoNewPrivileges` was not the remaining blocker.

## Changes
- install the distribution `bubblewrap` package
- on Ubuntu 24.04, install and load the packaged `bwrap-userns-restrict` AppArmor profile
- add deleted-dentry mediation required for real temporary and atomic-file workloads
- clear stale AppArmor disable markers so the repair survives restart
- stop an existing worker before activation and leave it stopped if setup or preflight fails
- refuse a partial update of an active worker unless `--start` is supplied
- preserve the global AppArmor restriction instead of disabling it with a sysctl
- add a Bubblewrap probe that creates and writes an anonymous temporary file
- provide a specific recovery error before a job is claimed
- document activation, verification and correct kernel-profile rollback
- add focused profile, installer and runtime tests

## Validation
- `pytest tests/agent -q` — 37 passed
- Ruff lint and format — passed
- Python compileall — passed
- shell syntax — passed
- systemd unit verification — passed
- `git diff --check` — passed
- independent security re-review — no critical or high findings

## Safety
Non-production build-agent repair only. The service remains the dedicated unprivileged `ih-agent` user with strict filesystem controls, private temporary storage, restrictive umask, saved-auth isolation, issue-linked worktrees, mandatory draft PR validation and production deployment disabled.

No production, DNS, certificate, database, payment, invitation or secret changes.