### PR TITLE
Add local OCR fallback for receipt extraction

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,6 +5,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 

--- a/backend/app/services/local_receipt_ocr.py
+++ b/backend/app/services/local_receipt_ocr.py
@@ -1,0 +1,126 @@
+import io
+import re
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from PIL import Image, ImageEnhance, ImageOps
+import pytesseract
+
+from app.schemas.receipt import ReceiptCreate
+
+_AMOUNT = re.compile(r"(?<!\d)(\d{1,6}[.,]\d{2})(?!\d)")
+_DATE_PATTERNS = (
+    re.compile(r"\b(20\d{2})[-/.](\d{1,2})[-/.](\d{1,2})\b"),
+    re.compile(r"\b(\d{1,2})[-/.](\d{1,2})[-/.](20\d{2})\b"),
+)
+
+
+def extract_local_receipt(image_bytes: list[bytes], media_asset_ids: list) -> ReceiptCreate:
+    """Conservative local OCR fallback used when the external AI provider is unavailable.
+
+    The fallback only fills fields that can be identified with simple, auditable receipt
+    conventions. All values remain an unapproved draft and receive reduced confidence.
+    """
+    texts = [_ocr_image(data) for data in image_bytes]
+    text = "\n".join(part for part in texts if part).strip()
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+
+    vendor_name = _vendor(lines)
+    receipt_date = _date(text)
+    subtotal = _labelled_amount(lines, ("subtotal", "sub total"))
+    gst = _labelled_amount(lines, ("gst", "g.s.t")) or Decimal("0")
+    pst = _labelled_amount(lines, ("pst", "p.s.t")) or Decimal("0")
+    other_tax = _labelled_amount(lines, ("tax", "hst")) or Decimal("0")
+    total = _labelled_amount(lines, ("grand total", "amount due", "balance due", "total"))
+
+    if total is None:
+        amounts = [_amount(match.group(1)) for match in _AMOUNT.finditer(text)]
+        valid = [value for value in amounts if value is not None]
+        total = max(valid) if valid else None
+
+    confidence: dict[str, float] = {}
+    if vendor_name:
+        confidence["vendor_name"] = 0.72
+    if receipt_date:
+        confidence["receipt_date"] = 0.75
+    if subtotal is not None:
+        confidence["subtotal"] = 0.72
+    if total is not None:
+        confidence["total"] = 0.78
+
+    # Avoid double-counting a generic TAX line when explicit GST/PST was found.
+    if gst or pst:
+        other_tax = Decimal("0")
+
+    return ReceiptCreate(
+        media_asset_ids=media_asset_ids,
+        vendor_name=vendor_name,
+        receipt_date=receipt_date,
+        currency="CAD",
+        subtotal=float(subtotal) if subtotal is not None else None,
+        gst=float(gst),
+        pst=float(pst),
+        other_tax=float(other_tax),
+        total=float(total) if total is not None else None,
+        treatment="needs_review",
+        confidence=confidence,
+        flags=["local_ocr_fallback", "needs_review"],
+        line_items=[],
+    )
+
+
+def _ocr_image(data: bytes) -> str:
+    image = Image.open(io.BytesIO(data))
+    image = ImageOps.exif_transpose(image).convert("L")
+    image = ImageOps.autocontrast(image)
+    image = ImageEnhance.Contrast(image).enhance(1.6)
+    return pytesseract.image_to_string(image, config="--psm 6")
+
+
+def _vendor(lines: list[str]) -> str | None:
+    ignored = ("receipt", "invoice", "thank you", "welcome", "www.", "http", "tel", "phone")
+    for line in lines[:8]:
+        cleaned = re.sub(r"\s+", " ", line).strip(" -_:|")
+        lowered = cleaned.lower()
+        if len(cleaned) < 3 or any(term in lowered for term in ignored):
+            continue
+        if _AMOUNT.search(cleaned) or sum(character.isalpha() for character in cleaned) < 3:
+            continue
+        return cleaned[:255]
+    return None
+
+
+def _date(text: str):
+    for index, pattern in enumerate(_DATE_PATTERNS):
+        match = pattern.search(text)
+        if not match:
+            continue
+        try:
+            if index == 0:
+                year, month, day = map(int, match.groups())
+            else:
+                first, second, year = map(int, match.groups())
+                # Canadian receipts commonly use YYYY-MM-DD or MM/DD/YYYY.
+                month, day = (first, second) if first <= 12 else (second, first)
+            return datetime(year, month, day).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _labelled_amount(lines: list[str], labels: tuple[str, ...]) -> Decimal | None:
+    for line in reversed(lines):
+        lowered = line.lower()
+        if not any(label in lowered for label in labels):
+            continue
+        matches = list(_AMOUNT.finditer(line))
+        if matches:
+            return _amount(matches[-1].group(1))
+    return None
+
+
+def _amount(value: str) -> Decimal | None:
+    try:
+        return Decimal(value.replace(",", ".")).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError):
+        return None

--- a/backend/app/services/receipt_extraction.py
+++ b/backend/app/services/receipt_extraction.py
@@ -19,6 +19,7 @@ from app.models.supplier import Supplier
 from app.schemas.receipt import ReceiptCreate, ReceiptExtractionRequest, ReceiptExtractionResponse
 from app.services.auth import AuthenticatedUser
 from app.services.file_storage import resolve_storage_path
+from app.services.local_receipt_ocr import extract_local_receipt
 from app.services.receipts import _assets
 
 MAX_IMAGE_BYTES = 15 * 1024 * 1024
@@ -37,10 +38,9 @@ Return JSON matching the supplied schema exactly, with null for unknown scalar f
 
 def extract_receipt(db: Session, payload: ReceiptExtractionRequest, user: AuthenticatedUser) -> ReceiptExtractionResponse:
     settings = get_settings()
