### PR TITLE
Preserve FLHA assessment time when editing drafts

### DIFF
--- a/frontend/src/components/FLHAWorkflow.test.tsx
+++ b/frontend/src/components/FLHAWorkflow.test.tsx
@@ -40,4 +40,41 @@ describe("FLHAWorkflow", () => {
     expect(screen.getByText(/Blocked: 1 critical hazard/)).toBeInTheDocument();
     expect(screen.getByText(/never mark an FLHA safe or complete/i)).toBeInTheDocument();
   });
+
+  it("preserves the recorded assessment date and time when a draft is opened for edit", () => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    const savedData = {
+      ...data,
+      records: [{
+        id: "30000000-0000-0000-0000-000000000001",
+        record_type: "daily_hazard_assessment",
+        project_id: data.projects[0].id,
+        employee_id: null,
+        equipment_id: null,
+        supplier_id: null,
+        cost_code: null,
+        work_date: "2026-08-02",
+        title: "River Road FLHA",
+        status: "draft",
+        severity: "none",
+        details: {
+          assessment_datetime: "2026-08-02T07:15",
+          supervisor: { id: employee.id, name: "Field Foreperson" },
+          crew: [],
+          screening: {},
+          hazards: [],
+          emergency: {},
+        },
+        document_ids: [],
+        signatures: [],
+        alert_recipients: [],
+        submitted_by: employee.email,
+      }],
+    } as unknown as FieldOperationsBootstrap;
+
+    render(<FLHAWorkflow data={savedData} canCreate onSaved={vi.fn()} onError={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit draft" }));
+
+    expect(screen.getByLabelText("Date and time")).toHaveValue("2026-08-02T07:15");
+  });
 });

--- a/frontend/src/components/FLHAWorkflow.tsx
+++ b/frontend/src/components/FLHAWorkflow.tsx
@@ -126,7 +126,8 @@ export function FLHAWorkflow({ data, canCreate, onSaved, onError }: Props) {
     const value = record.details;
     setEditing(asReassessment ? null : record);
     setReassessment(asReassessment ? { sourceId: record.id, reason: window.prompt("Why is this re-assessment required?") ?? "Material field conditions changed" } : null);
-    setProjectId(record.project_id ?? ""); setSite(String(value.site_location ?? "")); setAssessmentDateTime(localDateTime());
+    setProjectId(record.project_id ?? ""); setSite(String(value.site_location ?? ""));
+    setAssessmentDateTime(asReassessment ? localDateTime() : String(value.assessment_datetime ?? localDateTime()));
     setSupervisorId(String((value.supervisor as Record<string, unknown> | undefined)?.id ?? ""));
     setFirstAidId(String((value.first_aid_attendant as Record<string, unknown> | undefined)?.id ?? ""));
     setCrewIds(((value.crew as Array<Record<string, string>> | undefined) ?? []).map((item) => item.id));


### PR DESCRIPTION
Fixes #140
Relates to #136

## Summary

- preserve a saved FLHA draft's `assessment_datetime` when it is opened for edit
- retain current-time initialization for material-condition reassessments
- add one focused regression test for the confirmed record-integrity defect

## Confirmed defect and reproduction

High — opening a persisted FLHA draft for edit reset the assessment date/time to the browser's current time. Saving any unrelated edit therefore silently rewrote when the field assessment occurred.

Regression evidence before repair:

- command: `npm run test -- --run src/components/FLHAWorkflow.test.tsx`
- result: 1 passed, 1 failed
- expected persisted value: `2026-08-02T07:15`
- received value: `2026-08-03T05:47`

Repair commit: `84b1c3afc768acf141a7266b55318b7fa77a78b2`

## Focused verification

- `PYTHONPATH=/tmp/ihos-issue-140-backend-deps:backend python3 -m pytest tests/backend/test_flha_workflow.py -q` — 5 passed, 1 existing Pydantic warning
- `PYTHONPATH=/tmp/ihos-issue-140-backend-deps:backend python3 -m pytest tests/backend/test_flha_workflow.py tests/backend/test_media.py tests/backend/test_media_document_authorization.py -q` — 13 passed, 1 existing Pydantic warning
- `npm run test -- --run src/components/FLHAWorkflow.test.tsx` — 2 passed after repair
- `npm run build` — passed; 1 existing chunk-size warning

The focused backend path verifies create, API persistence, edit, weather/details, hazard/control/responsible-person validation, critical blocking, own/shared-device crew acknowledgement, foreperson release, view authorization, immutability, reassessment and PDF pagination. Media authorization coverage verifies owner/management boundaries, non-disclosing denials, controlled evidence, link authorization and document-route authorization; the FLHA category remains controlled.

Local Playwright execution was attempted after a successful build. Browser binaries installed, but this managed host lacks Playwright's required GUI system libraries. No host/infrastructure changes were made. The remote browser gates installed those libraries on disposable GitHub runners and passed.

## Full CI and release readiness

Exactly one post-change run of each required workflow completed successfully:

- [CI run 30788341971](https://github.com/iron-house-os/iron-house-os/actions/runs/30788341971) — success
  - backend lint + 237 tests passed (1 existing warning)
  - frontend design lock, RSC boundary, lint, 19 files / 54 tests, and build passed
  - browser/mobile/accessibility: 33 collected, 28 passed, 5 intentionally skipped
- [Release readiness run 30788341965](https://github.com/iron-house-os/iron-house-os/actions/runs/30788341965) — success
  - staging isolation passed
  - release backend lint + 237 tests passed (1 existing warning)
  - release frontend design lock, RSC boundary, lint, 19 files / 54 tests, and build passed
  - release browser/mobile/accessibility: 33 collected, 28 passed, 5 intentionally skipped
  - disposable staging smoke, rollback and immutable evidence passed
  - disposable production-stack smoke, PostgreSQL upgrade probe, backup/restore and release evidence passed

## Security and production gates

- no secrets, authentication rules, approval gates, infrastructure, environment files, live data or production resources changed
- no payments or invitations activated
- no deployment performed
- locked visual design unchanged

## Risk and rollback

Risk is limited to draft edit initialization. Revert commit `84b1c3a` to restore the prior behavior; no migration or data rollback is required.

## Owner-only staging acceptance

Live shared-staging field acceptance (including physical iPad Safari and real foreperson/crew device handoff) remains owner-only. It is not substituted for code verification and no staging or production deployment is included in this PR.
