### PR TITLE
Preserve foreman time sheet draft identity

### DIFF
--- a/frontend/src/components/DailyTimesheetWorkflow.test.tsx
+++ b/frontend/src/components/DailyTimesheetWorkflow.test.tsx
@@ -51,4 +51,22 @@ describe("DailyTimesheetWorkflow", () => {
     expect(screen.getByLabelText("Existing receipt record")).toHaveValue("receipt-1");
     expect(screen.getByText(/Mixed lines may use separate job cost codes/)).toBeInTheDocument();
   });
+
+  it("restores totals after refresh and updates the existing server draft", async () => {
+    const first = render(<DailyTimesheetWorkflow />);
+    fireEvent.change(await screen.findByLabelText("Job number and name"), { target: { value: "job-1" } });
+    fireEvent.change(screen.getByLabelText("Foreman / supervisor"), { target: { value: "foreman-1" } });
+    fireEvent.change(screen.getByLabelText("Job cost code"), { target: { value: "03-100" } });
+    fireEvent.change(screen.getByLabelText("ST"), { target: { value: "8" } });
+    fireEvent.change(screen.getByLabelText("OT"), { target: { value: "1.5" } });
+    await waitFor(() => expect(dailyTimesheetApi.save).toHaveBeenCalled(), { timeout: 2500 });
+    await waitFor(() => expect(localStorage.getItem("ihos:foreman-daily-timesheet:v1:user-115")).toContain('"sheetId":"sheet-1"'));
+
+    first.unmount();
+    vi.mocked(dailyTimesheetApi.save).mockClear();
+    render(<DailyTimesheetWorkflow />);
+
+    expect(await screen.findByText(/ST 8.00 · OT 1.50 · 9.50 hours/)).toBeInTheDocument();
+    await waitFor(() => expect(dailyTimesheetApi.save).toHaveBeenCalledWith(expect.any(Object), "sheet-1"), { timeout: 2500 });
+  });
 });

--- a/frontend/src/components/DailyTimesheetWorkflow.tsx
+++ b/frontend/src/components/DailyTimesheetWorkflow.tsx
@@ -11,14 +11,24 @@ const blankNarrative = { work_completed: "", delays_issues: "", potential_change
 const emptyPayload = (): DailyTimesheetPayload => ({ work_date: today(), shift: "day", project_id: "", project_manager_id: null, supervisor_id: "", weather: "", site_conditions: "", document_ids: [], labour: [], equipment: [], materials: [], narrative: { ...blankNarrative } });
 const STORAGE_KEY = "ihos:foreman-daily-timesheet:v1";
 
+function storedDraft(storageKey: string): { payload: DailyTimesheetPayload; sheetId?: string } {
+  try {
+    const saved = JSON.parse(localStorage.getItem(storageKey) || "null");
+    if (!saved) return { payload: emptyPayload() };
+    if (saved.payload) return saved;
+    return { payload: saved };
+  } catch {
+    return { payload: emptyPayload() };
+  }
+}
+
 export function DailyTimesheetWorkflow() {
   const { user } = useAuth();
   const storageKey = `${STORAGE_KEY}:${user?.id ?? user?.email ?? "anonymous"}`;
+  const [restoredDraft] = useState(() => storedDraft(storageKey));
   const [data, setData] = useState<DailyTimesheetBootstrap | null>(null);
-  const [payload, setPayload] = useState<DailyTimesheetPayload>(() => {
-    try { return JSON.parse(localStorage.getItem(storageKey) || "null") || emptyPayload(); } catch { return emptyPayload(); }
-  });
-  const [sheetId, setSheetId] = useState<string | undefined>();
+  const [payload, setPayload] = useState<DailyTimesheetPayload>(restoredDraft.payload);
+  const [sheetId, setSheetId] = useState<string | undefined>(restoredDraft.sheetId);
   const [status, setStatus] = useState("draft");
   const [files, setFiles] = useState<File[]>([]);
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "offline">("idle");
@@ -32,7 +42,10 @@ export function DailyTimesheetWorkflow() {
   }, []);
   useEffect(() => { void refresh(); }, [refresh]);
   useEffect(() => { localStorage.removeItem(STORAGE_KEY); }, []);
-  useEffect(() => { localStorage.setItem(storageKey, JSON.stringify(payload)); }, [payload, storageKey]);
+  useEffect(() => {
+    if (status === "draft") localStorage.setItem(storageKey, JSON.stringify({ payload, sheetId }));
+    else localStorage.removeItem(storageKey);
+  }, [payload, sheetId, status, storageKey]);
 
   const codes = data?.project_cost_codes[payload.project_id] ?? [];
   const totals = useMemo(() => payload.labour.reduce((sum, line) => {


### PR DESCRIPTION
Closes #143
Relates to #136

## Summary

- persist the server-side daily time sheet draft ID together with the user-scoped local recovery payload
- restore that ID after browser refresh so autosave updates the existing draft instead of creating a duplicate
- preserve compatibility with payload-only local drafts already stored by the current staging release
- add one focused regression test proving ST/OT totals survive reload and the existing draft ID is reused

## Root cause and impact

The Foreman Portal persisted entered time sheet values but omitted the saved server record ID. After refresh, the recovered values autosaved as a new record. This could create duplicate drafts and lead to conflict-control failures when the foreman later submitted the sheet. The repair keeps refresh persistence attached to the original draft without changing fields, workflow, visual design, approvals, posting rules, or other modules.

## Validation evidence

Focused baseline and regression checks:

- `PYTHONPATH=/tmp/ihos-143-pydeps:. python3 -m pytest -q ../tests/backend/test_daily_timesheets.py` — 5 passed, 1 existing Pydantic warning
- `npm run test -- --run src/components/DailyTimesheetWorkflow.test.tsx` — 3 passed after repair
- focused Playwright command reached browser launch but the local worker lacks `libatk-1.0.so.0`; no product assertion ran

Complete local code gates after the final change:

- `ruff check .` — passed
- `pytest` — 237 passed, 1 existing Pydantic warning
- `python3 ../scripts/check_visual_design_lock.py` — passed; 13 protected files, baseline `3c6cbe89`
- `npm run security:rsc-boundary` — passed; no RSC dependencies or APIs detected across 106 files
- `npm run lint` — passed
- `npm run test` — 19 files and 55 tests passed
- `npm run build` — passed; existing chunk-size warning only

GitHub CI and Release Readiness are required to supply the browser system libraries and Docker unavailable in the local worker.

## Security and production gates

- no secrets, authentication, authorization, approval, payment, invitation, infrastructure, deployment, or production changes
- no locked visual files changed
- no tests or approval gates weakened
- this PR remains draft and must not be self-approved or self-merged
- staging deployment and live acceptance remain owner-controlled follow-up; production is out of scope

## Risk and rollback

Risk is limited to local recovery serialization for foreman daily time sheets. Revert commit `fc5c6bd` to restore the previous payload-only storage behavior. Existing payload-only local drafts remain readable by this change.
