### PR TITLE
Fix employee receipt intake authorization

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -6,7 +6,11 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.core.config import get_settings
-from app.services.access_control import can_access_module, required_permission
+from app.services.access_control import (
+    can_access_employee_receipt_route,
+    can_access_module,
+    required_permission,
+)
 from app.services.auth import AuthenticatedUser, account_to_principal, decode_session_token, get_account
 from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
 from app.services.request_context import get_request_audit_context
@@ -76,6 +80,14 @@ def require_module_access(request: Request, user: CurrentUser) -> AuthenticatedU
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Change your temporary password before accessing business modules.",
         )
+    relative_path = path_parts[len(prefix) + 1 :]
+    if can_access_employee_receipt_route(
+        user.role,
+        module,
+        request.method,
+        relative_path,
+    ):
+        return user
     if can_access_module(user.role, module, permission):
         return user
 

--- a/backend/app/services/access_control.py
+++ b/backend/app/services/access_control.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from uuid import UUID
 
 from app.services.document_audit_access import normalize_role
 
@@ -105,6 +106,32 @@ def required_permission(module: str, method: str) -> ModulePermission:
 
 def can_access_module(role: str | None, module: str, permission: ModulePermission) -> bool:
     return permission in module_permissions_for_role(role, module)
+
+
+def can_access_employee_receipt_route(
+    role: str | None,
+    module: str,
+    method: str,
+    relative_path: list[str],
+) -> bool:
+    """Allow employee receipt intake without opening the rest of finance."""
+    if normalize_role(role) != "viewer" or module != "finance" or not relative_path:
+        return False
+
+    normalized_method = method.upper()
+    if relative_path == ["receipts"]:
+        return normalized_method in {"GET", "POST"}
+    if relative_path == ["receipts", "extract"]:
+        return normalized_method == "POST"
+    if len(relative_path) not in {2, 3} or relative_path[0] != "receipts":
+        return False
+    try:
+        UUID(relative_path[1])
+    except ValueError:
+        return False
+    if len(relative_path) == 2:
+        return normalized_method in {"GET", "PUT"}
+    return relative_path[2] == "submit" and normalized_method == "POST"
 
 
 def describe_role_access(role: str | None) -> dict[str, list[str]]:

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -8,6 +8,7 @@ from app.api.dependencies.auth import require_authenticated_user
 from app.main import app
 from app.services.access_control import (
     ModulePermission,
+    can_access_employee_receipt_route,
     can_access_module,
     describe_role_access,
 )
@@ -106,3 +107,63 @@ def test_permission_summary_is_available_for_the_current_session() -> None:
         "role": "estimator",
         "modules": describe_role_access("estimator"),
     }
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", ["receipts"]),
+        ("POST", ["receipts"]),
+        ("POST", ["receipts", "extract"]),
+        ("GET", ["receipts", "00000000-0000-0000-0000-000000000010"]),
+        ("PUT", ["receipts", "00000000-0000-0000-0000-000000000010"]),
+        (
+            "POST",
+            ["receipts", "00000000-0000-0000-0000-000000000010", "submit"],
+        ),
+    ],
+)
+def test_viewer_receipt_intake_routes_are_narrowly_allowed(
+    method: str,
+    path: list[str],
+) -> None:
+    assert can_access_employee_receipt_route("viewer", "finance", method, path)
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", ["startup-expenses"]),
+        ("POST", ["entries"]),
+        (
+            "POST",
+            ["receipts", "00000000-0000-0000-0000-000000000010", "approve"],
+        ),
+        (
+            "POST",
+            ["receipts", "00000000-0000-0000-0000-000000000010", "export"],
+        ),
+        ("GET", ["receipts", "not-a-uuid"]),
+    ],
+)
+def test_viewer_receipt_intake_does_not_open_sensitive_finance_routes(
+    method: str,
+    path: list[str],
+) -> None:
+    assert not can_access_employee_receipt_route("viewer", "finance", method, path)
+
+
+def test_viewer_can_list_only_their_receipts_but_cannot_access_finance_admin() -> None:
+    _authenticate_as("viewer")
+
+    receipts = client.get("/api/v1/finance/receipts")
+    startup_expenses = client.get("/api/v1/finance/startup-expenses")
+    approve = client.post(
+        "/api/v1/finance/receipts/00000000-0000-0000-0000-000000000010/approve",
+        json={"version": 1, "reason": "Viewer must not approve receipts"},
+    )
+
+    assert receipts.status_code == 200
+    assert receipts.json() == {"items": [], "total": 0}
+    assert startup_expenses.status_code == 403
+    assert approve.status_code == 403


