### PR TITLE
Fix exact staging release deployment

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -38,22 +38,50 @@ jobs:
           test -f backend/app/services/local_receipt_ocr.py
 
       - name: Build and deploy exact checkout
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
-          sudo docker compose \
+          sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose \
             --env-file /etc/iron-house-os/staging.env \
             -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
             -p iron-house-os-staging \
             up -d --build --force-recreate --remove-orphans
 
       - name: Verify live backend contains OCR fallback
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
-          sudo docker compose \
+          sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose \
             --env-file /etc/iron-house-os/staging.env \
             -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
             -p iron-house-os-staging \
             exec -T backend python -c 'import app.services.local_receipt_ocr; print("LOCAL_OCR_READY")'
 
+      - name: Verify exact staging migration
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
+        run: |
+          expected_migration="$(
+            sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose \
+              --env-file /etc/iron-house-os/staging.env \
+              -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
+              -p iron-house-os-staging \
+              exec -T backend alembic heads | awk '{print $1}'
+          )"
+          migration="$(
+            sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose \
+              --env-file /etc/iron-house-os/staging.env \
+              -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
+              -p iron-house-os-staging \
+              exec -T postgres sh -ceu \
+              'psql -v ON_ERROR_STOP=1 -At -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT version_num FROM alembic_version"'
+          )"
+          test "$migration" = "$expected_migration"
+          printf 'Verified staging Alembic revision %s\n' "$migration"
+
       - name: Verify public staging endpoints
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
           for attempt in $(seq 1 30); do
             if curl --fail --silent https://staging.os.ironhousecivil.com/health >/dev/null; then
@@ -62,4 +90,15 @@ jobs:
             sleep 5
           done
           curl --fail --silent --show-error https://staging.os.ironhousecivil.com/health
-          curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness
+          readiness="$(curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness)"
+          printf '%s\n' "$readiness"
+          READINESS_JSON="$readiness" python3 - <<'PY'
+          import json
+          import os
+
+          readiness = json.loads(os.environ["READINESS_JSON"])
+          actual = readiness.get("checks", {}).get("release_id")
+          expected = os.environ["RELEASE_SHA"]
+          if actual != expected:
+              raise SystemExit(f"Live staging release mismatch: expected {expected}, got {actual}")
+          PY

--- a/tests/backend/test_staging_config.py
+++ b/tests/backend/test_staging_config.py
@@ -87,6 +87,17 @@ def test_release_workflow_uses_disposable_staging_and_immutable_evidence() -> No
     assert 'backend_image="$(docker image inspect' in workflow
 
 
+def test_staging_deploy_pins_and_verifies_the_live_release() -> None:
+    workflow = (ROOT / ".github/workflows/staging-deploy.yml").read_text()
+
+    assert 'sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose' in workflow
+    assert "exec -T backend alembic heads" in workflow
+    assert 'test "$migration" = "$expected_migration"' in workflow
+    assert 'actual = readiness.get("checks", {}).get("release_id")' in workflow
+    assert 'expected = os.environ["RELEASE_SHA"]' in workflow
+    assert "if actual != expected:" in workflow
+
+
 def test_frontend_proxy_exposes_backend_health_without_spa_fallback() -> None:
     nginx = (ROOT / "frontend/nginx.conf").read_text()
 


### PR DESCRIPTION
Relates to #136.

## Defect and reproduction

The exact-target staging deploy for `f4df6dfe383204c6e966cd8b0c9a7bd20961b51d` completed successfully in Actions run 31173911126, but a subsequent public read-only request to `https://staging.os.ironhousecivil.com/readiness` returned HTTP 200 with `checks.release_id=3408b15ce25b12f4a5852dbba50c3c733da0aaaa`.

Root cause: the workflow checked out the requested SHA but allowed persistent `/etc/iron-house-os/staging.env` to supply `IHOS_STAGING_RELEASE_ID`, then accepted any healthy readiness response. A stale release could therefore be reported as a successful exact deployment.

## Minimal repair

- Override `IHOS_STAGING_RELEASE_ID` for the Compose process with the requested SHA without modifying the protected host environment file.
- Compare the live database Alembic revision with the checked-out backend image's Alembic head (currently `20260806_0017`).
- Fail the deployment unless public readiness reports the exact requested SHA.
- Add one focused regression test for these fail-closed controls.

## Evidence executed

Focused:

- `pytest -c pyproject.toml ../tests/backend/test_staging_config.py -q` — 8 passed in 0.52s.
- Public staging anonymous smoke — root, healthz, health, readiness, and seven protected API denials passed; readiness exposed the stale release mismatch above.

Full local gates on the final diff:

- YAML parse of `.github/workflows/staging-deploy.yml` — passed.
- `ruff check .` — passed.
- `pytest -c pyproject.toml` — 293 passed, 1 existing Pydantic warning in 94.79s.
- Visual design lock — passed for 13 protected files, baseline `c24ecec8`.
- React Router RSC boundary — passed; 115 files scanned, no errors.
- `npm run lint` — passed.
- `npm run test` — 22 files / 63 tests passed in 76.16s.
- `npm run build` — passed in 2.63s with the existing chunk-size warning.

Exact-base pre-repair Actions evidence:

- CI run 31173911116 — passed for `f4df6df`.
- Release readiness run 31173911095 — all backend, frontend, browser, disposable staging/rollback/evidence, and disposable stack jobs passed for `f4df6df`.
- Staging deploy run 31173911126 — reported success but failed to detect the live release mismatch reproduced above.

PR-head Actions evidence:

- CI run 31182577581 — success: backend, frontend, and browser/mobile/accessibility passed; Playwright reported 31 passed and 5 skipped.
- Release readiness run 31182585698 — success: staging isolation, backend, frontend, browser/mobile/accessibility, disposable staging smoke/rollback/evidence, and disposable stack smoke all passed.

## Remaining blockers

- The repaired workflow must merge before it can deploy a main-reachable target and prove exact live release/migration checks on the self-hosted staging runner.
- Authenticated shared-staging acceptance is blocked in this job because `STAGING_EMAIL`, `STAGING_PASSWORD`, `STAGING_VIEWER_EMAIL`, and `STAGING_VIEWER_PASSWORD` are absent. No credential values were read or printed.
- Until the repair is merged and current main is deployed, live staging remains stale and the requested authenticated Backups, Request PO, and onboarding acceptance cannot be claimed.

## Security and production gate

Staging workflow only. No production host, files, DNS, certificates, secrets, data, payments, payroll, banking, invitations, or approval gates were changed. The patch does not persist or print protected environment values.

## Risk and rollback

Risk is limited to staging deployments failing closed when the release ID or migration does not match the checked-out revision. Roll back by reverting commit `b799b26dd768b40df2f3586cb4846714b2797549`; no schema or data rollback is required.