-    if not settings.openai_api_key:
-        raise HTTPException(status_code=503, detail="AI receipt extraction is unavailable; keep the photos and enter the draft manually.")
     assets = _assets(db, payload.media_asset_ids, user)
     content = [{"type": "input_text", "text": _context(db, user)}]
+    images: list[bytes] = []
     for asset in assets:
         document = db.get(Document, asset.original_document_id)
         if document is None or not document.storage_uri:
@@ -51,8 +51,13 @@ def extract_receipt(db: Session, payload: ReceiptExtractionRequest, user: Authen
         media_type = str((document.metadata_json or {}).get("content_type", "image/jpeg"))
         if not media_type.startswith("image/"):
             raise HTTPException(status_code=422, detail="Receipt extraction accepts images only.")
+        images.append(image)
         encoded = base64.b64encode(image).decode("ascii")
         content.append({"type": "input_image", "image_url": f"data:{media_type};base64,{encoded}", "detail": "original"})
+
+    if not settings.openai_api_key:
+        return _local_response(images, payload)
+
     body = {
         "model": settings.openai_chat_model,
         "instructions": INSTRUCTIONS,
@@ -71,13 +76,22 @@ def extract_receipt(db: Session, payload: ReceiptExtractionRequest, user: Authen
         regions = {item["name"]: item["source_region"] for item in raw.pop("field_regions") if item["source_region"] is not None}
         _normalize_extraction(raw, confidence)
         draft = ReceiptCreate.model_validate({**raw, "media_asset_ids": payload.media_asset_ids, "confidence": confidence, "source_regions": regions})
-    except HTTPError as exc:
-        raise HTTPException(status_code=503, detail=f"AI receipt extraction was rejected by the provider ({exc.code}); enter the draft manually.") from exc
-    except (URLError, TimeoutError) as exc:
-        raise HTTPException(status_code=503, detail="AI receipt extraction is temporarily unavailable; enter the draft manually.") from exc
+    except (HTTPError, URLError, TimeoutError):
+        return _local_response(images, payload)
     except (json.JSONDecodeError, UnicodeDecodeError, KeyError, TypeError, ValidationError, ValueError) as exc:
         raise HTTPException(status_code=502, detail="AI receipt extraction returned an invalid draft; enter the values manually.") from exc
     return ReceiptExtractionResponse(draft=draft, model=settings.openai_chat_model)
+
+
+def _local_response(images: list[bytes], payload: ReceiptExtractionRequest) -> ReceiptExtractionResponse:
+    try:
+        draft = extract_local_receipt(images, payload.media_asset_ids)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Receipt extraction is temporarily unavailable; the photos were kept for manual entry.",
+        ) from exc
+    return ReceiptExtractionResponse(draft=draft, model="local-tesseract-ocr")
 
 
 def _money(value: object) -> Decimal | None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,9 +3,11 @@ boto3==1.40.1
 email-validator==2.2.0
 fastapi==0.116.1
 openpyxl==3.1.5
+Pillow==11.3.0
 psycopg[binary]==3.2.9
 pydantic-settings==2.10.1
 pypdf==6.14.2
+pytesseract==0.3.13
 python-jose[cryptography]==3.5.0
 python-multipart==0.0.20
 sqlalchemy==2.0.41

--- a/tests/backend/test_receipt_local_ocr.py
+++ b/tests/backend/test_receipt_local_ocr.py
@@ -1,0 +1,41 @@
+from uuid import UUID
+
+from app.services import local_receipt_ocr
+
+
+ASSET_ID = UUID("00000000-0000-0000-0000-000000000123")
+
+
+def test_local_ocr_extracts_conservative_receipt_fields(monkeypatch) -> None:
+    monkeypatch.setattr(
+        local_receipt_ocr,
+        "_ocr_image",
+        lambda _data: "HOME HARDWARE\n2026-08-03\nSUBTOTAL 100.00\nGST 5.00\nTOTAL 105.00",
+    )
+
+    draft = local_receipt_ocr.extract_local_receipt([b"image"], [ASSET_ID])
+
+    assert draft.vendor_name == "HOME HARDWARE"
+    assert str(draft.receipt_date) == "2026-08-03"
+    assert draft.subtotal == 100
+    assert draft.gst == 5
+    assert draft.total == 105
+    assert draft.line_items == []
+    assert draft.treatment == "needs_review"
+    assert "local_ocr_fallback" in draft.flags
+
+
+def test_local_ocr_returns_reviewable_draft_when_only_total_is_visible(monkeypatch) -> None:
+    monkeypatch.setattr(
+        local_receipt_ocr,
+        "_ocr_image",
+        lambda _data: "THANK YOU\nAMOUNT DUE 42.19",
+    )
+
+    draft = local_receipt_ocr.extract_local_receipt([b"image"], [ASSET_ID])
+
+    assert draft.vendor_name is None
+    assert draft.total == 42.19
+    assert draft.currency == "CAD"
+    assert draft.confidence["total"] < 0.8
+    assert "needs_review" in draft.flags


### PR DESCRIPTION
Fixes the remaining receipt extraction blocker without depending on a valid OpenAI key.

Changes:
- installs Tesseract OCR in the backend image
- adds Pillow and pytesseract
- falls back to conservative local OCR when the OpenAI key is missing, rejected, unreachable, or times out
- extracts only vendor, date, subtotal, taxes, and total with reduced confidence
- always marks local OCR output as needs review
- keeps line items empty unless the external structured extractor succeeds
- adds focused fallback tests

Production and Dumper are not touched. Deploy to IHOS staging after CI and Release readiness pass.