### PR DESCRIPTION
Relates to #136

## Summary

- audits the existing IHOS baseline at `b832bdf98fdcb71148bd326a8cef030a0a9ccbbc`
- repairs one confirmed High defect that blocked employee, operator, and foreman receipt capture
- admits only employee-owned receipt list/create/extract/read/update/submit routes
- preserves management-only approval, export, reconciliation, accounting entry, startup expense, and project finance boundaries
- adds positive and negative route-shape tests plus authenticated endpoint coverage
- does not change UI design, migrations, infrastructure, production, payments, invitations, or financial policy

## Defect matrix

| ID | Severity | State | Reproduction / affected role-device | Expected | Actual before repair | Evidence |
| --- | --- | --- | --- | --- | --- | --- |
| IHOS-136-01 | High | Fixed | Sign in as any `viewer` portal role on phone/tablet/desktop and request `GET /api/v1/finance/receipts`. | Employees can work with only their own receipt drafts and submit them for management review. | Module authorization returned 403 before ownership controls ran, blocking the entire existing receipt screen. | Pre-fix authenticated probe: 403, `Role 'viewer' lacks 'read' permission for module 'finance'.`; post-fix role + receipt suites: 33 passed. |
| IHOS-136-04 | High | Blocked | Shared staging; every role/device workflow. | Probe `https://staging.os.ironhousecivil.com/health`, `/readiness`, protected APIs, and the receipt API. | Staging runs an authorized current release and protected workflows reach authentication before representative-record smoke. | Host is healthy but reports stale release `e9cde294b366d500c6e0f0746e0e0a474f859f58`; receipt API returns 404 while other protected APIs return 401. | Owner/operator must deploy the approved current staging release and provide staging-only login access. No host mutation or credential workaround was attempted. |
| IHOS-136-02 | Medium | Monitored | Run the frontend suite concurrently with two backend suites on this constrained worker. | RFQ builder test completes inside 5 seconds. | One timeout with no assertion failure. | Passed twice in isolation (4.889 s; 5.136 s under diagnostic timeout), full standalone suite 53/53, baseline hosted CI green. No timeout or interaction weakening. |
| IHOS-136-03 | Low | Deferred | Run the non-gated legacy `backend/tests` tree directly. | Maintained tests collect and match current policy. | 75 passed, 2 failed, 2 errored due old quote/warning expectations and a missing legacy fixture. | Canonical configured `tests/backend` suite passes. Production behavior was not changed to satisfy stale policy expectations; separate owner-approved test maintenance is recommended. |

No Critical defects were reproduced. The High application authorization defect is fixed; the High shared-staging version gap is explicitly blocked with endpoint and release-ID evidence.

## Acceptance matrix

