### PR TITLE
Preserve FLHA assessment time when editing drafts

### DIFF
--- a/frontend/src/components/FLHAWorkflow.test.tsx
+++ b/frontend/src/components/FLHAWorkflow.test.tsx
@@ -40,4 +40,41 @@ describe("FLHAWorkflow", () => {
     expect(screen.getByText(/Blocked: 1 critical hazard/)).toBeInTheDocument();
     expect(screen.getByText(/never mark an FLHA safe or complete/i)).toBeInTheDocument();
   });
+
+  it("preserves the recorded assessment date and time when a draft is opened for edit", () => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    const savedData = {
+      ...data,
+      records: [{
+        id: "30000000-0000-0000-0000-000000000001",
+        record_type: "daily_hazard_assessment",
+        project_id: data.projects[0].id,
+        employee_id: null,
+        equipment_id: null,
+        supplier_id: null,
+        cost_code: null,
+        work_date: "2026-08-02",
+        title: "River Road FLHA",
+        status: "draft",
+        severity: "none",
+        details: {
+          assessment_datetime: "2026-08-02T07:15",
+          supervisor: { id: employee.id, name: "Field Foreperson" },
+          crew: [],
+          screening: {},
+          hazards: [],
+          emergency: {},
+        },
+        document_ids: [],
+        signatures: [],
+        alert_recipients: [],
+        submitted_by: employee.email,
+      }],
+    } as unknown as FieldOperationsBootstrap;
+
+    render(<FLHAWorkflow data={savedData} canCreate onSaved={vi.fn()} onError={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit draft" }));
+
+    expect(screen.getByLabelText("Date and time")).toHaveValue("2026-08-02T07:15");
+  });
 });

--- a/frontend/src/components/FLHAWorkflow.tsx
+++ b/frontend/src/components/FLHAWorkflow.tsx
@@ -126,7 +126,8 @@ export function FLHAWorkflow({ data, canCreate, onSaved, onError }: Props) {
     const value = record.details;
     setEditing(asReassessment ? null : record);
     setReassessment(asReassessment ? { sourceId: record.id, reason: window.prompt("Why is this re-assessment required?") ?? "Material field conditions changed" } : null);
-    setProjectId(record.project_id ?? ""); setSite(String(value.site_location ?? "")); setAssessmentDateTime(localDateTime());
+    setProjectId(record.project_id ?? ""); setSite(String(value.site_location ?? ""));
+    setAssessmentDateTime(asReassessment ? localDateTime() : String(value.assessment_datetime ?? localDateTime()));
     setSupervisorId(String((value.supervisor as Record<string, unknown> | undefined)?.id ?? ""));
     setFirstAidId(String((value.first_aid_attendant as Record<string, unknown> | undefined)?.id ?? ""));
     setCrewIds(((value.crew as Array<Record<string, string>> | undefined) ?? []).map((item) => item.id));


### PR DESCRIPTION
Fixes #140
Relates to #136

## Summary
- preserve the saved FLHA assessment date/time when a draft is reopened for editing
- keep the current local date/time behavior for a new reassessment version
- add one regression test for the confirmed High field-use defect

## Confirmed defect and repair
Reproduction on current main: opening a draft saved with `assessment_datetime=2026-08-02T07:15` populated the edit form with `2026-08-03T06:24`. Saving would silently overwrite the safety assessment timestamp and could change its work date.

Repair commit: `68f586c` (`Preserve FLHA assessment time when editing drafts`). The edit path now loads the stored assessment timestamp, falling back to current local time only for legacy records without one. Reassessment continues to start with current local time.

## Verification evidence
Focused baseline before repair:
- backend FLHA: `5 passed`
- frontend FLHA: `1 passed`

Regression reproduction before repair:
- frontend FLHA: `1 failed, 1 passed`
- expected `2026-08-02T07:15`; received `2026-08-03T06:24`

Focused after repair:
- frontend FLHA: `2 passed`
- combined backend FLHA and media authorization: `12 passed, 1 warning`

Full local CI after final code change:
- backend Ruff: passed
- backend pytest: `237 passed, 1 warning`
- visual design lock: passed (`13 protected files`, baseline `3c6cbe89`)
- React Router RSC security boundary: passed (`106` files scanned)
- frontend typecheck: passed
- frontend Vitest: `54 passed` across `19` files
- frontend production build: passed

The local Playwright run reached browser launch after a successful build, but this restricted host lacks the system browser libraries installed by GitHub Actions. No browser case executed locally. CI and Release Readiness are required to supply authoritative Chromium, mobile, iPad/WebKit, accessibility, disposable staging, rollback, and release evidence before this draft is marked ready.

## Scope and risk
Two frontend files only. No redesign, new field, workflow change, infrastructure, production configuration, secrets, payments, invitations, or live data changes. The API contract is unchanged.

## Production and security gates
No production or staging deployment was performed. No secrets were accessed or moved. Approval and deployment gates remain unchanged.

## Rollback
Revert commit `68f586c`. This restores the prior edit-form timestamp behavior and removes its regression test; no migration or data rollback is required.

## Owner-only remaining acceptance
After automated gates pass, physical-device/live-staging field acceptance remains owner-only. It is not used as a substitute for code verification and no deployment is included in this PR.
