### PR TITLE
Harden production cutover rollback and release verification

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
   deploy:
     name: Approved production cutover
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     needs: validate
     runs-on: [self-hosted, linux, ihos-production]
     environment: production
@@ -68,7 +68,15 @@ jobs:
           [[ "$run_result" == "success" ]]
           [[ "$run_name" == "Release readiness" ]]
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Checkout trusted deploy tooling at workflow commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .deploy-tooling
+          persist-credentials: false
+
+      - name: Checkout approved release SHA
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha }}
           clean: true
@@ -101,7 +109,8 @@ jobs:
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
         run: >-
-          sudo /usr/local/sbin/ihos-production-deploy
+          sudo /bin/bash
+          "$GITHUB_WORKSPACE/.deploy-tooling/ops/digitalocean/production-deploy-wrapper.sh"
           --release "$RELEASE_SHA"
           --evidence "$RUNNER_TEMP/release-evidence/evidence.json"
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -32,7 +32,7 @@ jobs:
     name: Production agent policy validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Validate production agent scripts
         run: |
           bash -n \
@@ -68,11 +68,12 @@ jobs:
           [[ "$run_result" == "success" ]]
           [[ "$run_name" == "Release readiness" ]]
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha }}
           clean: true
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify approved main release
         env:
@@ -104,9 +105,25 @@ jobs:
           --release "$RELEASE_SHA"
           --evidence "$RUNNER_TEMP/release-evidence/evidence.json"
 
-      - name: Verify public production endpoints
+      - name: Verify public production endpoints and release identity
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha }}
         run: |
-          curl --fail --silent --show-error https://os.ironhousecivil.com/ >/dev/null
-          curl --fail --silent --show-error https://os.ironhousecivil.com/health >/dev/null
-          curl --fail --silent --show-error https://os.ironhousecivil.com/readiness >/dev/null
-          echo "Production deployment and endpoint verification passed."
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+            https://os.ironhousecivil.com/ >/dev/null
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+            https://os.ironhousecivil.com/health >/dev/null
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+            https://os.ironhousecivil.com/readiness |
+            python -c '
+          import json, os, sys
+          payload = json.load(sys.stdin)
+          expected = os.environ["RELEASE_SHA"]
+          release_id = payload.get("checks", {}).get("release_id")
+          if payload.get("status") != "ready" or release_id != expected:
+              raise SystemExit(
+                  f"Production release verification failed: "
+                  f"status={payload.get(\"status\")}, release_id={release_id}, expected={expected}"
+              )
+          '
+          echo "Production deployment and exact release verification passed."

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -122,8 +122,10 @@ jobs:
           release_id = payload.get("checks", {}).get("release_id")
           if payload.get("status") != "ready" or release_id != expected:
               raise SystemExit(
-                  f"Production release verification failed: "
-                  f"status={payload.get(\"status\")}, release_id={release_id}, expected={expected}"
+                  "Production release verification failed: "
+                  "status={}, release_id={}, expected={}".format(
+                      payload.get("status"), release_id, expected
+                  )
               )
           '
           echo "Production deployment and exact release verification passed."

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -169,8 +169,9 @@ release_id = payload.get("checks", {}).get("release_id")
 expected = os.environ["IHOS_RELEASE_ID"]
 if payload.get("status") != "ready" or release_id != expected:
     raise SystemExit(
-        f"Loopback readiness failed: status={payload.get(\"status\")}, "
-        f"release_id={release_id}, expected={expected}"
+        "Loopback readiness failed: status={}, release_id={}, expected={}".format(
+            payload.get("status"), release_id, expected
+        )
     )
 '
 application_ready=1

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -118,17 +118,6 @@ if not ports or any(port.get("host_ip") != "127.0.0.1" for port in ports):
     raise SystemExit("Frontend must bind only to 127.0.0.1 before cutover.")
 '
 
-install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
-nginx -t
-systemctl reload nginx
-"${compose[@]}" up -d --build --wait
-curl -fsS "http://127.0.0.1:${IHOS_PORT:-8080}/readiness" | python -c '
-import json, sys
-payload = json.load(sys.stdin)
-if payload.get("status") != "ready":
-    raise SystemExit(f"Loopback readiness failed: {payload}")
-'
-
 stamp=$(date -u +%Y%m%dT%H%M%SZ)
 IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
 IHOS_BACKUP_NAME="pre-cutover-$stamp" \
@@ -142,20 +131,53 @@ certbot certonly \
   --non-interactive \
   --keep-until-expiring
 