| Existing workflow | Status | Evidence / limitation |
| --- | --- | --- |
| Authentication, sessions, password recovery, roles, permission denials, navigation | Passed | Canonical auth/security tests; new narrow boundary tests; baseline CI/release gates. |
| Dashboard and employee/operator/foreman/management portals | Passed | Frontend and field-operation suites; baseline 33-case browser gate. |
| Projects, tenders, estimating, quotes, RFQs, suppliers, procurement | Passed | Canonical backend and frontend suites; RFQ external actions remain preview-only and approval-gated. |
| Documents, drawing intelligence, takeoffs, signed access, audit history | Passed | Document/storage/audit/takeoff/drawing suites. |
| Safety, FLHA, signatures, reassessment/release, PDF/audit | Passed | Field-operation and FLHA suites; baseline responsive browser gate. |
| Daily sheets, conflicts, approval, exports, posting, revision controls | Passed | Daily-time-sheet suite and baseline responsive/accessibility gate. |
| Employee receipt capture/extraction/own-list/submission | Passed | IHOS-136-01 repair and targeted authorization/receipt tests. |
| Receipt approval/export/reconciliation/sensitive-data controls | Passed | Management-only paths remain denied to viewers; receipt suite passed. No payment action exists or was activated. |
| Photos/media viewer, edits, replacement, versions, restore, access | Passed | Media/API authorization suites and baseline browser media gate. |
| Finance, equipment, reporting, administration | Passed | Canonical finance/equipment/role suites; no assumptions or live accounting changed. |
| Desktop/mobile/tablet/accessibility/overflow/recovery states | Passed | PR CI run `30776372546` passed all 33 browser/mobile/iPad accessibility cases in 4m44s. |
| Alembic/PostgreSQL upgrade, disposable stack, readiness, backup/restore, rollback | Passed | PR Release readiness run `30776372581` passed the PostgreSQL/disposable stack gate. |
| Live Google OAuth and live AI providers | Deferred | Require approved staging-only credentials and cost authorization; deterministic disabled/error paths pass. |
| Authenticated shared staging with representative owner records | Blocked | The authorized host is reachable and healthy but reports stale release `e9cde294b366d500c6e0f0746e0e0a474f859f58`; `/api/v1/finance/receipts` returns 404. No staging credentials were provided, so authenticated current-release smoke is blocked pending an owner/operator deployment and login access. |
| Physical iPad Safari acceptance | Blocked | Requires owner-accessible staging and a physical device. |
| Production/live data | Deferred | Explicitly out of scope and untouched. |

## Validation

Executed locally:

- `PYTHONPATH=/tmp/ihos-python-deps python3 -m ruff check .` — passed
- `PYTHONPATH=/tmp/ihos-python-deps python3 -m pytest -q` from `backend` — 237 passed, 1 existing Pydantic warning, 94.30 s
- targeted role and receipt suites — 33 passed, 3.19 s
- `python3 -m pytest -q tests/agent` — 37 passed, 2.88 s
- `npm run lint` — passed
- `npm run test` — 19 files, 53 tests passed, 64.45 s
- `npm run build` — passed, 1,860 modules transformed
- visual design lock — passed, 13 protected files, baseline `3c6cbe89`
- React Router RSC boundary — passed, RSC APIs/dependencies absent across 106 files
- `git diff --check` — passed

Environment-blocked local checks:

- `npm run test:e2e` attempted 33 cases; all browser launches were blocked by missing host libraries before any application assertion ran
- Docker/Compose migration, disposable stack, backup/restore, rollback, and readiness probes could not run because Docker is unavailable
- shared authenticated staging smoke could not run because no staging URL or credentials are available

Exact baseline hosted evidence at the audited SHA:

- CI run `30766010540`: backend, frontend, browser/mobile/accessibility jobs succeeded
- Release readiness run `30766010528`: backend, frontend, staging isolation, 33 browser cases, disposable authenticated/synthetic smoke, PostgreSQL upgrade, backup/restore, rollback, and immutable evidence all succeeded

PR CI run `30776372546` and Release readiness run `30776372581` both passed in full.

## Security and production gate

The exception is fail-closed by role, module, method, exact path shape, and UUID parsing. Viewer access remains denied for receipt approval/export/reconciliation/void, finance entries, startup expenses, and project finance. Existing receipt ownership checks still scope non-management users to their own records.

Production, DNS, certificates, secrets, live data, payments, payroll, banking, invitations, deployment, and approval gates were not accessed or changed.

## Owner actions and recommendation

Owner action is required only to provide/approve a non-production shared staging environment with representative records and staging-only credentials, then complete physical iPad Safari acceptance. Live Google or AI integration acceptance also needs separate staging-only credentials and cost approval.

Recommendation: disposable CI acceptance is complete and green. Shared-staging owner acceptance is not ready until an owner/operator deploys the authorized current release and provides staging login access. No production deployment is recommended or requested by this PR.

## Rollback

Revert commit `9e803064f70975708573ba3bf99ecdeff365ff87`. This restores the prior finance module denial for viewer roles; no migration or data rollback is required.



