### PR TITLE
Implement equipment and client rate-sheet library

### DIFF
--- a/backend/app/api/v1/routes/estimates.py
+++ b/backend/app/api/v1/routes/estimates.py
@@ -16,9 +16,23 @@ from app.schemas.estimate import (
     EstimateSummary,
     RateLibrary,
 )
+from app.schemas.equipment_rates import (
+    ClientRateSheetRequest,
+    EquipmentRateInput,
+    EquipmentRateLibrary,
+    EquipmentRateResult,
+)
 from app.schemas.estimate_validation import EstimateValidationRequest, EstimateValidationResult
 from app.schemas.estimate_workspace import EstimateWorkspaceList, EstimateWorkspaceRead, EstimateWorkspaceSaveRequest
-from app.services import estimate_handoff, estimate_validation, estimate_workspace, estimate_workbooks, estimates
+from app.services import (
+    equipment_rate_sheet_pdf,
+    equipment_rates,
+    estimate_handoff,
+    estimate_validation,
+    estimate_workspace,
+    estimate_workbooks,
+    estimates,
+)
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
@@ -27,6 +41,27 @@ DBSession = Annotated[Session, Depends(get_db)]
 @router.get("/rate-library", response_model=RateLibrary)
 def get_rate_library() -> RateLibrary:
     return estimates.get_rate_library()
+
+
+@router.get("/equipment-rate-library", response_model=EquipmentRateLibrary)
+def get_equipment_rate_library() -> EquipmentRateLibrary:
+    return equipment_rates.get_equipment_rate_library()
+
+
+@router.post("/equipment-rate", response_model=EquipmentRateResult)
+def calculate_equipment_rate(payload: EquipmentRateInput) -> EquipmentRateResult:
+    return equipment_rates.calculate_equipment_rate(payload)
+
+
+@router.post("/client-rate-sheet")
+def generate_client_rate_sheet(payload: ClientRateSheetRequest) -> StreamingResponse:
+    pdf_bytes = equipment_rate_sheet_pdf.render_client_rate_sheet_pdf(payload)
+    headers = {"Content-Disposition": 'attachment; filename="Iron_House_Client_Rate_Sheet.pdf"'}
+    return StreamingResponse(
+        BytesIO(pdf_bytes),
+        media_type="application/pdf",
+        headers=headers,
+    )
 
 
 @router.post("/line-item", response_model=EstimateLineItemCost)

--- a/backend/app/schemas/equipment_rates.py
+++ b/backend/app/schemas/equipment_rates.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import date
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class RegionalMarket(StrEnum):
+    vancouver_metro_west = "vancouver_metro_west"
+    surrey_fraser_valley_east = "surrey_fraser_valley_east"
+
+
+class RateCategory(StrEnum):
+    labour = "labour"
+    equipment = "equipment"
+    attachment = "attachment"
+    support_vehicle_light_equipment = "support_vehicle_light_equipment"
+    trucking_disposal = "trucking_disposal"
+    mobilization_logistics = "mobilization_logistics"
+
+
+class OwnershipBasis(StrEnum):
+    rented = "rented"
+    owned = "owned"
+    subcontracted = "subcontracted"
+
+
+class RateBasis(StrEnum):
+    industry_benchmark = "industry_benchmark"
+    vendor_quote = "vendor_quote"
+    owned_cost_model = "owned_cost_model"
+    contract_rate = "contract_rate"
+
+
+class RentalPeriod(StrEnum):
+    hour = "hour"
+    day = "day"
+    week = "week"
+    month = "month"
+
+
+class ApprovalStatus(StrEnum):
+    draft = "draft"
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
+
+
+class EquipmentBenchmark(BaseModel):
+    rate_category: RateCategory
+    equipment_class: str
+    equipment_description: str
+    base_rate: float | None = Field(default=None, ge=0)
+    operator_included: bool = True
+    source_name: str
+    source_url: str
+    source_effective_date: date
+    price_on_request: bool = False
+
+
+class EquipmentRateInput(BaseModel):
+    regional_market: RegionalMarket
+    rate_category: RateCategory = RateCategory.equipment
+    equipment_class: str = Field(min_length=1)
+    equipment_description: str = Field(min_length=1)
+    ownership_basis: OwnershipBasis = OwnershipBasis.rented
+    rate_basis: RateBasis = RateBasis.vendor_quote
+    operator_included: bool = False
+    base_rate: float = Field(default=0, ge=0)
+    rental_period: RentalPeriod = RentalPeriod.hour
+    included_hours: float = Field(default=1, gt=0)
+    overtime_hour_rate: float = Field(default=0, ge=0)
+    fuel_included: bool = True
+    fuel_cost: float = Field(default=0, ge=0)
+    fuel_surcharge_percent: float = Field(default=0, ge=0)
+    damage_waiver_percent_or_amount: float = Field(default=0, ge=0)
+    damage_waiver_is_percent: bool = True
+    rental_fees: float = Field(default=0, ge=0)
+    attachment_rate: float = Field(default=0, ge=0)
+    delivery_cost: float = Field(default=0, ge=0)
+    pickup_cost: float = Field(default=0, ge=0)
+    cleanup_allowance: float = Field(default=0, ge=0)
+    operator_hourly_cost: float = Field(default=0, ge=0)
+    project_support_hourly_cost: float = Field(default=0, ge=0)
+    mobilization_rate: float = Field(default=0, ge=0)
+    minimum_billable_hours: float = Field(default=4, ge=0)
+    standby_rate: float = Field(default=0, ge=0)
+    target_margin_percent: float = Field(default=10, ge=0, lt=100)
+    market_benchmark_rate: float | None = Field(default=None, ge=0)
+    contract_rate: float | None = Field(default=None, ge=0)
+    source_name: str = ""
+    source_url: str = ""
+    source_effective_date: date | None = None
+    quote_expiry_date: date | None = None
+    override_reason: str | None = None
+    approval_status: ApprovalStatus = ApprovalStatus.draft
+    waive_mobilization: bool = False
+    waive_minimum: bool = False
+    operator_inclusion_changed: bool = False
+
+    @model_validator(mode="after")
+    def validate_period_and_contract(self) -> EquipmentRateInput:
+        if self.rental_period != RentalPeriod.hour and self.included_hours <= 0:
+            raise ValueError("Day, week, and month rates require included_hours.")
+        if self.rate_basis == RateBasis.contract_rate and self.contract_rate is None:
+            raise ValueError("Contract-rate pricing requires contract_rate.")
+        return self
+
+
+class EquipmentRateResult(BaseModel):
+    hourly_base_rate: float
+    hourly_rental_direct_cost: float
+    hourly_all_in_direct_cost: float
+    calculated_client_rate: float
+    selected_client_rate: float
+    minimum_billable_amount: float
+    standby_rate: float
+    operator_labour_to_add: float
+    approval_required: bool
+    approval_reasons: list[str]
+    approval_status: ApprovalStatus
+    source_name: str
+    audit_components: dict[str, float]
+
+
+class EquipmentRateLibrary(BaseModel):
+    regional_markets: list[RegionalMarket]
+    benchmarks: list[EquipmentBenchmark]
+    default_target_margin_percent: float = 10
+    currency: str = "CAD"
+    gst_included: bool = False
+
+
+class ClientRateSheetRequest(BaseModel):
+    title: str = Field(default="Iron House Client Rate Sheet", min_length=1)
+    effective_date: date
+    expiry_date: date
+    regional_market: RegionalMarket
+    lines: list[EquipmentRateInput] = Field(default_factory=list)
+    qualifications: list[str] = Field(default_factory=list)
+    exclusions: list[str] = Field(default_factory=list)

--- a/backend/app/schemas/equipment_rates.py
+++ b/backend/app/schemas/equipment_rates.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 from enum import StrEnum
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class RegionalMarket(StrEnum):
@@ -60,6 +60,8 @@ class EquipmentBenchmark(BaseModel):
 
 
 class EquipmentRateInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     regional_market: RegionalMarket
     rate_category: RateCategory = RateCategory.equipment
     equipment_class: str = Field(min_length=1)