-live_enabled=0
-rollback_maintenance() {
+gateway_config=/etc/nginx/sites-available/iron-house-os
+previous_gateway=$(mktemp)
+previous_gateway_present=0
+if [[ -f "$gateway_config" ]]; then
+  cp --preserve=mode "$gateway_config" "$previous_gateway"
+  previous_gateway_present=1
+fi
+gateway_mutated=0
+application_ready=0
+restore_gateway_on_failure() {
   status=$?
-  if ((status != 0 && live_enabled == 1)); then
-    install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
+  if ((status != 0 && gateway_mutated == 1)); then
+    if ((application_ready == 1 && previous_gateway_present == 1)); then
+      install -m 0644 "$previous_gateway" "$gateway_config"
+    else
+      install -m 0644 ops/digitalocean/nginx-maintenance.conf "$gateway_config"
+    fi
     nginx -t >/dev/null && systemctl reload nginx
   fi
+  rm -f "$previous_gateway"
   exit "$status"
 }
-trap rollback_maintenance EXIT
-install -m 0644 ops/digitalocean/nginx-live.conf /etc/nginx/sites-available/iron-house-os
+trap restore_gateway_on_failure EXIT
+
+"${compose[@]}" build
+gateway_mutated=1
+install -m 0644 ops/digitalocean/nginx-maintenance.conf "$gateway_config"
 nginx -t
 systemctl reload nginx
-live_enabled=1
+"${compose[@]}" up -d --no-build --wait
+curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+  "http://127.0.0.1:${IHOS_PORT:-8080}/readiness" | python -c '
+import json, os, sys
+payload = json.load(sys.stdin)
+release_id = payload.get("checks", {}).get("release_id")
+expected = os.environ["IHOS_RELEASE_ID"]
+if payload.get("status") != "ready" or release_id != expected:
+    raise SystemExit(
+        f"Loopback readiness failed: status={payload.get(\"status\")}, "
+        f"release_id={release_id}, expected={expected}"
+    )
+'
+application_ready=1
+
+install -m 0644 ops/digitalocean/nginx-live.conf "$gateway_config"
+nginx -t
+systemctl reload nginx
 python scripts/release_smoke.py \
   --base-url "https://$domain" \
   --email "$BOOTSTRAP_ADMIN_EMAIL" \
@@ -188,7 +210,7 @@ cat >"$acceptance" <<EOF
 - Decision time (UTC): $(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 chmod 0600 "$acceptance"
-live_enabled=0
+rm -f "$previous_gateway"
 trap - EXIT
 echo "Release $release_sha live cutover passed: https://$domain"
 echo "Operator acceptance: $acceptance"

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -140,7 +140,7 @@ if [[ -f "$gateway_config" ]]; then
 fi
 gateway_mutated=0
 application_ready=0
-restore_gateway_on_failure() {
+rollback_maintenance() {
   status=$?
   if ((status != 0 && gateway_mutated == 1)); then
     if ((application_ready == 1 && previous_gateway_present == 1)); then
@@ -153,11 +153,11 @@ restore_gateway_on_failure() {
   rm -f "$previous_gateway"
   exit "$status"
 }
-trap restore_gateway_on_failure EXIT
+trap rollback_maintenance EXIT
 
 "${compose[@]}" build
 gateway_mutated=1
-install -m 0644 ops/digitalocean/nginx-maintenance.conf "$gateway_config"
+install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
 nginx -t
 systemctl reload nginx
 "${compose[@]}" up -d --no-build --wait

--- a/tests/backend/test_deploy_agent.py
+++ b/tests/backend/test_deploy_agent.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+CHECKOUT_PIN = "11d5960a326750d5838078e36cf38b85af677262"
 
 
 def test_deploy_agent_requires_both_release_gates_and_allowlisted_cutover() -> None:
@@ -33,3 +34,21 @@ def test_production_cutover_handoff_is_permission_safe() -> None:
 
     assert 'exec /bin/bash "$release_root/ops/digitalocean/cutover.sh"' in wrapper
     assert cutover.stat().st_mode & stat.S_IXUSR
+
+
+def test_production_deploy_uses_trusted_workflow_tooling() -> None:
+    workflow = (ROOT / ".github/workflows/production-deploy.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'" in workflow
+    assert "name: Checkout trusted deploy tooling at workflow commit" in workflow
+    assert "name: Checkout approved release SHA" in workflow
+    assert workflow.count(f"uses: actions/checkout@{CHECKOUT_PIN}") == 3
+    assert "ref: ${{ github.workflow_sha }}" in workflow
+    assert "path: .deploy-tooling" in workflow
+    assert workflow.count("persist-credentials: false") == 2
+    assert (
+        '"$GITHUB_WORKSPACE/.deploy-tooling/ops/digitalocean/production-deploy-wrapper.sh"'
+        in workflow
+    )

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -90,7 +90,8 @@ def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None
 
     trap = "trap rollback_maintenance EXIT"
     maintenance = (
-        'install -m 0644 ops/digitalocean/nginx-maintenance.conf "$gateway_config"'
+        "install -m 0644 ops/digitalocean/nginx-maintenance.conf "
+        "/etc/nginx/sites-available/iron-house-os"
     )
     compose_build = '"${compose[@]}" build'
     compose_up = '"${compose[@]}" up -d --no-build --wait'

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -88,7 +88,7 @@ def test_release_smoke_uses_the_real_project_scoped_drawing_route() -> None:
 def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None:
     cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
 
-    trap = "trap restore_gateway_on_failure EXIT"
+    trap = "trap rollback_maintenance EXIT"
     maintenance = (
         'install -m 0644 ops/digitalocean/nginx-maintenance.conf "$gateway_config"'
     )
@@ -97,9 +97,9 @@ def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None
 
     assert "previous_gateway=$(mktemp)" in cutover
     assert "application_ready=0" in cutover
-    assert cutover.index(trap) < cutover.index(maintenance)
-    assert cutover.index(compose_build) < cutover.index(maintenance)
-    assert cutover.index(maintenance) < cutover.index(compose_up)
+    assert cutover.index(trap) < cutover.rindex(maintenance)
+    assert cutover.index(compose_build) < cutover.rindex(maintenance)
+    assert cutover.rindex(maintenance) < cutover.index(compose_up)
     assert "release_id != expected" in cutover
     assert "--connect-timeout 5 --max-time 30" in cutover
 

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -83,3 +83,38 @@ def test_release_smoke_uses_the_real_project_scoped_drawing_route() -> None:
 
     assert "/api/v1/drawing-intelligence/projects/{project_id}" in smoke
     assert "/api/v1/drawing-intelligence/project/{project_id}" not in smoke
+
+
+def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None:
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+
+    trap = "trap restore_gateway_on_failure EXIT"
+    maintenance = (
+        'install -m 0644 ops/digitalocean/nginx-maintenance.conf "$gateway_config"'
+    )
+    compose_build = '"${compose[@]}" build'
+    compose_up = '"${compose[@]}" up -d --no-build --wait'
+
+    assert "previous_gateway=$(mktemp)" in cutover
+    assert "application_ready=0" in cutover
+    assert cutover.index(trap) < cutover.index(maintenance)
+    assert cutover.index(compose_build) < cutover.index(maintenance)
+    assert cutover.index(maintenance) < cutover.index(compose_up)
+    assert "release_id != expected" in cutover
+    assert "--connect-timeout 5 --max-time 30" in cutover
+
+
+def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:
+    workflow = (ROOT / ".github/workflows/production-deploy.yml").read_text()
+
+    checkout_pin = (
+        "actions/checkout@11d5960a326750d5838078e36cf38b85af677262"
+    )
+
+    assert workflow.count(checkout_pin) == 2
+    assert "actions/checkout@v4" not in workflow
+    assert "persist-credentials: false" in workflow
+    assert "Verify public production endpoints and release identity" in workflow
+    assert 'release_id = payload.get("checks", {}).get("release_id")' in workflow
+    assert "release_id != expected" in workflow
+    assert workflow.count("--connect-timeout 5 --max-time 30") == 3

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -112,7 +112,7 @@ def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:
         "actions/checkout@11d5960a326750d5838078e36cf38b85af677262"
     )
 
-    assert workflow.count(checkout_pin) == 2
+    assert workflow.count(checkout_pin) == 3
     assert "actions/checkout@v4" not in workflow
     assert "persist-credentials: false" in workflow
     assert "Verify public production endpoints and release identity" in workflow


### PR DESCRIPTION
Closes #176.

## What changed

- Moves image building, the pre-cutover recovery point, and certificate renewal ahead of the maintenance-mode mutation.
- Installs an EXIT recovery trap before nginx is changed, preserving the prior gateway configuration and restoring it when the new application has passed exact loopback readiness but a later cutover step fails.
- Keeps maintenance mode fail-closed when the replacement application itself is not ready.
- Requires loopback and public `/readiness` responses to report the exact approved release SHA.
- Adds bounded curl connection and total timeouts.
- Pins `actions/checkout` to the reviewed v4 commit and disables persisted checkout credentials on the production runner.
- Adds regression coverage for ordering, Action pinning, timeouts, and release identity.

## Why

The previous sequence could enter maintenance mode before several failure-prone operations and had no installed recovery trap until immediately before the live nginx switch. Final workflow verification also proved only HTTP availability, not that the approved SHA was serving.

## Validation

- `bash -n` for the cutover, wrapper, and runner installer: passed.
- Ruff for backend and deployment tests: passed.
- Focused deployment tests: 11 passed.
- Backend repository suite from `backend/`: 297 passed, one pre-existing Pydantic warning.
- Root deployment/backend test suite: 297 passed, one pre-existing Pydantic warning.
- `git diff --check`: passed.

## Approval boundary

Draft only. Do not merge or deploy from this PR until CI and staging evidence are reviewed. Production data, secrets, infrastructure, DNS, certificates, backups, and deployment state were not changed.

## Consolidation update

PR #175's trusted workflow-tooling checkout and runner execution fix is now included in this branch. The production job is main-dispatch-only, checks out tooling at `github.workflow_sha`, checks out the approved release separately, persists no checkout credentials, and executes the trusted wrapper via `/bin/bash`. Fresh consolidated CI is required before #175 is closed.