### PR TITLE
Deploy exact staging checkout and verify OCR

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -28,12 +28,36 @@ jobs:
           ref: ${{ inputs.release_sha || github.sha }}
           fetch-depth: 0
 
-      - name: Deploy staging
+      - name: Verify exact release checkout
         env:
           RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
-        run: sudo /usr/local/sbin/ihos-staging-deploy "$RELEASE_SHA"
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          test -f backend/app/services/local_receipt_ocr.py
+
+      - name: Build and deploy exact checkout
+        run: |
+          sudo docker compose \
+            --env-file /etc/iron-house-os/staging.env \
+            -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
+            -p iron-house-os-staging \
+            up -d --build --force-recreate --remove-orphans
+
+      - name: Verify live backend contains OCR fallback
+        run: |
+          sudo docker compose \
+            --env-file /etc/iron-house-os/staging.env \
+            -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
+            -p iron-house-os-staging \
+            exec -T backend python -c 'import app.services.local_receipt_ocr; print("LOCAL_OCR_READY")'
 
       - name: Verify public staging endpoints
         run: |
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent https://staging.os.ironhousecivil.com/health >/dev/null; then
+              break
+            fi
+            sleep 5
+          done
           curl --fail --silent --show-error https://staging.os.ironhousecivil.com/health
           curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -33,6 +33,8 @@ jobs:
           RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
           test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
           test -f backend/app/services/local_receipt_ocr.py
 
       - name: Build and deploy exact checkout


### PR DESCRIPTION
Fixes the staging deployment path that reported completion while the live backend remained on old code.

Changes:
- deploys directly from the GitHub runner's exact checked-out commit
- force-recreates the staging stack
- verifies `local_receipt_ocr.py` exists before deployment
- verifies the live backend can import the OCR fallback after deployment
- keeps public health and readiness checks

Production and Dumper are untouched.