@@ -133,6 +135,8 @@ class EquipmentRateLibrary(BaseModel):
 
 
 class ClientRateSheetRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     title: str = Field(default="Iron House Client Rate Sheet", min_length=1)
     effective_date: date
     expiry_date: date
@@ -140,13 +144,9 @@ class ClientRateSheetRequest(BaseModel):
     lines: list[EquipmentRateInput] = Field(default_factory=list)
     qualifications: list[str] = Field(default_factory=list)
     exclusions: list[str] = Field(default_factory=list)
-    executive_approved: bool = False
-    approval_reference: str | None = None
 
     @model_validator(mode="after")
     def validate_issue_gate(self) -> ClientRateSheetRequest:
         if self.expiry_date < self.effective_date:
             raise ValueError("Rate-sheet expiry cannot precede its effective date.")
-        if self.executive_approved and not (self.approval_reference or "").strip():
-            raise ValueError("Executive approval requires an approval reference.")
         return self

--- a/backend/app/schemas/equipment_rates.py
+++ b/backend/app/schemas/equipment_rates.py
@@ -140,3 +140,13 @@ class ClientRateSheetRequest(BaseModel):
     lines: list[EquipmentRateInput] = Field(default_factory=list)
     qualifications: list[str] = Field(default_factory=list)
     exclusions: list[str] = Field(default_factory=list)
+    executive_approved: bool = False
+    approval_reference: str | None = None
+
+    @model_validator(mode="after")
+    def validate_issue_gate(self) -> ClientRateSheetRequest:
+        if self.expiry_date < self.effective_date:
+            raise ValueError("Rate-sheet expiry cannot precede its effective date.")
+        if self.executive_approved and not (self.approval_reference or "").strip():
+            raise ValueError("Executive approval requires an approval reference.")
+        return self

--- a/backend/app/schemas/estimate.py
+++ b/backend/app/schemas/estimate.py
@@ -2,6 +2,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from app.schemas.equipment_rates import EquipmentRateInput
+
 
 class EstimateItemType(StrEnum):
     self_perform = "self_perform"
@@ -64,6 +66,7 @@ class EquipmentResource(BaseModel):
     hourly_rate: float = Field(default=0, ge=0)
     daily_rate: float | None = Field(default=None, ge=0)
     owned_or_rented: str | None = None
+    rate_input: EquipmentRateInput | None = None
 
 
 class MaterialInput(BaseModel):

--- a/backend/app/services/equipment_rate_sheet_pdf.py
+++ b/backend/app/services/equipment_rate_sheet_pdf.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from textwrap import wrap
+
+from app.core.errors import AppError
+from app.schemas.equipment_rates import ClientRateSheetRequest
+from app.services.equipment_rates import calculate_equipment_rate
+from app.services.flha_pdf import _build_pdf
+
+
+def render_client_rate_sheet_pdf(payload: ClientRateSheetRequest) -> bytes:
+    calculated = [(line, calculate_equipment_rate(line)) for line in payload.lines]
+    blocked = [result for _, result in calculated if result.approval_required]
+    if payload.executive_approved and blocked:
+        raise AppError(
+            "Executive issue is blocked until all rate exceptions are approved.",
+            status_code=409,
+        )
+
+    lines: list[str] = []
+
+    def add(value: str = "") -> None:
+        lines.extend(wrap(str(value), width=96, break_long_words=False) or [""])
+
+    add("IRON HOUSE CONTRACTING LTD.")
+    add(payload.title.upper())
+    if payload.executive_approved:
+        add(f"APPROVED FOR ISSUE - Reference: {payload.approval_reference}")
+    else:
+        add("DRAFT - NOT APPROVED FOR EXTERNAL ISSUE")
+    add(
+        f"Market: {payload.regional_market.value.replace('_', ' ').title()} | "
+        f"Effective: {payload.effective_date} | Expires: {payload.expiry_date}"
+    )
+    add("Currency: CAD | GST excluded unless expressly stated")
+    add()
+
+    order = (
+        "labour",
+        "equipment",
+        "attachment",
+        "support_vehicle_light_equipment",
+        "trucking_disposal",
+        "mobilization_logistics",
+    )
+    for category in order:
+        category_lines = [
+            (source, result)
+            for source, result in calculated
+            if source.rate_category.value == category
+        ]
+        if not category_lines:
+            continue
+        add(category.replace("_", " ").upper())
+        for source, result in category_lines:
+            status = "APPROVAL REQUIRED" if result.approval_required else "READY"
+            operator = (
+                "operator included"
+                if source.operator_included
+                else "operator priced in all-in rate"
+            )
+            add(
+                f"{source.equipment_class} - {source.equipment_description}: "
+                f"${result.selected_client_rate:,.2f}/hr | {operator} | "
+                f"minimum ${result.minimum_billable_amount:,.2f} | "
+                f"standby ${result.standby_rate:,.2f}/hr | {status}"
+            )
+            add(
+                f"  Basis: {source.rate_basis.value.replace('_', ' ')} | "
+                f"Source: {source.source_name or 'not identified'} | "
+                f"Calculated minimum: ${result.calculated_client_rate:,.2f}/hr"
+            )
+            if result.approval_reasons:
+                add(f"  Controls: {', '.join(result.approval_reasons)}")
+        add()
+
+    add("COMMERCIAL TERMS")
+    for term in (
+        "Compact equipment and labour-only service calls carry a 4-hour minimum unless a vendor minimum is greater.",
+        "Heavy equipment, trucking and subcontracted specialty equipment carry an 8-hour minimum unless quoted otherwise.",
+        "Mobilization and demobilization are visible and separate.",
+        "Standby caused by Iron House is not billable. Client-caused standby is billable subject to contract.",
+        "Operator and attachment inclusion are stated per line. Operator labour must not be added twice.",
+        "Fuel surcharge is 0% while the selected benchmark fuel provision is not exceeded.",
+        "Contract, tender or stipulated force-account rates take precedence when approved.",
+        "Parking, congestion, restricted access, permits, ferries, tolls and accommodation are separate.",
+    ):
+        add(f"- {term}")
+
+    if payload.qualifications:
+        add()
+        add("QUALIFICATIONS")
+        for item in payload.qualifications:
+            add(f"- {item}")
+    if payload.exclusions:
+        add()
+        add("EXCLUSIONS")
+        for item in payload.exclusions:
+            add(f"- {item}")
+
+    pages = [lines[index : index + 52] for index in range(0, len(lines), 52)] or [[""]]
+    return _build_pdf(pages)

--- a/backend/app/services/equipment_rate_sheet_pdf.py
+++ b/backend/app/services/equipment_rate_sheet_pdf.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from textwrap import wrap
 
-from app.core.errors import AppError
 from app.schemas.equipment_rates import ClientRateSheetRequest
 from app.services.equipment_rates import calculate_equipment_rate
 from app.services.flha_pdf import _build_pdf
@@ -10,13 +9,6 @@ from app.services.flha_pdf import _build_pdf
 
 def render_client_rate_sheet_pdf(payload: ClientRateSheetRequest) -> bytes:
     calculated = [(line, calculate_equipment_rate(line)) for line in payload.lines]
-    blocked = [result for _, result in calculated if result.approval_required]
-    if payload.executive_approved and blocked:
-        raise AppError(
-            "Executive issue is blocked until all rate exceptions are approved.",
-            status_code=409,
-        )
-
     lines: list[str] = []
 
     def add(value: str = "") -> None:
@@ -24,10 +16,7 @@ def render_client_rate_sheet_pdf(payload: ClientRateSheetRequest) -> bytes:
 
     add("IRON HOUSE CONTRACTING LTD.")
     add(payload.title.upper())
