### PR TITLE
Add Request PO workflow to IHOS portals

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { PasswordRecoveryPage } from "./pages/PasswordRecoveryPage";
 import { ProjectOperationsPage } from "./pages/ProjectOperationsPage";
 import { ProjectScopedLauncherPage } from "./pages/ProjectScopedLauncherPage";
 import { ProjectWorkspacePage } from "./pages/ProjectWorkspacePage";
+import { PurchaseOrderRequestPage } from "./pages/PurchaseOrderRequestPage";
 import { QuantityTakeoffPage } from "./pages/QuantityTakeoffPage";
 import { QuoteComparisonPage } from "./pages/QuoteComparisonPage";
 import { RFQAutomationPage } from "./pages/RFQAutomationPage";
@@ -64,7 +65,7 @@ function AuthenticatedApp() {
     const root = `/${portalRole ?? "employee"}-portal`;
     const sections = portalRole === "foreman" ? ["time", "backups", "receipts", "schedule", "production", "loads", "forms", "safety", "milestones", "small-equipment", "records"] : portalRole === "operator" ? ["time", "backups", "receipts", "schedule", "loads", "inspections", "small-equipment", "photos", "milestones", "records"] : ["time", "backups", "receipts", "journal", "schedule", "safety", "milestones", "small-equipment", "profile", "records"];
     const Page = portalRole === "foreman" ? ForemanPortalPage : portalRole === "operator" ? OperatorPortalPage : EmployeePortalPage;
-    return <AppLayout><Routes><Route path={root} element={<Page />} /><Route path="/backups" element={<BackupsPage />} />{sections.map((section) => <Route key={section} path={`${root}/${section}`} element={<Page section={section} />} />)}<Route path="*" element={<Navigate to={root} replace />} /></Routes></AppLayout>;
+    return <AppLayout><Routes><Route path={root} element={<Page />} /><Route path="/request-po" element={<PurchaseOrderRequestPage />} /><Route path={`${root}/request-po`} element={<PurchaseOrderRequestPage />} /><Route path="/backups" element={<BackupsPage />} />{sections.map((section) => <Route key={section} path={`${root}/${section}`} element={<Page section={section} />} />)}<Route path="*" element={<Navigate to={root} replace />} /></Routes></AppLayout>;
   }
 
   return (
@@ -72,6 +73,7 @@ function AuthenticatedApp() {
       <Routes>
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/request-po" element={<PurchaseOrderRequestPage />} />
         <Route path="/backups" element={<BackupsPage />} />
         <Route path="/employee-portal" element={<EmployeePortalPage />} />
         <Route path="/employee-portal/:section" element={<EmployeePortalRoute />} />

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Menu } from "lucide-react";
+import { LogOut, Menu, ShoppingCart } from "lucide-react";
 import { PropsWithChildren, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 
@@ -19,6 +19,7 @@ export function AppLayout({ children }: PropsWithChildren) {
         : user?.role === "operations_manager"
           ? "Operations access"
           : "Administrator access";
+  const poPath = user?.role === "viewer" ? `/${portalRole ?? "employee"}-portal/request-po` : "/request-po";
 
   return (
     <div className="min-h-screen bg-iron-50 text-iron-950">
@@ -44,14 +45,10 @@ export function AppLayout({ children }: PropsWithChildren) {
               <NavLink
                 key={module.path}
                 to={modulePathWithProjectContext(module.path, activeProject)}
-                className={({ isActive }) =>
-                  [
-                    "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-shadow",
-                    isActive
-                      ? "bg-brand-gold text-brand-black shadow-md"
-                      : "text-iron-100 hover:bg-white/10 hover:text-white",
-                  ].join(" ")
-                }
+                className={({ isActive }) => [
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-shadow",
+                  isActive ? "bg-brand-gold text-brand-black shadow-md" : "text-iron-100 hover:bg-white/10 hover:text-white",
+                ].join(" ")}
                 onClick={() => setIsSidebarOpen(false)}
               >
                 <Icon className="h-4 w-4" aria-hidden="true" />
@@ -59,6 +56,17 @@ export function AppLayout({ children }: PropsWithChildren) {
               </NavLink>
             );
           })}
+          <NavLink
+            to={poPath}
+            className={({ isActive }) => [
+              "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-shadow",
+              isActive ? "bg-brand-gold text-brand-black shadow-md" : "text-iron-100 hover:bg-white/10 hover:text-white",
+            ].join(" ")}
+            onClick={() => setIsSidebarOpen(false)}
+          >
+            <ShoppingCart className="h-4 w-4" aria-hidden="true" />
+            Request PO
+          </NavLink>
         </nav>
         <div className="border-t border-white/10 px-5 py-4 text-[10px] font-semibold uppercase tracking-[0.2em] text-iron-300">
           Civil • Earthworks • Utilities
@@ -66,39 +74,19 @@ export function AppLayout({ children }: PropsWithChildren) {
       </aside>
 
       {isSidebarOpen ? (
-        <button
-          type="button"
-          aria-label="Close navigation"
-          className="fixed inset-0 z-20 bg-iron-950/60 backdrop-blur-sm lg:hidden"
-          onClick={() => setIsSidebarOpen(false)}
-        />
+        <button type="button" aria-label="Close navigation" className="fixed inset-0 z-20 bg-iron-950/60 backdrop-blur-sm lg:hidden" onClick={() => setIsSidebarOpen(false)} />
       ) : null}
 
       <div className="lg:pl-72">
         <header className="sticky top-0 z-20 flex h-16 items-center justify-between border-b border-brand-gold/20 bg-white/95 px-4 shadow-sm backdrop-blur lg:px-8">
-          <button
-            type="button"
-            className="rounded-md border border-brand-gold/40 p-2 text-iron-800 lg:hidden"
-            onClick={() => setIsSidebarOpen((value) => !value)}
-            aria-label="Open navigation"
-          >
+          <button type="button" className="rounded-md border border-brand-gold/40 p-2 text-iron-800 lg:hidden" onClick={() => setIsSidebarOpen((value) => !value)} aria-label="Open navigation">
             <Menu className="h-5 w-5" />
           </button>
-          <div className="hidden text-sm font-medium text-iron-700 lg:block">
-            {user ? `Signed in as ${user.display_name}` : "Signed out"}
-          </div>
+          <div className="hidden text-sm font-medium text-iron-700 lg:block">{user ? `Signed in as ${user.display_name}` : "Signed out"}</div>
           <div className="flex items-center gap-3">
             <div className="hidden text-xs font-medium text-iron-500 sm:block">{accessLabel}</div>
-            <div className="rounded-md bg-brand-gold px-3 py-1 text-xs font-semibold capitalize text-brand-black">
-              {user?.role.replace("_", " ")}
-            </div>
-            <button
-              type="button"
-              onClick={() => void logout()}
-              className="rounded-md border border-iron-100 p-2 text-iron-700 transition hover:border-brand-gold hover:bg-brand-gold/10"
-              aria-label="Sign out"
-              title="Sign out"
-            >
+            <div className="rounded-md bg-brand-gold px-3 py-1 text-xs font-semibold capitalize text-brand-black">{user?.role.replace("_", " ")}</div>
+            <button type="button" onClick={() => void logout()} className="rounded-md border border-iron-100 p-2 text-iron-700 transition hover:border-brand-gold hover:bg-brand-gold/10" aria-label="Sign out" title="Sign out">
               <LogOut className="h-4 w-4" />
             </button>
           </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { ClipboardList, Database, FileStack, FolderKanban, RefreshCw } from "lucide-react";
+import { ClipboardList, Database, FileStack, FolderKanban, RefreshCw, ShoppingCart } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
@@ -32,11 +32,7 @@ export function DashboardPage() {
         suppliersApi.list({}),
         rfqPackagesApi.list(),
       ]);
-      setState({
-        projects: projectList.items,
-        suppliers: supplierList.items,
-        rfqs: rfqList.items,
-      });
+      setState({ projects: projectList.items, suppliers: supplierList.items, rfqs: rfqList.items });
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to load dashboard");
     } finally {
@@ -44,19 +40,12 @@ export function DashboardPage() {
     }
   }
 
-  useEffect(() => {
-    void refresh();
-  }, []);
+  useEffect(() => { void refresh(); }, []);
 
-  const activeProjects = state.projects.filter(
-    (project) => !["completed", "archived"].includes(project.status),
-  );
+  const activeProjects = state.projects.filter((project) => !["completed", "archived"].includes(project.status));
   const tenderingProjects = state.projects.filter((project) => project.status === "tendering");
   const openRfqs = state.rfqs.filter((rfq) => !["issued", "closed"].includes(rfq.status));
-  const supplierContacts = state.suppliers.reduce(
-    (total, supplier) => total + supplier.contacts.length,
-    0,
-  );
+  const supplierContacts = state.suppliers.reduce((total, supplier) => total + supplier.contacts.length, 0);
 
   return (
     <section className="space-y-6">
@@ -67,27 +56,21 @@ export function DashboardPage() {
             <div>
               <div className="text-xs font-semibold uppercase tracking-[0.22em] text-brand-gold">Iron House Contracting</div>
               <h1 className="mt-2 text-3xl font-semibold text-brand-silver">Iron House Dashboard</h1>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-100">
-                Operating snapshot for tenders, projects, RFQs, suppliers, and estimating.
-              </p>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-100">Operating snapshot for tenders, projects, RFQs, suppliers, purchasing, and estimating.</p>
             </div>
           </div>
-          <button
-            type="button"
-            onClick={() => void refresh()}
-            className="inline-flex items-center justify-center gap-2 rounded-md border border-brand-gold/40 bg-white/10 px-3 py-2 text-sm font-medium text-white transition hover:bg-brand-gold hover:text-brand-black"
-          >
-            <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
-            Refresh
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <Link to="/request-po" className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-gold px-4 py-2 text-sm font-semibold text-brand-black transition hover:brightness-105">
+              <ShoppingCart className="h-4 w-4" /> Request PO
+            </Link>
+            <button type="button" onClick={() => void refresh()} className="inline-flex items-center justify-center gap-2 rounded-md border border-brand-gold/40 bg-white/10 px-3 py-2 text-sm font-medium text-white transition hover:bg-brand-gold hover:text-brand-black">
+              <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} /> Refresh
+            </button>
+          </div>
         </div>
       </div>
 
-      {error ? (
-        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-          {error}
-        </div>
-      ) : null}
+      {error ? <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div> : null}
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <DashboardCard icon={FolderKanban} label="Active Projects" value={activeProjects.length} href="/projects" />
@@ -99,109 +82,31 @@ export function DashboardPage() {
       <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
         <div className="rounded-md border border-iron-100 bg-white p-5">
           <div className="flex items-center justify-between gap-3">
-            <div>
-              <h2 className="text-base font-semibold text-iron-950">Current Work</h2>
-              <p className="mt-1 text-sm text-iron-500">Latest project records in the system.</p>
-            </div>
-            <Link to="/projects" className="text-sm font-semibold text-signal-blue">
-              Open projects
-            </Link>
+            <div><h2 className="text-base font-semibold text-iron-950">Current Work</h2><p className="mt-1 text-sm text-iron-500">Latest project records in the system.</p></div>
+            <Link to="/projects" className="text-sm font-semibold text-signal-blue">Open projects</Link>
           </div>
-
           <div className="mt-4 overflow-hidden rounded-md border border-iron-100">
             <table className="w-full text-left text-sm">
-              <thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500">
-                <tr>
-                  <th className="px-3 py-2">Project</th>
-                  <th className="px-3 py-2">Municipality</th>
-                  <th className="px-3 py-2">Bid Due</th>
-                  <th className="px-3 py-2">Status</th>
-                </tr>
-              </thead>
+              <thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500"><tr><th className="px-3 py-2">Project</th><th className="px-3 py-2">Municipality</th><th className="px-3 py-2">Bid Due</th><th className="px-3 py-2">Status</th></tr></thead>
               <tbody>
-                {state.projects.slice(0, 8).map((project) => (
-                  <tr key={project.id} className="border-t border-iron-100">
-                    <td className="px-3 py-2 font-medium text-iron-950">
-                      <Link to={`/projects/${project.id}`}>{project.name}</Link>
-                    </td>
-                    <td className="px-3 py-2 text-iron-600">{project.municipality ?? "—"}</td>
-                    <td className="px-3 py-2 text-iron-600">{project.bid_due_date ?? "—"}</td>
-                    <td className="px-3 py-2 text-iron-600">{project.status}</td>
-                  </tr>
-                ))}
-                {!state.projects.length ? (
-                  <tr>
-                    <td className="px-3 py-4 text-iron-500" colSpan={4}>
-                      No projects yet. Create the first one in Project Workspace.
-                    </td>
-                  </tr>
-                ) : null}
+                {state.projects.slice(0, 8).map((project) => <tr key={project.id} className="border-t border-iron-100"><td className="px-3 py-2 font-medium text-iron-950"><Link to={`/projects/${project.id}`}>{project.name}</Link></td><td className="px-3 py-2 text-iron-600">{project.municipality ?? "—"}</td><td className="px-3 py-2 text-iron-600">{project.bid_due_date ?? "—"}</td><td className="px-3 py-2 text-iron-600">{project.status}</td></tr>)}
+                {!state.projects.length ? <tr><td className="px-3 py-4 text-iron-500" colSpan={4}>No projects yet. Create the first one in Project Workspace.</td></tr> : null}
               </tbody>
             </table>
           </div>
         </div>
 
         <aside className="space-y-6">
-          <div className="rounded-md border border-iron-100 bg-white p-5">
-            <h2 className="text-base font-semibold text-iron-950">MVP Health</h2>
-            <dl className="mt-4 space-y-3 text-sm">
-              <HealthRow label="Supplier contacts" value={supplierContacts} />
-              <HealthRow label="RFQ packages" value={state.rfqs.length} />
-              <HealthRow label="Project records" value={state.projects.length} />
-            </dl>
-          </div>
-
-          <div className="rounded-md border border-iron-100 bg-white p-5">
-            <h2 className="text-base font-semibold text-iron-950">Next Actions</h2>
-            <div className="mt-4 grid gap-2 text-sm">
-              <QuickLink href="/projects" label="Create or update project" />
-              <QuickLink href="/suppliers" label="Add supplier contact" />
-              <QuickLink href="/rfq-builder" label="Build RFQ package" />
-              <QuickLink href="/estimating" label="Build estimate" />
-            </div>
-          </div>
+          <div className="rounded-md border border-iron-100 bg-white p-5"><h2 className="text-base font-semibold text-iron-950">MVP Health</h2><dl className="mt-4 space-y-3 text-sm"><HealthRow label="Supplier contacts" value={supplierContacts} /><HealthRow label="RFQ packages" value={state.rfqs.length} /><HealthRow label="Project records" value={state.projects.length} /></dl></div>
+          <div className="rounded-md border border-iron-100 bg-white p-5"><h2 className="text-base font-semibold text-iron-950">Next Actions</h2><div className="mt-4 grid gap-2 text-sm"><QuickLink href="/request-po" label="Request purchase order" /><QuickLink href="/projects" label="Create or update project" /><QuickLink href="/suppliers" label="Add supplier contact" /><QuickLink href="/rfq-builder" label="Build RFQ package" /><QuickLink href="/estimating" label="Build estimate" /></div></div>
         </aside>
       </div>
     </section>
   );
 }
 
-function DashboardCard({
-  icon: Icon,
-  label,
-  value,
-  href,
-}: {
-  icon: typeof FolderKanban;
-  label: string;
-  value: number;
-  href: string;
-}) {
-  return (
-    <Link to={href} className="rounded-md border border-iron-100 bg-white p-5">
-      <div className="flex items-center justify-between">
-        <div className="text-sm font-medium text-iron-500">{label}</div>
-        <Icon className="h-5 w-5 text-brand-gold" />
-      </div>
-      <div className="mt-4 text-3xl font-semibold text-iron-950">{value}</div>
-    </Link>
-  );
+function DashboardCard({ icon: Icon, label, value, href }: { icon: typeof FolderKanban; label: string; value: number; href: string }) {
+  return <Link to={href} className="rounded-md border border-iron-100 bg-white p-5"><div className="flex items-center justify-between"><div className="text-sm font-medium text-iron-500">{label}</div><Icon className="h-5 w-5 text-brand-gold" /></div><div className="mt-4 text-3xl font-semibold text-iron-950">{value}</div></Link>;
 }
-
-function HealthRow({ label, value }: { label: string; value: number | string }) {
-  return (
-    <div className="flex justify-between gap-3">
-      <dt className="text-iron-500">{label}</dt>
-      <dd className="font-semibold text-iron-950">{value}</dd>
-    </div>
-  );
-}
-
-function QuickLink({ href, label }: { href: string; label: string }) {
-  return (
-    <Link className="rounded-md border border-iron-100 px-3 py-2 font-medium text-iron-800 transition hover:border-brand-gold hover:bg-brand-gold/10" to={href}>
-      {label}
-    </Link>
-  );
-}
-
+function HealthRow({ label, value }: { label: string; value: number | string }) { return <div className="flex justify-between gap-3"><dt className="text-iron-500">{label}</dt><dd className="font-semibold text-iron-950">{value}</dd></div>; }
+function QuickLink({ href, label }: { href: string; label: string }) { return <Link className="rounded-md border border-iron-100 px-3 py-2 font-medium text-iron-800 transition hover:border-brand-gold hover:bg-brand-gold/10" to={href}>{label}</Link>; }

--- a/frontend/src/pages/PurchaseOrderRequestPage.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.tsx
@@ -1,0 +1,145 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import { fieldOperationsApi, FieldOperationsBootstrap, FieldRecord } from "../api/fieldOperations";
+import { useAuth } from "../contexts/AuthContext";
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+function buildPoNumber(jobNumber: string) {
+  const sequence = Date.now().toString().slice(-8);
+  return `PO-${sequence}-${jobNumber}`;
+}
+
+export function PurchaseOrderRequestPage() {
+  const { user, portalRole } = useAuth();
+  const [data, setData] = useState<FieldOperationsBootstrap | null>(null);
+  const [projectId, setProjectId] = useState("");
+  const [supplierId, setSupplierId] = useState("");
+  const [costCode, setCostCode] = useState("");
+  const [purpose, setPurpose] = useState("");
+  const [amount, setAmount] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdPo, setCreatedPo] = useState<string | null>(null);
+
+  async function refresh() {
+    setError(null);
+    try {
+      setData(await fieldOperationsApi.bootstrap());
+    } catch (current) {
+      setError(current instanceof Error ? current.message : "Unable to load PO request data.");
+    }
+  }
+
+  useEffect(() => { void refresh(); }, []);
+
+  const selectedProject = data?.projects.find((project) => project.id === projectId);
+  const selectedSupplier = data?.suppliers.find((supplier) => supplier.id === supplierId);
+  const pending = useMemo(
+    () => (data?.records ?? []).filter((record) => record.record_type === "purchase_order_request"),
+    [data],
+  );
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    if (!selectedProject || !purpose.trim()) return;
+    const jobNumber = String(selectedProject.project_number ?? selectedProject.name).trim();
+    const poNumber = buildPoNumber(jobNumber);
+    setSaving(true);
+    setError(null);
+    try {
+      await fieldOperationsApi.createRecord({
+        record_type: "purchase_order_request",
+        project_id: selectedProject.id,
+        supplier_id: supplierId || null,
+        cost_code: costCode || null,
+        work_date: today(),
+        title: `${poNumber} — ${purpose.trim()}`,
+        status: "pending_approval",
+        details: {
+          po_number: poNumber,
+          job_number: jobNumber,
+          supplier_name: selectedSupplier?.name ?? null,
+          purpose: purpose.trim(),
+          amount_estimate: amount ? Number(amount) : null,
+          requester_role: portalRole ?? user?.role ?? "management",
+          requested_by: user?.email ?? null,
+          requested_at: new Date().toISOString(),
+        },
+      });
+      setCreatedPo(poNumber);
+      setPurpose("");
+      setAmount("");
+      setSupplierId("");
+      setCostCode("");
+      await refresh();
+    } catch (current) {
+      setError(current instanceof Error ? current.message : "Unable to create PO request.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="rounded-xl border border-brand-gold/30 bg-iron-950 p-6 text-white shadow-brand">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-gold">Purchasing control</div>
+        <h1 className="mt-2 text-3xl font-semibold">Request PO</h1>
+        <p className="mt-2 max-w-3xl text-sm text-iron-200">
+          Select the job and purchase details. IHOS generates the PO automatically with the PO identifier first and the job number appended.
+        </p>
+      </div>
+
+      {error ? <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">{error}</div> : null}
+      {createdPo ? <div className="rounded-md border border-green-200 bg-green-50 p-4 text-sm font-semibold text-green-800">Created {createdPo} and sent for approval.</div> : null}
+
+      <form onSubmit={submit} className="grid gap-4 rounded-xl border border-iron-100 bg-white p-5 shadow-sm md:grid-cols-2">
+        <label className="grid gap-2 text-sm font-medium text-iron-800">
+          Job
+          <select required value={projectId} onChange={(event) => setProjectId(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2">
+            <option value="">Select job</option>
+            {data?.projects.map((project) => <option key={project.id} value={project.id}>{String(project.project_number ?? "")} {project.name}</option>)}
+          </select>
+        </label>
+        <label className="grid gap-2 text-sm font-medium text-iron-800">
+          Supplier / vendor
+          <select value={supplierId} onChange={(event) => setSupplierId(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2">
+            <option value="">Not selected</option>
+            {data?.suppliers.map((supplier) => <option key={supplier.id} value={supplier.id}>{supplier.name}</option>)}
+          </select>
+        </label>
+        <label className="grid gap-2 text-sm font-medium text-iron-800">
+          Cost code
+          <select value={costCode} onChange={(event) => setCostCode(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2">
+            <option value="">Not selected</option>
+            {data?.cost_codes.map((item) => <option key={item.code} value={item.code}>{item.code} — {item.name}</option>)}
+          </select>
+        </label>
+        <label className="grid gap-2 text-sm font-medium text-iron-800">
+          Estimated amount
+          <input type="number" step="0.01" min="0" value={amount} onChange={(event) => setAmount(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" />
+        </label>
+        <label className="grid gap-2 text-sm font-medium text-iron-800 md:col-span-2">
+          Purchase purpose / items needed
+          <textarea required value={purpose} onChange={(event) => setPurpose(event.target.value)} className="min-h-28 rounded-md border border-iron-200 px-3 py-2" placeholder="Example: 20 m of 200 mm PVC, fittings and bedding material" />
+        </label>
+        <div className="md:col-span-2">
+          <button disabled={saving || !projectId || !purpose.trim()} className="rounded-md bg-brand-gold px-4 py-2 font-semibold text-brand-black disabled:opacity-50">
+            {saving ? "Creating PO…" : "Request PO"}
+          </button>
+        </div>
+      </form>
+
+      <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-iron-950">PO request queue</h2>
+        <p className="mt-1 text-sm text-iron-500">Submitted requests remain pending until management approval.</p>
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500"><tr><th className="px-3 py-2">PO</th><th className="px-3 py-2">Job</th><th className="px-3 py-2">Purpose</th><th className="px-3 py-2">Status</th></tr></thead>
+            <tbody>{pending.slice(0, 25).map((record: FieldRecord) => <tr key={record.id} className="border-t border-iron-100"><td className="px-3 py-2 font-semibold text-iron-950">{String(record.details.po_number ?? "—")}</td><td className="px-3 py-2">{String(record.details.job_number ?? "—")}</td><td className="px-3 py-2">{String(record.details.purpose ?? record.title)}</td><td className="px-3 py-2">{record.status.replaceAll("_", " ")}</td></tr>)}</tbody>
+          </table>
+        </div>
+      </section>
+    </section>
+  );
+}


### PR DESCRIPTION
Adds a shared Request PO workflow for management, foremen, operators, and employees.

Includes:
- Request PO page using existing authenticated field-operations API
- Automatic PO identifier with job number appended
- Job, supplier, cost code, purpose, and estimated amount fields
- Pending approval queue using field records
- Shared sidebar Request PO navigation for all portal roles
- Management dashboard Request PO action
- Viewer-safe role-specific portal route

The Supabase Dext intake already has a po_number field so this workflow can be matched into receipt processing in the next integration step.