### PR TITLE
Restore least-privilege production runner wrapper execution

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -105,12 +105,18 @@ jobs:
             --dir "$RUNNER_TEMP/release-evidence"
           test -f "$RUNNER_TEMP/release-evidence/evidence.json"
 
+      - name: Verify installed production wrapper
+        run: |
+          installed_wrapper=/usr/local/sbin/ihos-production-deploy
+          trusted_wrapper="$GITHUB_WORKSPACE/.deploy-tooling/ops/digitalocean/production-deploy-wrapper.sh"
+          [[ "$(stat -c '%U:%G:%a' "$installed_wrapper")" == "root:root:755" ]]
+          cmp --silent "$trusted_wrapper" "$installed_wrapper"
+
       - name: Execute restricted production cutover
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
         run: >-
-          sudo /bin/bash
-          "$GITHUB_WORKSPACE/.deploy-tooling/ops/digitalocean/production-deploy-wrapper.sh"
+          sudo -n /usr/local/sbin/ihos-production-deploy
           --release "$RELEASE_SHA"
           --evidence "$RUNNER_TEMP/release-evidence/evidence.json"
 

--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -15,6 +15,9 @@ DigitalOcean web console.
   name before cutover, preventing a parallel stack from being created.
 - The runner account has passwordless sudo access only to the validated
   production deployment wrapper.
+- Before cutover, the workflow verifies that the installed wrapper is owned by
+  `root:root`, has mode `0755`, and exactly matches the trusted workflow
+  checkout. A stale or modified wrapper fails closed.
 - The production workflow uses GitHub's `production` environment as the human
   approval boundary.
 
@@ -30,3 +33,19 @@ sudo bash ops/digitalocean/install-production-runner.sh
 After the service reports healthy, production releases are started through the
 manual `Production deploy` GitHub Actions workflow. Do not run arbitrary shell
 commands through the production runner.
+
+## Controlled wrapper refresh
+
+Whenever `ops/digitalocean/production-deploy-wrapper.sh` changes, refresh only
+the root-owned launcher from an approved `main` checkout on
+`iron-house-os-prod-1` before the next deployment:
+
+```bash
+sudo bash ops/digitalocean/install-production-runner.sh --refresh-wrapper-only
+```
+
+This mode updates `/usr/local/sbin/ihos-production-deploy`, rewrites and
+validates its narrow sudoers rule, and exits without registering, restarting,
+or reconfiguring the runner service. Treat the refresh as a production
+infrastructure change: obtain explicit approval and record the exact source
+commit before running it.

--- a/ops/digitalocean/install-production-runner.sh
+++ b/ops/digitalocean/install-production-runner.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+mode=install
+if (($#)); then
+  if [[ "$1" == "--refresh-wrapper-only" && $# -eq 1 ]]; then
+    mode=refresh-wrapper
+  else
+    echo "Usage: $0 [--refresh-wrapper-only]" >&2
+    exit 2
+  fi
+fi
+
 repository=iron-house-os/iron-house-os
 runner_user=ihos-runner
 runner_root=/opt/iron-house-os-actions-runner
@@ -22,17 +32,22 @@ if [[ ! -f /etc/iron-house-os/production.env || ! -f "$wrapper_source" ]]; then
   echo "Production environment or deployment wrapper is missing." >&2
   exit 1
 fi
-if ! gh auth status --hostname github.com >/dev/null 2>&1; then
-  echo "GitHub CLI must already be authenticated for $repository." >&2
-  exit 1
-fi
-
 install -o root -g root -m 0755 "$wrapper_source" "$wrapper_target"
 printf '%s\n' \
   "$runner_user ALL=(root) NOPASSWD: $wrapper_target *" \
   >"$sudoers_target"
 chmod 0440 "$sudoers_target"
 visudo -cf "$sudoers_target" >/dev/null
+
+if [[ "$mode" == "refresh-wrapper" ]]; then
+  echo "Production deployment wrapper and sudo policy refreshed."
+  exit 0
+fi
+
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  echo "GitHub CLI must already be authenticated for $repository." >&2
+  exit 1
+fi
 
 if ! id "$runner_user" >/dev/null 2>&1; then
   useradd --system --create-home --home-dir "$runner_root" --shell /usr/sbin/nologin "$runner_user"

--- a/tests/backend/test_deploy_agent.py
+++ b/tests/backend/test_deploy_agent.py
@@ -48,7 +48,22 @@ def test_production_deploy_uses_trusted_workflow_tooling() -> None:
     assert "ref: ${{ github.workflow_sha }}" in workflow
     assert "path: .deploy-tooling" in workflow
     assert workflow.count("persist-credentials: false") == 2
-    assert (
-        '"$GITHUB_WORKSPACE/.deploy-tooling/ops/digitalocean/production-deploy-wrapper.sh"'
-        in workflow
+    assert 'cmp --silent "$trusted_wrapper" "$installed_wrapper"' in workflow
+    assert '"root:root:755"' in workflow
+    assert "sudo -n /usr/local/sbin/ihos-production-deploy" in workflow
+    assert "sudo /bin/bash" not in workflow
+
+
+def test_production_runner_has_bounded_wrapper_refresh_mode() -> None:
+    installer = (ROOT / "ops/digitalocean/install-production-runner.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "--refresh-wrapper-only" in installer
+    assert 'if [[ "$mode" == "refresh-wrapper" ]]' in installer
+    assert installer.index('install -o root -g root -m 0755') < installer.index(
+        'if [[ "$mode" == "refresh-wrapper" ]]'
+    )
+    assert installer.index('if [[ "$mode" == "refresh-wrapper" ]]') < installer.index(
+        "gh auth status"
     )


### PR DESCRIPTION
Closes #185.

## Root cause

The approved production deployment reached the protected runner and failed before cutover because the workflow invoked `sudo /bin/bash <checkout>/production-deploy-wrapper.sh`. The runner's intentionally narrow sudoers rule allows only the root-owned `/usr/local/sbin/ihos-production-deploy` launcher, so sudo correctly refused a passwordless arbitrary shell.

## Changes

- Invoke the root-owned allowlisted launcher with `sudo -n`.
- Fail closed unless the installed launcher is `root:root`, mode `0755`, and byte-for-byte identical to the trusted workflow checkout.
- Add a bounded `--refresh-wrapper-only` installer mode that updates and validates only the launcher and sudoers rule, without registering, restarting, or reconfiguring the runner.
- Add regression coverage preventing `sudo /bin/bash` from returning.
- Document the controlled production-host refresh and approval boundary.

## Local validation

- Shell syntax: passed.
- Deployment policy tests executed directly: 5 passed.
- Python compile: passed.
- `git diff --check`: passed.
- Full pytest/Ruff deferred to GitHub CI because the sandbox lacks installed project dependencies.

## Approval boundary

Draft only. No production runner, infrastructure, secrets, data, DNS, certificates, backups, or deployment state were changed. After merge, the root-owned wrapper refresh remains a separate protected infrastructure approval before a new production dispatch.