-    if payload.executive_approved:
-        add(f"APPROVED FOR ISSUE - Reference: {payload.approval_reference}")
-    else:
-        add("DRAFT - NOT APPROVED FOR EXTERNAL ISSUE")
+    add("DRAFT - NOT APPROVED FOR EXTERNAL ISSUE")
     add(
         f"Market: {payload.regional_market.value.replace('_', ' ').title()} | "
         f"Effective: {payload.effective_date} | Expires: {payload.expiry_date}"

--- a/backend/app/services/equipment_rates.py
+++ b/backend/app/services/equipment_rates.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from datetime import date
+
+from app.schemas.equipment_rates import (
+    ApprovalStatus,
+    EquipmentBenchmark,
+    EquipmentRateInput,
+    EquipmentRateLibrary,
+    EquipmentRateResult,
+    RateBasis,
+    RateCategory,
+    RegionalMarket,
+    RentalPeriod,
+)
+
+_SOURCE_NAME = "IEOA 2026 Suggested Equipment Rates"
+_SOURCE_URL = "https://www.ieoa.ca/rates/"
+_SOURCE_DATE = date(2026, 1, 1)
+
+_EQUIPMENT_ROWS: tuple[tuple[str, str, float], ...] = (
+    ("Excavator", "1.4-2.75 t", 142),
+    ("Excavator", "2.75-4 t", 163),
+    ("Excavator", "4-6 t", 169),
+    ("Excavator", "6-9.5 t", 180),
+    ("Excavator", "9.5-14 t", 193),
+    ("Excavator", "14-19 t", 205),
+    ("Excavator", "20-23 t", 228),
+    ("Excavator", "23-26 t", 248),
+    ("Excavator", "26-30 t", 257),
+    ("Excavator", "30-36 t", 287),
+    ("Skid steer", "Under 1,000 lb operating load", 112),
+    ("Skid steer", "1,000-2,000 lb operating load", 124),
+    ("Skid steer", "2,000-3,200 lb operating load", 143),
+    ("Compact track loader", "Under 1,100 lb operating load", 121),
+    ("Compact track loader", "1,100-2,230 lb operating load", 146),
+    ("Compact track loader", "2,230-3,000 lb operating load", 151),
+    ("Compact track loader", "3,000-3,225 lb operating load", 154),
+    ("Loader/backhoe", "80-100 HP extendahoe", 165),
+    ("Loader/backhoe", "100-108 HP extendahoe", 187),
+    ("Bulldozer", "Under 80 HP", 195),
+    ("Bulldozer", "80-125 HP", 228),
+    ("Bulldozer", "125-220 HP", 282),
+    ("Wheel loader", "Under 1.75 yd3", 184),
+    ("Wheel loader", "2-2.5 yd3", 205),
+    ("Wheel loader", "3 yd3", 249),
+    ("Vibratory compactor", "Up to 4.9 t", 184),
+    ("Vibratory compactor", "5-7.9 t", 195),
+    ("Vibratory compactor", "8-11.9 t", 219),
+    ("Grader", "Under 80 HP", 184),
+    ("Grader", "85-90 HP", 205),
+    ("Grader", "125-135 HP", 219),
+    ("Grader", "135-150 HP", 249),
+    ("Dump truck", "Single axle, 7-8 t", 141),
+    ("Dump truck", "Tandem, 13-14 t", 165),
+    ("Dump truck", "Tridem, 20 t", 175),
+    ("Dump truck", "Tandem and pup, 25-27 t", 219),
+    ("Dump truck", "Tandem and tri-axle pup, 29-31 t", 228),
+    ("Off-road rock truck", "20 ton", 231),
+    ("Off-road rock truck", "25 ton", 249),
+    ("Off-road rock truck", "30 ton", 266),
+    ("Slinger truck", "Tandem, 13-14 t", 205),
+    ("Slinger truck", "Tridem, 20 t", 213),
+    ("Lowbed with tandem tractor", "20 ton", 179),
+    ("Lowbed with tandem tractor", "30 ton", 184),
+    ("Lowbed with tandem tractor", "40 ton", 202),
+)
+
+_ATTACHMENT_ROWS: tuple[tuple[str, str, float], ...] = (
+    ("Hydraulic hammer", "Approx. 13,000 lb excavator", 109),
+    ("Hydraulic hammer", "Approx. 22,000 lb excavator", 128),
+    ("Hydraulic hammer", "Approx. 25,000 lb excavator", 143),
+    ("Hydraulic hammer", "Approx. 38,000 lb excavator", 155),
+    ("Hydraulic hammer", "Approx. 45,000 lb excavator", 174),
+    ("Compactor attachment", "5 t excavator or rubber-tired backhoe", 47),
+    ("Compactor attachment", "7-10 t excavator", 58),
+    ("Compactor attachment", "20 t excavator", 79),
+)
+
+
+def get_equipment_rate_library() -> EquipmentRateLibrary:
+    benchmarks = [
+        EquipmentBenchmark(
+            rate_category=RateCategory.equipment,
+            equipment_class=category,
+            equipment_description=description,
+            base_rate=rate,
+            source_name=_SOURCE_NAME,
+            source_url=_SOURCE_URL,
+            source_effective_date=_SOURCE_DATE,
+        )
+        for category, description, rate in _EQUIPMENT_ROWS
+    ]
+    benchmarks.extend(
+        EquipmentBenchmark(
+            rate_category=RateCategory.attachment,
+            equipment_class=category,
+            equipment_description=description,
+            base_rate=rate,
+            operator_included=False,
+            source_name=_SOURCE_NAME,
+            source_url=_SOURCE_URL,
+            source_effective_date=_SOURCE_DATE,
+        )
+        for category, description, rate in _ATTACHMENT_ROWS
+    )
+    for category, description in (
+        ("Excavator", "Over 36 t"),
+        ("Bulldozer", "Over 290 HP"),
+        ("Wheel loader", "Over 6 yd3"),
+        ("Vibratory compactor", "Over 12 t"),
+        ("Lowbed", "Over 50 t"),
+        ("Specialized crane", "Vendor-priced class"),
+    ):
+        benchmarks.append(
+            EquipmentBenchmark(
+                rate_category=RateCategory.equipment,
+                equipment_class=category,
+                equipment_description=description,
+                base_rate=None,
+                source_name=_SOURCE_NAME,
+                source_url=_SOURCE_URL,
+                source_effective_date=_SOURCE_DATE,
+                price_on_request=True,
+            )
+        )
+    return EquipmentRateLibrary(
+        regional_markets=list(RegionalMarket),
+        benchmarks=benchmarks,
+    )
+
+
+def calculate_equipment_rate(
+    payload: EquipmentRateInput,
+    *,
+    as_of: date | None = None,
+) -> EquipmentRateResult:
+    current_date = as_of or date.today()
+    divisor = payload.included_hours if payload.rental_period != RentalPeriod.hour else 1
+    base_period_cost = payload.base_rate
+    waiver = (
+        base_period_cost * payload.damage_waiver_percent_or_amount / 100
+        if payload.damage_waiver_is_percent
+        else payload.damage_waiver_percent_or_amount
+    )
+    surcharge = base_period_cost * payload.fuel_surcharge_percent / 100
+    allocated_period_cost = (
+        base_period_cost
+        + waiver
+        + payload.rental_fees
+        + payload.fuel_cost
+        + surcharge
+        + payload.delivery_cost
+        + payload.pickup_cost
+        + payload.cleanup_allowance
+    )
+    hourly_base_rate = base_period_cost / divisor
+    hourly_rental_direct_cost = allocated_period_cost / divisor + payload.attachment_rate
+    operator_cost = 0 if payload.operator_included else payload.operator_hourly_cost
+    hourly_all_in_direct_cost = (
+        hourly_rental_direct_cost + operator_cost + payload.project_support_hourly_cost
+    )
+    calculated_client_rate = hourly_all_in_direct_cost / (
+        1 - payload.target_margin_percent / 100
+    )
+    benchmark = payload.market_benchmark_rate or 0
+    if payload.rate_basis == RateBasis.contract_rate:
+        selected_client_rate = payload.contract_rate or 0
+    else:
+        selected_client_rate = max(benchmark, calculated_client_rate)
+
+    reasons = _approval_reasons(
+        payload,
+        selected_client_rate=selected_client_rate,
+        benchmark=benchmark,
+        current_date=current_date,
+    )
+    approval_required = bool(reasons) and payload.approval_status != ApprovalStatus.approved
+    minimum_billable_amount = (
+        0 if payload.waive_minimum else selected_client_rate * payload.minimum_billable_hours
+    )
+    components = {
+        "base_rate": base_period_cost,
+        "damage_waiver": waiver,
+        "rental_fees": payload.rental_fees,
+        "fuel": payload.fuel_cost,
+        "fuel_surcharge": surcharge,
+        "attachment_hourly": payload.attachment_rate,
+        "delivery": payload.delivery_cost,
+        "pickup": payload.pickup_cost,
+        "cleanup": payload.cleanup_allowance,
+        "operator_hourly": operator_cost,
+        "support_hourly": payload.project_support_hourly_cost,
+        "mobilization": 0 if payload.waive_mobilization else payload.mobilization_rate,
+    }
+    return EquipmentRateResult(
+        hourly_base_rate=_money(hourly_base_rate),
+        hourly_rental_direct_cost=_money(hourly_rental_direct_cost),
+        hourly_all_in_direct_cost=_money(hourly_all_in_direct_cost),
+        calculated_client_rate=_money(calculated_client_rate),
+        selected_client_rate=_money(selected_client_rate),
+        minimum_billable_amount=_money(minimum_billable_amount),
+        standby_rate=_money(payload.standby_rate),
+        operator_labour_to_add=0,
+        approval_required=approval_required,
+        approval_reasons=reasons,
+        approval_status=payload.approval_status,
+        source_name=payload.source_name,
+        audit_components={key: _money(value) for key, value in components.items()},
+    )
+
+
+def _approval_reasons(
+    payload: EquipmentRateInput,
+    *,
+    selected_client_rate: float,
+    benchmark: float,
+    current_date: date,
+) -> list[str]:
+    reasons: list[str] = []
+    if benchmark and selected_client_rate < benchmark:
+        reasons.append("selected_rate_below_benchmark")
+    if payload.target_margin_percent < 10:
+        reasons.append("margin_below_10_percent")
+    if payload.waive_mobilization:
+        reasons.append("mobilization_waived")
+    if payload.waive_minimum:
+        reasons.append("minimum_charge_waived")
+    if payload.operator_inclusion_changed:
+        reasons.append("operator_inclusion_changed")
+    if payload.quote_expiry_date and payload.quote_expiry_date < current_date:
+        reasons.append("vendor_quote_expired")
+    if not payload.source_name.strip() or not payload.equipment_class.strip():
+        reasons.append("source_or_class_missing")
+    if reasons and not (payload.override_reason or "").strip():
+        reasons.append("override_reason_required")
+    return reasons
+
+
+def _money(value: float) -> float:
+    return round(value + 1e-9, 2)

--- a/backend/app/services/equipment_rates.py
+++ b/backend/app/services/equipment_rates.py
@@ -175,7 +175,10 @@ def calculate_equipment_rate(
         benchmark=benchmark,
         current_date=current_date,
     )
-    approval_required = bool(reasons) and payload.approval_status != ApprovalStatus.approved
+    approval_required = bool(reasons) and (
+        payload.approval_status != ApprovalStatus.approved
+        or "override_reason_required" in reasons
+    )
     minimum_billable_amount = (
         0 if payload.waive_minimum else selected_client_rate * payload.minimum_billable_hours
     )
@@ -186,6 +189,7 @@ def calculate_equipment_rate(
         "fuel": payload.fuel_cost,
         "fuel_surcharge": surcharge,
         "attachment_hourly": payload.attachment_rate,
+        "overtime_hour_rate": payload.overtime_hour_rate,
         "delivery": payload.delivery_cost,
         "pickup": payload.pickup_cost,
         "cleanup": payload.cleanup_allowance,

--- a/backend/app/services/estimate_workbooks.py
+++ b/backend/app/services/estimate_workbooks.py
@@ -8,6 +8,7 @@ from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
 from openpyxl.worksheet.worksheet import Worksheet
 
 from app.schemas.estimate import EstimateCreate, EstimateSummary
+from app.services.equipment_rates import get_equipment_rate_library
 from app.services.estimates import calculate_estimate, get_rate_library
 
 TITLE_FILL = "1F4E79"
@@ -28,6 +29,7 @@ def build_estimate_workbook(payload: EstimateCreate) -> bytes:
     _build_summary_sheet(workbook, summary)
     _build_line_items_sheet(workbook, summary)
     _build_production_rates_sheet(workbook)
+    _build_equipment_rates_sheet(workbook)
     _build_markups_sheet(workbook, payload, summary)
     _build_risks_sheet(workbook, payload)
     _build_assumptions_sheet(workbook, summary)
@@ -188,6 +190,43 @@ def _build_production_rates_sheet(workbook: Workbook) -> None:
     _apply_borders(sheet, 3, 1, len(get_rate_library().production_rates) + 3, len(headers))
     _set_widths(sheet, {"A": 24, "B": 42, "C": 10, "D": 16, "E": 44, "F": 44, "G": 42})
 
+
+
+def _build_equipment_rates_sheet(workbook: Workbook) -> None:
+    sheet = workbook.create_sheet("Equipment Rates")
+    _title(sheet, "Approved Equipment and Attachment Rate Library")
+    headers = [
+        "Category",
+        "Class",
+        "Description",
+        "Client Benchmark",
+        "Operator Included",
+        "Source",
+        "Effective Date",
+    ]
+    _write_headers(sheet, headers, row=3)
+    library = get_equipment_rate_library()
+    for row_index, rate in enumerate(library.benchmarks, start=4):
+        _write_row(
+            sheet,
+            row_index,
+            [
+                rate.rate_category.value,
+                rate.equipment_class,
+                rate.equipment_description,
+                "Price on Request" if rate.price_on_request else rate.base_rate,
+                "Yes" if rate.operator_included else "No",
+                rate.source_name,
+                rate.source_effective_date.isoformat(),
+            ],
+        )
+        if rate.base_rate is not None:
+            sheet.cell(row=row_index, column=4).number_format = MONEY_FORMAT
+    _apply_borders(sheet, 3, 1, len(library.benchmarks) + 3, len(headers))
+    _set_widths(
+        sheet,
+        {"A": 20, "B": 28, "C": 42, "D": 20, "E": 18, "F": 34, "G": 18},
+    )
 
 def _build_markups_sheet(workbook: Workbook, payload: EstimateCreate, summary: EstimateSummary) -> None:
     sheet = workbook.create_sheet("Markups")

--- a/backend/app/services/estimates.py
+++ b/backend/app/services/estimates.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from app.services.equipment_rates import calculate_equipment_rate
+
 from app.schemas.estimate import (
     DefaultProductionActivity,
     EquipmentResource,
@@ -273,11 +275,31 @@ def calculate_estimate(payload: EstimateCreate) -> EstimateSummary:
 def calculate_line_item(item: EstimateLineItem) -> EstimateLineItemCost:
     item = _apply_default_rate(item)
     hours = _calculate_hours(item)
+    has_all_in_equipment_rate = any(
+        resource.rate_input is not None
+        and (
+            resource.rate_input.operator_included
+            or resource.rate_input.operator_hourly_cost > 0
+        )
+        for resource in item.equipment
+    )
     labour_cost = sum(
-        member.quantity * member.burdened_hourly_rate * hours for member in item.labour
+        member.quantity * member.burdened_hourly_rate * hours
+        for member in item.labour
+        if not (
+            has_all_in_equipment_rate
+            and "operator" in member.role.casefold()
+        )
     )
     equipment_cost = sum(
-        resource.quantity * resource.hourly_rate * hours for resource in item.equipment
+        resource.quantity
+        * (
+            calculate_equipment_rate(resource.rate_input).hourly_all_in_direct_cost
+            if resource.rate_input is not None
+            else resource.hourly_rate
+        )
+        * hours
+        for resource in item.equipment
     )
     material_cost = sum(
         material.quantity * material.unit_cost * (1 + material.waste_percent / 100)

--- a/frontend/e2e/media-viewer.spec.ts
+++ b/frontend/e2e/media-viewer.spec.ts
@@ -102,6 +102,19 @@ async function mockMediaApi(page: Page) {
       await route.fulfill({ status: 200, json: { role: "admin", modules: { equipment: ["read", "write"], media: ["read", "write"] } } });
       return;
     }
+    if (path.endsWith("/estimates/equipment-rate-library")) {
+      await route.fulfill({
+        status: 200,
+        json: {
+          regional_markets: ["vancouver_metro_west", "surrey_fraser_valley_east"],
+          benchmarks: [],
+          default_target_margin_percent: 10,
+          currency: "CAD",
+          gst_included: false,
+        },
+      });
+      return;
+    }
     if (path.endsWith("/equipment")) {
       await route.fulfill({
         status: 200,

--- a/frontend/e2e/release-gate.spec.ts
+++ b/frontend/e2e/release-gate.spec.ts
@@ -127,6 +127,19 @@ async function mockApi(page: Page) {
       await route.fulfill({ status: 200, json: { items: [], total: 0 } });
       return;
     }
+    if (path.endsWith("/estimates/equipment-rate-library")) {
+      await route.fulfill({
+        status: 200,
+        json: {
+          regional_markets: ["vancouver_metro_west", "surrey_fraser_valley_east"],
+          benchmarks: [],
+          default_target_margin_percent: 10,
+          currency: "CAD",
+          gst_included: false,
+        },
+      });
+      return;
+    }
     if (path.endsWith("/estimates/rate-library")) {
       await route.fulfill({ status: 200, json: { production_rates: [] } });
       return;

--- a/frontend/src/api/equipmentRates.ts
+++ b/frontend/src/api/equipmentRates.ts
@@ -1,0 +1,130 @@
+import { apiFetch } from "./client";
+
+export type RegionalMarket = "vancouver_metro_west" | "surrey_fraser_valley_east";
+export type RateCategory =
+  | "labour"
+  | "equipment"
+  | "attachment"
+  | "support_vehicle_light_equipment"
+  | "trucking_disposal"
+  | "mobilization_logistics";
+export type RentalPeriod = "hour" | "day" | "week" | "month";
+
+export type EquipmentBenchmark = {
+  rate_category: RateCategory;
+  equipment_class: string;
+  equipment_description: string;
+  base_rate: number | null;
+  operator_included: boolean;
+  source_name: string;
+  source_url: string;
+  source_effective_date: string;
+  price_on_request: boolean;
+};
+
+export type EquipmentRateLibrary = {
+  regional_markets: RegionalMarket[];
+  benchmarks: EquipmentBenchmark[];
+  default_target_margin_percent: number;
+  currency: string;
+  gst_included: boolean;
+};
+
+export type EquipmentRateInput = {
+  regional_market: RegionalMarket;
+  rate_category: RateCategory;
+  equipment_class: string;
+  equipment_description: string;
+  ownership_basis: "rented" | "owned" | "subcontracted";
+  rate_basis: "industry_benchmark" | "vendor_quote" | "owned_cost_model" | "contract_rate";
+  operator_included: boolean;
+  base_rate: number;
+  rental_period: RentalPeriod;
+  included_hours: number;
+  overtime_hour_rate?: number;
+  fuel_included?: boolean;
+  fuel_cost?: number;
+  fuel_surcharge_percent?: number;
+  damage_waiver_percent_or_amount?: number;
+  damage_waiver_is_percent?: boolean;
+  rental_fees?: number;
+  attachment_rate?: number;
+  delivery_cost?: number;
+  pickup_cost?: number;
+  cleanup_allowance?: number;
+  operator_hourly_cost?: number;
+  project_support_hourly_cost?: number;
+  mobilization_rate?: number;
+  minimum_billable_hours?: number;
+  standby_rate?: number;
+  target_margin_percent: number;
+  market_benchmark_rate?: number | null;
+  contract_rate?: number | null;
+  source_name: string;
+  source_url?: string;
+  source_effective_date?: string | null;
+  quote_expiry_date?: string | null;
+  override_reason?: string | null;
+  approval_status?: "draft" | "pending" | "approved" | "rejected";
+  waive_mobilization?: boolean;
+  waive_minimum?: boolean;
+  operator_inclusion_changed?: boolean;
+};
+
+export type EquipmentRateResult = {
+  hourly_base_rate: number;
+  hourly_rental_direct_cost: number;
+  hourly_all_in_direct_cost: number;
+  calculated_client_rate: number;
+  selected_client_rate: number;
+  minimum_billable_amount: number;
+  standby_rate: number;
+  operator_labour_to_add: number;
+  approval_required: boolean;
+  approval_reasons: string[];
+  approval_status: string;
+  source_name: string;
+  audit_components: Record<string, number>;
+};
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const response = await apiFetch(`${API_BASE_URL}${path}`, options);
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null) as { detail?: string } | null;
+    throw new Error(payload?.detail ?? `Request failed with ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export const equipmentRatesApi = {
+  library: () => request<EquipmentRateLibrary>("/estimates/equipment-rate-library"),
+  calculate: (payload: EquipmentRateInput) => request<EquipmentRateResult>(
+    "/estimates/equipment-rate",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  ),
+  exportDraft: async (payload: EquipmentRateInput) => {
+    const effective = new Date();
+    const expiry = new Date(effective);
+    expiry.setDate(expiry.getDate() + 30);
+    const response = await apiFetch(`${API_BASE_URL}/estimates/client-rate-sheet`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Iron House Client Rate Sheet",
+        effective_date: effective.toISOString().slice(0, 10),
+        expiry_date: expiry.toISOString().slice(0, 10),
+        regional_market: payload.regional_market,
+        lines: [payload],
+        executive_approved: false,
+      }),
+    });
+    if (!response.ok) throw new Error("Unable to export draft rate sheet");
+    return response.blob();
+  },
+};

--- a/frontend/src/api/equipmentRates.ts
+++ b/frontend/src/api/equipmentRates.ts
@@ -121,7 +121,6 @@ export const equipmentRatesApi = {
         expiry_date: expiry.toISOString().slice(0, 10),
         regional_market: payload.regional_market,
         lines: [payload],
-        executive_approved: false,
       }),
     });
     if (!response.ok) throw new Error("Unable to export draft rate sheet");

--- a/frontend/src/components/EquipmentRateLibraryPanel.test.tsx
+++ b/frontend/src/components/EquipmentRateLibraryPanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { equipmentRatesApi } from "../api/equipmentRates";
+import { EquipmentRateLibraryPanel } from "./EquipmentRateLibraryPanel";
+
+vi.mock("../api/equipmentRates", () => ({
+  equipmentRatesApi: {
+    library: vi.fn(),
+    calculate: vi.fn(),
+    exportDraft: vi.fn(),
+  },
+}));
+
+describe("EquipmentRateLibraryPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(equipmentRatesApi.library).mockResolvedValue({
+      regional_markets: ["vancouver_metro_west", "surrey_fraser_valley_east"],
+      benchmarks: [{
+        rate_category: "equipment",
+        equipment_class: "Excavator",
+        equipment_description: "20-23 t",
+        base_rate: 228,
+        operator_included: true,
+        source_name: "IEOA 2026 Suggested Equipment Rates",
+        source_url: "https://www.ieoa.ca/rates/",
+        source_effective_date: "2026-01-01",
+        price_on_request: false,
+      }],
+      default_target_margin_percent: 10,
+      currency: "CAD",
+      gst_included: false,
+    });
+  });
+
+  it("converts a vendor period and displays the controlled selected rate", async () => {
+    const user = userEvent.setup();
+    vi.mocked(equipmentRatesApi.calculate).mockResolvedValue({
+      hourly_base_rate: 100,
+      hourly_rental_direct_cost: 100,
+      hourly_all_in_direct_cost: 150,
+      calculated_client_rate: 166.67,
+      selected_client_rate: 228,
+      minimum_billable_amount: 912,
+      standby_rate: 0,
+      operator_labour_to_add: 0,
+      approval_required: false,
+      approval_reasons: [],
+      approval_status: "draft",
+      source_name: "Vendor quote",
+      audit_components: {},
+    });
+
+    render(<EquipmentRateLibraryPanel />);
+    await user.selectOptions(await screen.findByLabelText("Equipment class"), "0");
+    await user.type(screen.getByLabelText("Vendor base rental"), "800");
+    await user.type(screen.getByLabelText("Operator hourly direct cost"), "50");
+    await user.type(screen.getByLabelText("Vendor/source name"), "Vendor quote");
+    await user.click(screen.getByRole("button", { name: "Calculate controlled rate" }));
+
+    expect(equipmentRatesApi.calculate).toHaveBeenCalledWith(expect.objectContaining({
+      base_rate: 800,
+      included_hours: 8,
+      operator_hourly_cost: 50,
+      market_benchmark_rate: 228,
+      target_margin_percent: 10,
+    }));
+    expect(await screen.findByText("$228.00/hr")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /export draft pdf/i })).toBeEnabled();
+  });
+});

--- a/frontend/src/components/EquipmentRateLibraryPanel.tsx
+++ b/frontend/src/components/EquipmentRateLibraryPanel.tsx
@@ -1,0 +1,158 @@
+import { Calculator, Download } from "lucide-react";
+import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
+
+import {
+  EquipmentBenchmark,
+  EquipmentRateInput,
+  EquipmentRateLibrary,
+  EquipmentRateResult,
+  RegionalMarket,
+  RentalPeriod,
+  equipmentRatesApi,
+} from "../api/equipmentRates";
+
+const money = new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" });
+
+export function EquipmentRateLibraryPanel() {
+  const [library, setLibrary] = useState<EquipmentRateLibrary | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState("");
+  const [market, setMarket] = useState<RegionalMarket>("surrey_fraser_valley_east");
+  const [period, setPeriod] = useState<RentalPeriod>("day");
+  const [baseRate, setBaseRate] = useState("");
+  const [includedHours, setIncludedHours] = useState("8");
+  const [operatorCost, setOperatorCost] = useState("");
+  const [sourceName, setSourceName] = useState("");
+  const [result, setResult] = useState<EquipmentRateResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    equipmentRatesApi.library()
+      .then(setLibrary)
+      .catch((current) => setError(current instanceof Error ? current.message : "Unable to load rate library"));
+  }, []);
+
+  const benchmark = useMemo<EquipmentBenchmark | null>(() => {
+    if (!library || selectedIndex === "") return null;
+    return library.benchmarks[Number(selectedIndex)] ?? null;
+  }, [library, selectedIndex]);
+
+  function payload(): EquipmentRateInput | null {
+    if (!benchmark || !baseRate || !sourceName.trim()) return null;
+    return {
+      regional_market: market,
+      rate_category: benchmark.rate_category,
+      equipment_class: benchmark.equipment_class,
+      equipment_description: benchmark.equipment_description,
+      ownership_basis: "rented",
+      rate_basis: "vendor_quote",
+      operator_included: false,
+      base_rate: Number(baseRate),
+      rental_period: period,
+      included_hours: period === "hour" ? 1 : Number(includedHours),
+      operator_hourly_cost: Number(operatorCost || 0),
+      target_margin_percent: library?.default_target_margin_percent ?? 10,
+      market_benchmark_rate: benchmark.base_rate,
+      fuel_surcharge_percent: 0,
+      source_name: sourceName.trim(),
+    };
+  }
+
+  async function calculate(event: FormEvent) {
+    event.preventDefault();
+    const input = payload();
+    if (!input) return;
+    setBusy(true);
+    setError(null);
+    try {
+      setResult(await equipmentRatesApi.calculate(input));
+    } catch (current) {
+      setError(current instanceof Error ? current.message : "Unable to calculate rate");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function exportDraft() {
+    const input = payload();
+    if (!input) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const blob = await equipmentRatesApi.exportDraft(input);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "Iron_House_Client_Rate_Sheet_DRAFT.pdf";
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (current) {
+      setError(current instanceof Error ? current.message : "Unable to export draft rate sheet");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-md border border-iron-100 bg-white p-5" aria-labelledby="equipment-rate-heading">
+      <div className="flex items-center gap-2">
+        <Calculator className="h-4 w-4" />
+        <h2 id="equipment-rate-heading" className="text-base font-semibold">Equipment and client rate library</h2>
+      </div>
+      <p className="mt-1 text-sm text-iron-500">
+        Convert vendor rental periods to an auditable hourly cost, apply final margin, and compare it with the approved benchmark.
+      </p>
+      {error ? <div role="alert" className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
+      <form onSubmit={calculate} className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <Select label="Regional market" value={market} onChange={(value) => setMarket(value as RegionalMarket)}>
+          <option value="surrey_fraser_valley_east">Surrey / Fraser Valley East</option>
+          <option value="vancouver_metro_west">Vancouver / Metro West</option>
+        </Select>
+        <Select label="Equipment class" value={selectedIndex} onChange={setSelectedIndex} required>
+          <option value="">Select approved benchmark</option>
+          {library?.benchmarks.map((item, index) => (
+            <option key={`${item.rate_category}-${item.equipment_class}-${item.equipment_description}`} value={index}>
+              {item.equipment_class} — {item.equipment_description}{item.base_rate == null ? " — price on request" : ` — ${money.format(item.base_rate)}/hr`}
+            </option>
+          ))}
+        </Select>
+        <Select label="Vendor rental period" value={period} onChange={(value) => setPeriod(value as RentalPeriod)}>
+          <option value="hour">Hour</option><option value="day">Day</option><option value="week">Week</option><option value="month">Month</option>
+        </Select>
+        <NumberInput label="Vendor base rental" value={baseRate} onChange={setBaseRate} required />
+        <NumberInput label="Included hours" value={period === "hour" ? "1" : includedHours} onChange={setIncludedHours} disabled={period === "hour"} required />
+        <NumberInput label="Operator hourly direct cost" value={operatorCost} onChange={setOperatorCost} />
+        <label className="grid gap-1 text-sm md:col-span-2 xl:col-span-3">
+          <span className="font-medium text-iron-700">Vendor/source name</span>
+          <input required value={sourceName} onChange={(event) => setSourceName(event.target.value)} className="rounded-md border border-iron-100 px-3 py-2" />
+        </label>
+        <div className="flex flex-wrap gap-2 md:col-span-2 xl:col-span-3">
+          <button disabled={busy} type="submit" className="rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">Calculate controlled rate</button>
+          <button disabled={busy || !result} type="button" onClick={() => void exportDraft()} className="inline-flex items-center gap-2 rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold disabled:opacity-50"><Download className="h-4 w-4" /> Export draft PDF</button>
+        </div>
+      </form>
+      {result ? (
+        <div className="mt-5 grid gap-3 rounded-md bg-iron-50 p-4 sm:grid-cols-2 lg:grid-cols-4">
+          <Result label="Hourly direct cost" value={money.format(result.hourly_all_in_direct_cost)} />
+          <Result label="Calculated minimum" value={`${money.format(result.calculated_client_rate)}/hr`} />
+          <Result label="Selected client rate" value={`${money.format(result.selected_client_rate)}/hr`} />
+          <Result label="Minimum billable" value={money.format(result.minimum_billable_amount)} />
+          {result.approval_required ? <div role="alert" className="sm:col-span-2 lg:col-span-4 text-sm font-semibold text-amber-800">Approval required: {result.approval_reasons.join(", ").replaceAll("_", " ")}</div> : null}
+        </div>
+      ) : null}
+      <p className="mt-4 text-xs text-iron-500">Exports remain marked DRAFT until executive approval is recorded. Vancouver logistics and access premiums remain separate estimate lines.</p>
+    </section>
+  );
+}
+
+function Select({ label, value, onChange, required = false, children }: { label: string; value: string; onChange: (value: string) => void; required?: boolean; children: ReactNode }) {
+  return <label className="grid gap-1 text-sm"><span className="font-medium text-iron-700">{label}</span><select required={required} value={value} onChange={(event) => onChange(event.target.value)} className="rounded-md border border-iron-100 px-3 py-2">{children}</select></label>;
+}
+
+function NumberInput({ label, value, onChange, required = false, disabled = false }: { label: string; value: string; onChange: (value: string) => void; required?: boolean; disabled?: boolean }) {
+  return <label className="grid gap-1 text-sm"><span className="font-medium text-iron-700">{label}</span><input type="number" min="0" step="0.01" required={required} disabled={disabled} value={value} onChange={(event) => onChange(event.target.value)} className="rounded-md border border-iron-100 px-3 py-2 disabled:bg-iron-50" /></label>;
+}
+
+function Result({ label, value }: { label: string; value: string }) {
+  return <div><div className="text-xs font-semibold uppercase tracking-wide text-iron-500">{label}</div><div className="mt-1 font-semibold text-iron-950">{value}</div></div>;
+}

--- a/frontend/src/pages/EquipmentPage.tsx
+++ b/frontend/src/pages/EquipmentPage.tsx
@@ -1,6 +1,7 @@
 import { Plus, RefreshCw, Truck } from "lucide-react";
 import { FormEvent, useCallback, useEffect, useState } from "react";
 
+import { EquipmentRateLibraryPanel } from "../components/EquipmentRateLibraryPanel";
 import { UniversalPhotoField } from "../components/UniversalPhotoField";
 
 import {
@@ -70,6 +71,8 @@ export function EquipmentPage() {
       {error ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div> : null}
 
       <CreateEquipmentForm onSubmit={create} />
+
+      <EquipmentRateLibraryPanel />
 
       <div className="rounded-md border border-iron-100 bg-white p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/tests/backend/test_equipment_rates.py
+++ b/tests/backend/test_equipment_rates.py
@@ -1,0 +1,163 @@
+from datetime import date
+
+import pytest
+
+from app.schemas.equipment_rates import (
+    ApprovalStatus,
+    EquipmentRateInput,
+    RateBasis,
+    RateCategory,
+    RegionalMarket,
+    RentalPeriod,
+)
+from app.services.equipment_rates import calculate_equipment_rate, get_equipment_rate_library
+
+
+def rate_input(**overrides) -> EquipmentRateInput:
+    values = {
+        "regional_market": RegionalMarket.surrey_fraser_valley_east,
+        "rate_category": RateCategory.equipment,
+        "equipment_class": "Excavator",
+        "equipment_description": "20-23 t",
+        "base_rate": 800,
+        "rental_period": RentalPeriod.day,
+        "included_hours": 8,
+        "operator_hourly_cost": 50,
+        "market_benchmark_rate": 228,
+        "source_name": "Current vendor quote",
+        "source_url": "https://vendor.example/quote",
+        "target_margin_percent": 10,
+    }
+    values.update(overrides)
+    return EquipmentRateInput(**values)
+
+
+def test_library_uses_one_benchmark_set_for_both_markets() -> None:
+    library = get_equipment_rate_library()
+
+    assert library.regional_markets == [
+        RegionalMarket.vancouver_metro_west,
+        RegionalMarket.surrey_fraser_valley_east,
+    ]
+    assert len(library.benchmarks) == 59
+    excavator = next(
+        item
+        for item in library.benchmarks
+        if item.equipment_class == "Excavator"
+        and item.equipment_description == "20-23 t"
+    )
+    assert excavator.base_rate == 228
+    assert excavator.operator_included is True
+
+
+def test_period_conversion_uses_included_hours_and_margin_not_markup() -> None:
+    result = calculate_equipment_rate(rate_input(market_benchmark_rate=0))
+
+    assert result.hourly_base_rate == 100
+    assert result.hourly_all_in_direct_cost == 150
+    assert result.calculated_client_rate == 166.67
+    assert result.selected_client_rate == 166.67
+
+
+def test_selects_greater_of_benchmark_or_calculated_minimum() -> None:
+    result = calculate_equipment_rate(rate_input())
+
+    assert result.calculated_client_rate == 166.67
+    assert result.selected_client_rate == 228
+
+
+def test_operator_inclusion_prevents_double_counting() -> None:
+    result = calculate_equipment_rate(
+        rate_input(
+            operator_included=True,
+            operator_hourly_cost=75,
+            market_benchmark_rate=0,
+        )
+    )
+
+    assert result.hourly_all_in_direct_cost == 100
+    assert result.operator_labour_to_add == 0
+
+
+def test_zero_fuel_surcharge_and_attachment_are_auditable() -> None:
+    result = calculate_equipment_rate(
+        rate_input(
+            base_rate=800,
+            damage_waiver_percent_or_amount=10,
+            fuel_surcharge_percent=0,
+            attachment_rate=25,
+            delivery_cost=80,
+            pickup_cost=80,
+            market_benchmark_rate=0,
+        )
+    )
+
+    assert result.audit_components["damage_waiver"] == 80
+    assert result.audit_components["fuel_surcharge"] == 0
+    assert result.audit_components["attachment_hourly"] == 25
+    assert result.hourly_rental_direct_cost == 155
+
+
+def test_standby_and_minimum_charge_are_explicit() -> None:
+    result = calculate_equipment_rate(
+        rate_input(
+            standby_rate=120,
+            minimum_billable_hours=8,
+            market_benchmark_rate=200,
+        )
+    )
+
+    assert result.standby_rate == 120
+    assert result.minimum_billable_amount == 1600
+
+
+def test_contract_rate_overrides_default_but_below_benchmark_needs_approval() -> None:
+    result = calculate_equipment_rate(
+        rate_input(
+            rate_basis=RateBasis.contract_rate,
+            contract_rate=190,
+            market_benchmark_rate=228,
+            override_reason="Tender force-account rate",
+        )
+    )
+
+    assert result.selected_client_rate == 190
+    assert result.approval_required is True
+    assert "selected_rate_below_benchmark" in result.approval_reasons
+
+
+def test_approved_override_clears_gate_without_hiding_reasons() -> None:
+    result = calculate_equipment_rate(
+        rate_input(
+            rate_basis=RateBasis.contract_rate,
+            contract_rate=190,
+            market_benchmark_rate=228,
+            override_reason="Approved tender force-account rate",
+            approval_status=ApprovalStatus.approved,
+        )
+    )
+
+    assert result.approval_required is False
+    assert "selected_rate_below_benchmark" in result.approval_reasons
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"target_margin_percent": 9}, "margin_below_10_percent"),
+        ({"waive_mobilization": True}, "mobilization_waived"),
+        ({"waive_minimum": True}, "minimum_charge_waived"),
+        ({"operator_inclusion_changed": True}, "operator_inclusion_changed"),
+        ({"quote_expiry_date": date(2026, 1, 1)}, "vendor_quote_expired"),
+        ({"source_name": ""}, "source_or_class_missing"),
+    ],
+)
+def test_controlled_exceptions_require_reason_and_approval(overrides, reason) -> None:
+    result = calculate_equipment_rate(
+        rate_input(**overrides),
+        as_of=date(2026, 8, 5),
+    )
+
+    assert result.approval_required is True
+    assert reason in result.approval_reasons
+    assert "override_reason_required" in result.approval_reasons

--- a/tests/backend/test_equipment_rates.py
+++ b/tests/backend/test_equipment_rates.py
@@ -128,6 +128,20 @@ def test_contract_rate_overrides_default_but_below_benchmark_needs_approval() ->
     assert "selected_rate_below_benchmark" in result.approval_reasons
 
 
+def test_approved_override_without_written_reason_stays_blocked() -> None:
+    result = calculate_equipment_rate(
+        rate_input(
+            rate_basis=RateBasis.contract_rate,
+            contract_rate=190,
+            market_benchmark_rate=228,
+            approval_status=ApprovalStatus.approved,
+        )
+    )
+
+    assert result.approval_required is True
+    assert "override_reason_required" in result.approval_reasons
+
+
 def test_approved_override_clears_gate_without_hiding_reasons() -> None:
     result = calculate_equipment_rate(
         rate_input(

--- a/tests/backend/test_equipment_rates.py
+++ b/tests/backend/test_equipment_rates.py
@@ -11,7 +11,6 @@ from app.schemas.equipment_rates import (
     RegionalMarket,
     RentalPeriod,
 )
-from app.core.errors import AppError
 from app.services.equipment_rate_sheet_pdf import render_client_rate_sheet_pdf
 from app.services.equipment_rates import calculate_equipment_rate, get_equipment_rate_library
 
@@ -180,37 +179,13 @@ def test_client_rate_sheet_defaults_to_draft_watermark() -> None:
     assert b"DRAFT - NOT APPROVED FOR EXTERNAL ISSUE" in pdf
 
 
-def test_executive_issue_is_blocked_by_unapproved_rate_exception() -> None:
-    payload = ClientRateSheetRequest(
-        effective_date=date(2026, 8, 5),
-        expiry_date=date(2026, 9, 4),
-        regional_market=RegionalMarket.surrey_fraser_valley_east,
-        lines=[
-            rate_input(
-                rate_basis=RateBasis.contract_rate,
-                contract_rate=190,
-                market_benchmark_rate=228,
-                override_reason="Tender rate",
-            )
-        ],
-        executive_approved=True,
-        approval_reference="Executive approval 2026-08-05",
-    )
 
-    with pytest.raises(AppError, match="blocked"):
-        render_client_rate_sheet_pdf(payload)
-
-
-def test_approved_rate_sheet_records_executive_reference() -> None:
-    payload = ClientRateSheetRequest(
-        effective_date=date(2026, 8, 5),
-        expiry_date=date(2026, 9, 4),
-        regional_market=RegionalMarket.surrey_fraser_valley_east,
-        lines=[rate_input()],
-        executive_approved=True,
-        approval_reference="Executive approval 2026-08-05",
-    )
-
-    pdf = render_client_rate_sheet_pdf(payload)
-
-    assert b"APPROVED FOR ISSUE - Reference: Executive approval 2026-08-05" in pdf
+def test_client_cannot_self_declare_executive_approval() -> None:
+    with pytest.raises(ValueError, match="executive_approved"):
+        ClientRateSheetRequest(
+            effective_date=date(2026, 8, 5),
+            expiry_date=date(2026, 9, 4),
+            regional_market=RegionalMarket.surrey_fraser_valley_east,
+            lines=[rate_input()],
+            executive_approved=True,
+        )

--- a/tests/backend/test_equipment_rates.py
+++ b/tests/backend/test_equipment_rates.py
@@ -4,12 +4,15 @@ import pytest
 
 from app.schemas.equipment_rates import (
     ApprovalStatus,
+    ClientRateSheetRequest,
     EquipmentRateInput,
     RateBasis,
     RateCategory,
     RegionalMarket,
     RentalPeriod,
 )
+from app.core.errors import AppError
+from app.services.equipment_rate_sheet_pdf import render_client_rate_sheet_pdf
 from app.services.equipment_rates import calculate_equipment_rate, get_equipment_rate_library
 
 
@@ -161,3 +164,53 @@ def test_controlled_exceptions_require_reason_and_approval(overrides, reason) ->
     assert result.approval_required is True
     assert reason in result.approval_reasons
     assert "override_reason_required" in result.approval_reasons
+
+
+def test_client_rate_sheet_defaults_to_draft_watermark() -> None:
+    payload = ClientRateSheetRequest(
+        effective_date=date(2026, 8, 5),
+        expiry_date=date(2026, 9, 4),
+        regional_market=RegionalMarket.surrey_fraser_valley_east,
+        lines=[rate_input()],
+    )
+
+    pdf = render_client_rate_sheet_pdf(payload)
+
+    assert pdf.startswith(b"%PDF-1.4")
+    assert b"DRAFT - NOT APPROVED FOR EXTERNAL ISSUE" in pdf
+
+
+def test_executive_issue_is_blocked_by_unapproved_rate_exception() -> None:
+    payload = ClientRateSheetRequest(
+        effective_date=date(2026, 8, 5),
+        expiry_date=date(2026, 9, 4),
+        regional_market=RegionalMarket.surrey_fraser_valley_east,
+        lines=[
+            rate_input(
+                rate_basis=RateBasis.contract_rate,
+                contract_rate=190,
+                market_benchmark_rate=228,
+                override_reason="Tender rate",
+            )
+        ],
+        executive_approved=True,
+        approval_reference="Executive approval 2026-08-05",
+    )
+
+    with pytest.raises(AppError, match="blocked"):
+        render_client_rate_sheet_pdf(payload)
+
+
+def test_approved_rate_sheet_records_executive_reference() -> None:
+    payload = ClientRateSheetRequest(
+        effective_date=date(2026, 8, 5),
+        expiry_date=date(2026, 9, 4),
+        regional_market=RegionalMarket.surrey_fraser_valley_east,
+        lines=[rate_input()],
+        executive_approved=True,
+        approval_reference="Executive approval 2026-08-05",
+    )
+
+    pdf = render_client_rate_sheet_pdf(payload)
+
+    assert b"APPROVED FOR ISSUE - Reference: Executive approval 2026-08-05" in pdf

--- a/tests/backend/test_estimate_workbooks.py
+++ b/tests/backend/test_estimate_workbooks.py
@@ -16,6 +16,7 @@ EXPECTED_SHEETS = [
     "Summary",
     "Line Items",
     "Production Rates",
+    "Equipment Rates",
     "Markups",
     "Risks",
     "Assumptions",
@@ -75,6 +76,9 @@ def test_workbook_contains_complete_estimator_sheet_contract() -> None:
     assert workbook["Quote Comparison"]["F4"].value == "Yes"
     assert workbook["Quote Comparison"]["G4"].value == "Complete scope and confirmed delivery"
     assert workbook["Quote Comparison"]["H4"].value == "Scope reviewed"
+    assert workbook["Equipment Rates"]["B4"].value == "Excavator"
+    assert workbook["Equipment Rates"]["D4"].value == 142
+    assert workbook["Equipment Rates"]["F4"].value == "IEOA 2026 Suggested Equipment Rates"
 
 
 def test_workbook_records_empty_assumptions_exclusions_and_line_items() -> None:

--- a/tests/backend/test_estimates.py
+++ b/tests/backend/test_estimates.py
@@ -224,3 +224,50 @@ def test_rate_library_exposes_default_activities() -> None:
 
     assert DefaultProductionActivity.pipe_installation in activities
     assert DefaultProductionActivity.traffic_control in activities
+
+
+
+def test_shared_all_in_equipment_rate_prevents_operator_double_count() -> None:
+    from app.schemas.equipment_rates import (
+        EquipmentRateInput,
+        RateCategory,
+        RegionalMarket,
+        RentalPeriod,
+    )
+
+    item = EstimateLineItem(
+        description="Operate rented excavator",
+        quantity=8,
+        unit=EstimateUnit.hour,
+        production_rate_per_hour=1,
+        labour=[
+            LabourCrewMember(role="Operator", quantity=1, hourly_rate=50),
+            LabourCrewMember(role="Labourer", quantity=1, hourly_rate=30),
+        ],
+        equipment=[
+            EquipmentResource(
+                name="20-23 t excavator",
+                quantity=1,
+                hourly_rate=0,
+                rate_input=EquipmentRateInput(
+                    regional_market=RegionalMarket.surrey_fraser_valley_east,
+                    rate_category=RateCategory.equipment,
+                    equipment_class="Excavator",
+                    equipment_description="20-23 t",
+                    operator_included=True,
+                    base_rate=800,
+                    rental_period=RentalPeriod.day,
+                    included_hours=8,
+                    target_margin_percent=10,
+                    market_benchmark_rate=228,
+                    source_name="IEOA 2026 Suggested Equipment Rates",
+                ),
+            )
+        ],
+    )
+
+    result = calculate_line_item(item)
+
+    assert result.labour_cost == 240
+    assert result.equipment_cost == 800
+    assert result.direct_cost == 1040


### PR DESCRIPTION
Closes #151.

Implements the approved equipment and client-rate standard from `Documentation/EQUIPMENT_AND_CLIENT_RATE_SHEET_STANDARD.md`.

Scope is limited to:
- the typed shared rate library and calculation controls;
- approval gates and audit fields;
- estimate/workbook/client-sheet integration;
- management-facing UI and export;
- focused automated tests, followed by one complete release-readiness run.

Production deployment and external issue of a client rate sheet remain blocked pending staging arithmetic review and separate executive approval.