### PR TITLE
Fix Request PO validation and structured API errors

### DIFF
--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -26,6 +26,7 @@ RecordType = Literal[
     "rental_equipment",
     "weather",
     "daily_timesheet",
+    "purchase_order_request",
 ]
 
 

--- a/frontend/src/api/fieldOperations.test.ts
+++ b/frontend/src/api/fieldOperations.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fieldOperationsApi, formatApiErrorDetail } from "./fieldOperations";
+
+describe("field operations API errors", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("formats FastAPI validation issues without object coercion", () => {
+    expect(formatApiErrorDetail([
+      {
+        type: "literal_error",
+        loc: ["body", "record_type"],
+        msg: "Input should be a permitted record type",
+      },
+      {
+        type: "missing",
+        loc: ["body", "title"],
+        msg: "Field required",
+      },
+    ])).toBe("record_type: Input should be a permitted record type; title: Field required");
+  });
+
+  it("surfaces structured validation errors from a PO request", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      detail: [{ loc: ["body", "record_type"], msg: "Input should be a permitted record type" }],
+    }), {
+      status: 422,
+      headers: { "Content-Type": "application/json" },
+    })));
+
+    await expect(fieldOperationsApi.createRecord({
+      record_type: "purchase_order_request",
+    })).rejects.toThrow("record_type: Input should be a permitted record type");
+  });
+
+  it("formats structured message and blocker responses", () => {
+    expect(formatApiErrorDetail({
+      message: "Receipt approval is blocked.",
+      blockers: ["Select a project.", "Confirm the vendor."],
+    })).toBe("Receipt approval is blocked. Select a project. Confirm the vendor.");
+  });
+});

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -128,14 +128,51 @@ export type FieldOperationsBootstrap = {
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
+type ValidationIssue = {
+  loc?: unknown;
+  msg?: unknown;
+};
+
+export function formatApiErrorDetail(detail: unknown): string | null {
+  if (typeof detail === "string") {
+    return detail.trim() || null;
+  }
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => {
+        if (typeof item === "string") return item.trim();
+        if (!item || typeof item !== "object") return "";
+        const issue = item as ValidationIssue;
+        const message = typeof issue.msg === "string" ? issue.msg.trim() : "";
+        const location = Array.isArray(issue.loc)
+          ? issue.loc.filter((part) => part !== "body").map(String).join(".")
+          : "";
+        return message ? (location ? `${location}: ${message}` : message) : "";
+      })
+      .filter(Boolean);
+    return messages.length ? messages.join("; ") : null;
+  }
+  if (detail && typeof detail === "object") {
+    const payload = detail as Record<string, unknown>;
+    const message = typeof payload.message === "string" ? payload.message.trim() : "";
+    const blockers = Array.isArray(payload.blockers)
+      ? payload.blockers.filter((item): item is string => typeof item === "string" && Boolean(item.trim()))
+      : [];
+    if (message || blockers.length) {
+      return [message, ...blockers].filter(Boolean).join(" ");
+    }
+  }
+  return null;
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const response = await apiFetch(API_BASE_URL + path, {
     headers: { "Content-Type": "application/json", ...options?.headers },
     ...options,
   });
   if (!response.ok) {
-    const body = await response.json().catch(() => null) as { detail?: string } | null;
-    throw new Error(body?.detail ?? "Request failed with " + response.status);
+    const body = await response.json().catch(() => null) as { detail?: unknown } | null;
+    throw new Error(formatApiErrorDetail(body?.detail) ?? "Request failed with " + response.status);
   }
   return response.json() as Promise<T>;
 }

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -459,3 +459,35 @@ def test_time_off_request_rejects_reversed_dates() -> None:
         json={"record_type": "time_off_request", "employee_id": employee["id"], "work_date": str(date.today()), "title": "Invalid dates", "details": {"start_date": "2026-08-10", "end_date": "2026-08-09"}},
     )
     assert response.status_code == 422
+
+
+def test_purchase_order_request_is_accepted_and_returned() -> None:
+    project = _project()
+    payload = {
+        "record_type": "purchase_order_request",
+        "project_id": project["id"],
+        "cost_code": "03-310",
+        "work_date": str(date.today()),
+        "title": "PO-12345678-FIELD-OPS-001 — PVC pipe and fittings",
+        "status": "pending_approval",
+        "details": {
+            "po_number": "PO-12345678-FIELD-OPS-001",
+            "job_number": "FIELD-OPS-001",
+            "purpose": "PVC pipe and fittings",
+            "amount_estimate": 1250.5,
+        },
+    }
+
+    response = client.post("/api/v1/field-operations/records", json=payload)
+
+    assert response.status_code == 201
+    assert response.json()["record_type"] == "purchase_order_request"
+    assert response.json()["status"] == "pending_approval"
+    bootstrap = client.get("/api/v1/field-operations/bootstrap")
+    assert bootstrap.status_code == 200
+    stored = next(
+        item
+        for item in bootstrap.json()["records"]
+        if item["id"] == response.json()["id"]
+    )
+    assert stored["details"]["po_number"] == "PO-12345678-FIELD-OPS-001"


### PR DESCRIPTION
Closes #170.

## What changed

- Adds `purchase_order_request` to the backend field-record type contract.
- Converts FastAPI validation arrays into readable field-level messages.
- Formats structured `{ message, blockers }` API responses without JavaScript object coercion.
- Adds backend coverage proving a valid PO request is created and returned by the field-operations bootstrap endpoint.
- Adds frontend regression coverage proving structured validation errors never render as `[object Object]`.

## Validation

- Ruff targeted checks: passed.
- Backend Request PO/field-operations tests: 17 passed; one pre-existing Pydantic warning.
- `git diff --check`: passed.
- Local frontend dependency installation was blocked by the workspace npm cache/filesystem configuration after one clean retry. GitHub CI is the required frontend validation gate.

## Design

The locked Iron House visual design is unchanged.

## Approval boundary

Draft only. No merge, staging mutation, or production deployment was performed.