### PR TITLE
Automate IHOS staging deployment

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,39 @@
+name: Staging deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: Exact 40-character commit SHA from main
+        required: true
+        type: string
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iron-house-os-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy and verify staging
+    runs-on: [self-hosted, linux, ihos-staging]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Deploy staging
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
+        run: sudo /usr/local/sbin/ihos-staging-deploy "$RELEASE_SHA"
+
+      - name: Verify public staging endpoints
+        run: |
+          curl --fail --silent --show-error https://staging.os.ironhousecivil.com/health
+          curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness

--- a/ops/digitalocean/staging-deploy-wrapper.sh
+++ b/ops/digitalocean/staging-deploy-wrapper.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_sha="${1:-}"
+app_dir="/opt/iron-house-os-staging-rc-e9cde294"
+env_file="/etc/iron-house-os/staging.env"
+compose_file="docker-compose.staging.yml"
+project_name="iron-house-os-staging"
+public_url="https://staging.os.ironhousecivil.com"
+
+[[ "$release_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid release SHA" >&2; exit 2; }
+
+cd "$app_dir"
+git fetch --quiet origin main
+git merge-base --is-ancestor "$release_sha" origin/main
+git checkout --detach "$release_sha"
+
+if ! grep -qE '^OPENAI_API_KEY=.+$' "$env_file"; then
+  echo "OPENAI_API_KEY is missing or empty" >&2
+  exit 3
+fi
+
+docker compose --env-file "$env_file" -f "$compose_file" -p "$project_name" up -d --build --remove-orphans
+
+for attempt in $(seq 1 30); do
+  if curl --fail --silent "$public_url/health" >/dev/null; then
+    break
+  fi
+  sleep 5
+done
+
+curl --fail --silent --show-error "$public_url/health"
+curl --fail --silent --show-error "$public_url/readiness"
+docker compose --env-file "$env_file" -f "$compose_file" -p "$project_name" ps
+
+echo "Staging deployment completed for $release_sha"


### PR DESCRIPTION
Adds a dedicated staging deployment workflow and restricted staging deployment wrapper.

The workflow is designed to run on a self-hosted runner labelled `ihos-staging`, deploy only an exact commit from `main`, rebuild the isolated staging stack, and verify public health/readiness endpoints.

The wrapper refuses deployment when the staging OpenAI key is missing or empty.

Production and Dumper are not touched.