### PR TITLE
Fix Backups classification confidence fallback

### DIFF
--- a/backend/app/services/backups.py
+++ b/backend/app/services/backups.py
@@ -434,7 +434,7 @@ def _local_classification(text: str) -> Classification:
     receipt_score += 1 if any(term in normalized for term in ("cash", "debit", "credit", "visa", "mastercard", "approved")) else 0
     receipt_score += 1 if any(term in normalized for term in ("gst", "pst", "hst", "sales tax")) else 0
 
-    amount_count = len(re.findall(r"(?<!\\d)(?:[$]\\s*)?\\d{1,6}[.,]\\d{2}(?!\\d)", normalized))
+    amount_count = len(re.findall(r"(?<!\d)(?:[$]\s*)?\d{1,6}[.,]\d{2}(?!\d)", normalized))
     receipt_score += 1 if amount_count >= 2 else 0
     receipt_score += 1 if amount_count >= 4 else 0
 

--- a/backend/app/services/backups.py
+++ b/backend/app/services/backups.py
@@ -403,9 +403,14 @@ def _ensure_media_link(db: Session, media_id: UUID, record_type: str, record_id:
 
 def _classify(text: str) -> Classification:
     local = _local_classification(text)
-    settings = get_settings()
-    if not settings.openai_api_key or not text.strip():
+    if local.detected_type != "other" and local.confidence >= MIN_ROUTE_CONFIDENCE:
         return local
+    if not text.strip():
+        return Classification("other", 0.0, "local_ocr_no_text")
+
+    settings = get_settings()
+    if not settings.openai_api_key:
+        return Classification(local.detected_type, local.confidence, "local_ocr_provider_unconfigured")
     try:
         return _external_classification(text, settings)
     except (HTTPError, URLError, TimeoutError, ValueError, KeyError, TypeError, json.JSONDecodeError):
@@ -414,14 +419,28 @@ def _classify(text: str) -> Classification:
 
 def _local_classification(text: str) -> Classification:
     normalized = " ".join(text.lower().split())
+    if not normalized:
+        return Classification("other", 0.0, "local_ocr_no_text")
     if any(term in normalized for term in ("packing slip", "delivery ticket", "proof of delivery", "packing list")):
         return Classification("packing_slip", 0.94, "local_ocr")
     if any(term in normalized for term in ("supplier invoice", "tax invoice", "invoice number", "invoice #", "amount due", "remit to")):
         return Classification("supplier_invoice", 0.92, "local_ocr")
-    receipt_score = sum(term in normalized for term in ("receipt", "subtotal", "total", "thank you", "change due"))
-    if receipt_score >= 2:
-        return Classification("receipt", min(0.96, 0.68 + receipt_score * 0.07), "local_ocr")
-    return Classification("other", 0.25 if normalized else 0.0, "local_ocr")
+
+    receipt_score = 0
+    receipt_score += 2 if "receipt" in normalized else 0
+    receipt_score += 2 if any(term in normalized for term in ("subtotal", "sub total", "sub-total")) else 0
+    receipt_score += 1 if "total" in normalized else 0
+    receipt_score += 1 if any(term in normalized for term in ("thank you", "change due", "cashier", "transaction")) else 0
+    receipt_score += 1 if any(term in normalized for term in ("cash", "debit", "credit", "visa", "mastercard", "approved")) else 0
+    receipt_score += 1 if any(term in normalized for term in ("gst", "pst", "hst", "sales tax")) else 0
+
+    amount_count = len(re.findall(r"(?<!\\d)(?:[$]\\s*)?\\d{1,6}[.,]\\d{2}(?!\\d)", normalized))
+    receipt_score += 1 if amount_count >= 2 else 0
+    receipt_score += 1 if amount_count >= 4 else 0
+
+    if receipt_score >= 4:
+        return Classification("receipt", min(0.96, 0.74 + receipt_score * 0.04), "local_ocr")
+    return Classification("other", 0.0, "local_ocr_unclassified")
 
 
 def _external_classification(text: str, settings) -> Classification:

--- a/frontend/src/pages/BackupsPage.test.tsx
+++ b/frontend/src/pages/BackupsPage.test.tsx
@@ -97,6 +97,25 @@ describe("BackupsPage", () => {
     expect(await screen.findByRole("status")).toHaveTextContent("daily controller");
   });
 
+  it("shows meaningful classification diagnostics instead of a fixed fallback confidence", async () => {
+    auth.role = "admin";
+    vi.mocked(backupsApi.list).mockResolvedValue({
+      items: [{
+        ...intake,
+        status: "needs_review",
+        detected_type: "other",
+        confidence: 0,
+        classification_source: "local_ocr_provider_fallback",
+      }],
+      total: 1,
+    });
+    render(<BackupsPage />);
+
+    expect(await screen.findByText("other · 0% confidence")).toBeInTheDocument();
+    expect(screen.getByText("Classification source: Local OCR fallback")).toBeInTheDocument();
+    expect(screen.queryByText(/25% confidence/)).not.toBeInTheDocument();
+  });
+
   it("shows only management controls for the company queue", async () => {
     auth.role = "admin";
     vi.mocked(backupsApi.list).mockResolvedValue({ items: [intake], total: 1 });

--- a/frontend/src/pages/BackupsPage.tsx
+++ b/frontend/src/pages/BackupsPage.tsx
@@ -157,6 +157,7 @@ export function BackupsPage() {
                   {isManagement ? <span className="text-xs text-iron-500">{item.uploader_email} · {item.uploader_role.replaceAll("_", " ")}</span> : null}
                 </div>
                 <div className="mt-2 text-sm text-iron-700">{item.detected_type ? item.detected_type.replaceAll("_", " ") : "Awaiting classification"}{item.confidence !== null ? ` · ${Math.round(item.confidence * 100)}% confidence` : ""}</div>
+                {item.classification_source ? <div className="mt-1 text-xs text-iron-500">Classification source: {classificationSourceLabel(item.classification_source)}</div> : null}
                 {item.project_hint ? <div className="mt-1 text-sm text-iron-500">Project hint: {item.project_hint}</div> : null}
                 {item.note ? <div className="mt-1 text-sm text-iron-500">{item.note}</div> : null}
                 {item.sensitive_quarantine ? <div className="mt-2 inline-flex items-center gap-2 text-sm font-semibold text-amber-800"><ShieldCheck className="h-4 w-4" />Sensitive-content quarantine; external AI was skipped.</div> : null}
@@ -172,6 +173,16 @@ export function BackupsPage() {
       </section>
     </section>
   );
+}
+
+function classificationSourceLabel(source: string) {
+  if (source === "openai_api") return "AI-assisted classification";
+  if (source === "local_ocr") return "Local OCR";
+  if (source === "local_sensitive_screen") return "Local sensitive-content screen";
+  if (source === "local_ocr_no_text") return "No readable text detected";
+  if (source === "local_ocr_unclassified") return "Local OCR found no reliable document type";
+  if (source === "local_ocr_provider_unconfigured" || source === "local_ocr_provider_fallback") return "Local OCR fallback";
+  return source.replaceAll("_", " ");
 }
 
 function StatusPill({ status }: { status: string }) {

--- a/tests/backend/test_backups.py
+++ b/tests/backend/test_backups.py
@@ -2,6 +2,7 @@ import json
 from io import BytesIO
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.error import URLError
 from uuid import UUID
 
 import pytest
@@ -197,6 +198,44 @@ def test_low_confidence_is_kept_in_management_triage(monkeypatch) -> None:
     assert current["detected_type"] == "other"
     assert current["confidence"] == 0.51
     assert current["destination_record_id"] is None
+
+
+def test_clear_transaction_structure_classifies_as_receipt_without_external_provider(monkeypatch) -> None:
+    def provider_must_not_be_needed():
+        raise AssertionError("Clear local receipt classification should not call the external provider")
+
+    monkeypatch.setattr(backups, "get_settings", provider_must_not_be_needed)
+    classification = backups._classify(
+        "FORTIS STORE\n2026-08-05 09:02\nGST 0.62\n"
+        "VISA APPROVED\n12.34\n0.62\n12.96\nTHANK YOU"
+    )
+    assert classification.detected_type == "receipt"
+    assert classification.confidence >= backups.MIN_ROUTE_CONFIDENCE
+    assert classification.source == "local_ocr"
+
+
+def test_unmatched_local_text_does_not_report_hard_coded_twenty_five_percent() -> None:
+    classification = backups._local_classification("legible project paperwork with no reliable document type")
+    assert classification.detected_type == "other"
+    assert classification.confidence == 0.0
+    assert classification.source == "local_ocr_unclassified"
+
+
+def test_provider_failure_reports_local_fallback_without_false_confidence(monkeypatch) -> None:
+    monkeypatch.setattr(
+        backups,
+        "get_settings",
+        lambda: SimpleNamespace(
+            openai_api_key="configured-test-key",
+            openai_chat_model="gpt-test",
+            openai_api_base_url="https://api.openai.test/v1",
+        ),
+    )
+    monkeypatch.setattr(backups, "urlopen", lambda *_args, **_kwargs: (_ for _ in ()).throw(URLError("offline")))
+    classification = backups._classify("legible project paperwork with no reliable document type")
+    assert classification.detected_type == "other"
+    assert classification.confidence == 0.0
+    assert classification.source == "local_ocr_provider_fallback"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #154

## What changed
- Removes the hard-coded 25% confidence assigned to every locally unclassified image.
- Classifies clear transaction-shaped receipts locally using payment, tax, amount, and receipt-language signals.
- Skips the external provider when local OCR already has a reliable document classification.
- Distinguishes no-text, unclassified, provider-unconfigured, and provider-fallback outcomes.
- Shows a plain-language classification source in the Backups queue.
- Adds focused backend and frontend regression tests.

## Root cause
The local fallback returned `other` at exactly `0.25` whenever OCR text did not contain a narrow keyword set. Provider failure or missing configuration therefore looked like image-quality confidence, and even clear transaction-shaped receipts could land in triage with the same number.

## Controls preserved
Uncertain documents remain `needs_review`. No automatic approval, posting, reconciliation, payment, inventory acceptance, project selection, or launch gate changes are included. Private media and role-based access are unchanged. Staging only.

## Validation
Focused tests are included. Full CI and release-readiness gates must pass before review or merge.