### PR TITLE
Repair staging receipt OCR fallback

### DIFF
--- a/backend/app/services/local_receipt_ocr.py
+++ b/backend/app/services/local_receipt_ocr.py
@@ -54,6 +54,12 @@ def extract_local_receipt(image_bytes: list[bytes], media_asset_ids: list) -> Re
     if subtotal is None and total is not None and taxes > 0 and total >= taxes:
         subtotal = (total - taxes).quantize(Decimal("0.01"))
 
+    # Do not publish a plausible-looking header when OCR could not verify any
+    # receipt date or amount. The retained image remains available for manual entry.
+    if receipt_date is None and total is None:
+        vendor_name = None
+        reference = None
+
     confidence: dict[str, float] = {}
     for field, value, score in (
         ("vendor_name", vendor_name, 0.74),
@@ -90,6 +96,7 @@ def extract_local_receipt(image_bytes: list[bytes], media_asset_ids: list) -> Re
 def _ocr_image(data: bytes) -> str:
     image = Image.open(io.BytesIO(data))
     image = ImageOps.exif_transpose(image).convert("L")
+    image = _crop_receipt_region(image)
 
     if max(image.size) < 2400:
         scale = min(3, max(2, 2400 // max(image.size)))
@@ -109,13 +116,106 @@ def _ocr_image(data: bytes) -> str:
             text = pytesseract.image_to_string(variant, config=f"--oem 3 --psm {psm}").strip()
             if text:
                 candidates.append(text)
-    return max(candidates, key=_ocr_quality, default="")
+
+    sparse_header = pytesseract.image_to_string(image, config="--oem 3 --psm 11").strip()
+    if sparse_header:
+        candidates.append(sparse_header)
+
+    best = max(candidates, key=_ocr_quality, default="")
+    header = _best_vendor_header(candidates)
+    if header and header.casefold() not in best.casefold():
+        return f"{header}\n{best}".strip()
+    return best
 
 
 def _ocr_quality(text: str) -> tuple[int, int, int]:
     labelled = sum(term in text.lower() for term in ("total", "gst", "subtotal", "invoice", "date"))
     alpha = sum(character.isalpha() for character in text)
     return labelled, alpha, len(text)
+
+
+def _crop_receipt_region(image: Image.Image) -> Image.Image:
+    """Crop a bright paper receipt from a substantially darker photo background."""
+    width, height = image.size
+    if width < 120 or height < 120:
+        return image
+
+    pixels = image.load()
+    bright_columns = [
+        x for x in range(width)
+        if sum(pixels[x, y] >= 145 for y in range(height)) >= max(1, int(height * 0.45))
+    ]
+    horizontal = _longest_run(bright_columns)
+    if not horizontal:
+        return image
+
+    left, right = horizontal[0], horizontal[-1] + 1
+    receipt_width = right - left
+    if receipt_width < width * 0.08 or receipt_width > width * 0.92:
+        return image
+
+    bright_rows = [
+        y for y in range(height)
+        if sum(pixels[x, y] >= 145 for x in range(left, right)) >= max(1, int(receipt_width * 0.45))
+    ]
+    vertical = _longest_run(bright_rows)
+    if not vertical:
+        return image
+
+    top, bottom = vertical[0], vertical[-1] + 1
+    if bottom - top < height * 0.20:
+        return image
+
+    padding = max(4, int(max(width, height) * 0.015))
+    crop_box = (
+        max(0, left - padding),
+        max(0, top - padding),
+        min(width, right + padding),
+        min(height, bottom + padding),
+    )
+    cropped = image.crop(crop_box)
+    if cropped.width * cropped.height >= width * height * 0.92:
+        return image
+    return cropped
+
+
+def _longest_run(values: list[int]) -> list[int]:
+    best: list[int] = []
+    current: list[int] = []
+    for value in values:
+        if current and value != current[-1] + 1:
+            if len(current) > len(best):
+                best = current
+            current = []
+        current.append(value)
+    if len(current) > len(best):
+        best = current
+    return best
+
+
+def _best_vendor_header(candidates: list[str]) -> str | None:
+    scored: list[tuple[int, str]] = []
+    for text in candidates:
+        lines = [_clean_line(line) for line in text.splitlines()[:8]]
+        vendor = _vendor([line for line in lines if line])
+        if vendor:
+            scored.append((_vendor_text_quality(vendor), vendor))
+    score, value = max(scored, default=(0, ""))
+    return value if score >= 25 else None
+
+
+def _vendor_text_quality(value: str) -> int:
+    words = re.findall(r"[A-Za-z]{2,}", value)
+    letters = sum(character.isalpha() for character in value)
+    score = letters
+    if 1 <= len(words) <= 3:
+        score += 12
+    if value.istitle():
+        score += 12
+    if len(value) > 28:
+        score -= min(20, len(value) - 28)
+    score -= 2 * len(re.findall(r"[^A-Za-z0-9 &'().-]", value))
+    return score
 
 
 def _clean_line(line: str) -> str:

--- a/frontend/src/components/ReceiptCapturePanel.test.tsx
+++ b/frontend/src/components/ReceiptCapturePanel.test.tsx
@@ -43,6 +43,16 @@ describe("ReceiptCapturePanel", () => {
     expect(financeApi.createReceipt).not.toHaveBeenCalled();
   });
 
+  it("clears the capture date when extraction cannot verify a receipt date", async () => {
+    const user = userEvent.setup(); render(<ReceiptCapturePanel />);
+    vi.mocked((await import("../api/media")).mediaApi.upload).mockResolvedValue([{ id: "asset-local" }] as never);
+    vi.mocked(financeApi.extractReceipt).mockResolvedValue({ model: "local-tesseract", draft: { media_asset_ids: ["asset-local"], vendor_name: null, vendor_address: null, reference: null, receipt_date: null, receipt_time: null, currency: "CAD", subtotal: null, discounts: 0, gst: 0, pst: 0, other_tax: 0, tip: 0, total: null, payment_method: null, card_brand: null, card_last_four: null, employee_email: null, treatment: "needs_review", confidence: {}, source_regions: {}, flags: ["local_ocr_fallback", "needs_review"], line_items: [] } });
+    await user.click(screen.getByRole("button", { name: "Choose mock photo" }));
+    await user.click(screen.getByRole("button", { name: "Extract receipt" }));
+    expect(await screen.findByText(/AI draft extracted with local-tesseract/)).toBeInTheDocument();
+    expect(screen.getByLabelText("Date")).toHaveValue("");
+  });
+
   it("shows source highlights and disables approval for low-confidence, unbalanced receipts", async () => {
     vi.mocked(financeApi.getReceipts).mockResolvedValue({ items: [blockedReceipt], total: 1 } as never);
     render(<ReceiptCapturePanel reviewer />);

--- a/frontend/src/components/ReceiptCapturePanel.tsx
+++ b/frontend/src/components/ReceiptCapturePanel.tsx
@@ -33,7 +33,7 @@ export function ReceiptCapturePanel({ reviewer = false }: { reviewer?: boolean }
         const assetIds = assets.map((asset) => asset.id); setUploadedAssetIds(assetIds);
         try {
           const { draft, model } = await financeApi.extractReceipt(assetIds);
-          setVendor(draft.vendor_name ?? ""); setVendorAddress(draft.vendor_address ?? ""); setReceiptTime(draft.receipt_time ?? ""); setCurrency(draft.currency); setEmployeeEmail(draft.employee_email); setReference(draft.reference ?? ""); setDate(draft.receipt_date ?? date);
+          setVendor(draft.vendor_name ?? ""); setVendorAddress(draft.vendor_address ?? ""); setReceiptTime(draft.receipt_time ?? ""); setCurrency(draft.currency); setEmployeeEmail(draft.employee_email); setReference(draft.reference ?? ""); setDate(draft.receipt_date ?? "");
           setSubtotal(draft.subtotal == null ? "" : String(draft.subtotal)); setDiscounts(String(draft.discounts)); setGst(String(draft.gst)); setPst(String(draft.pst)); setOtherTax(String(draft.other_tax)); setTip(String(draft.tip)); setTotal(draft.total == null ? "" : String(draft.total));
           setPaymentMethod(draft.treatment); setCardBrand(draft.card_brand ?? ""); setLastFour(draft.card_last_four ?? ""); setConfidence(draft.confidence); setSourceRegions(draft.source_regions); setDraftFlags(draft.flags);
           setLines(draft.line_items.length ? draft.line_items.map((line) => ({ description: line.description, quantity: String(line.quantity), unitPrice: String(line.unit_price), tax: String(line.tax), total: String(line.line_total), category: line.category, projectId: "", costCode: "", overhead: "", equipmentId: "", confidence: line.confidence, sourceRegion: line.source_region })) : [newLine()]);

--- a/tests/backend/test_receipt_local_ocr.py
+++ b/tests/backend/test_receipt_local_ocr.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 
+from PIL import Image
+
 from app.services import local_receipt_ocr
 
 
@@ -77,3 +79,39 @@ def test_generic_tax_does_not_match_total(monkeypatch) -> None:
 
     assert draft.other_tax == 0
     assert draft.total == 100
+
+
+
+def test_local_ocr_crops_bright_receipt_from_dark_background() -> None:
+    image = Image.new("L", (400, 400), color=20)
+    image.paste(220, (135, 15, 265, 385))
+
+    cropped = local_receipt_ocr._crop_receipt_region(image)
+
+    assert cropped.width < image.width * 0.5
+    assert cropped.height > image.height * 0.8
+
+
+def test_local_ocr_prefers_sparse_title_header() -> None:
+    candidates = [
+        "PIUPBAL AATUBAL GAS) CH&eOAI\nINVOICE otee",
+        "Fortins",
+    ]
+
+    assert local_receipt_ocr._best_vendor_header(candidates) == "Fortins"
+
+
+def test_local_ocr_clears_unverified_garbage_header(monkeypatch) -> None:
+    monkeypatch.setattr(
+        local_receipt_ocr,
+        "_ocr_image",
+        lambda _data: "PIUPBAL AATUBAL GAS) CH&eOAI\nINVOICE otee",
+    )
+
+    draft = local_receipt_ocr.extract_local_receipt([b"image"], [ASSET_ID])
+
+    assert draft.vendor_name is None
+    assert draft.reference is None
+    assert draft.receipt_date is None
+    assert draft.total is None
+    assert "vendor_name" not in draft.confidence


### PR DESCRIPTION
Relates to #145.

## Confirmed live-staging failure
A narrow, light receipt photographed on a dark background produced plausible-looking garbage fields and silently retained today's date.

## Focused repair
- Crop the detected receipt-paper region before local OCR.
- Add a sparse header pass so a clear vendor heading can replace noisy full-page text.
- Suppress vendor/reference output when neither a receipt date nor total is verified.
- Clear the receipt date in the form when OCR does not extract one instead of keeping today's default.
- Add backend and frontend regression coverage for the observed failure mode.

## Gates
- OCR results remain unapproved `needs_review` drafts.
- Manual correction, authorization, data isolation, and financial approval/export controls are unchanged.
- No production deployment is included.

## Validation
- Python syntax compilation passed locally.
- Focused crop, vendor-header, and garbage-suppression runtime checks passed locally.
- Full backend/frontend/browser/staging gates are delegated to the repository CI run for this draft PR.