### PR TITLE
Persist safety training credential status (#70)

### DIFF
--- a/backend/app/api/v1/routes/field_operations.py
+++ b/backend/app/api/v1/routes/field_operations.py
@@ -47,8 +47,17 @@ def create_employee(payload: EmployeeCreate, db: DBSession, user: CurrentUser) -
 
 
 @router.post("/certifications", response_model=CertificationRead, status_code=status.HTTP_201_CREATED)
-def create_certification(payload: CertificationCreate, db: DBSession) -> CertificationRead:
-    return field_operations.create_certification(db, payload)
+def create_certification(payload: CertificationCreate, db: DBSession, user: CurrentUser) -> CertificationRead:
+    return field_operations.create_certification(db, payload, user)
+
+
+@router.get("/certifications.csv")
+def export_certifications(db: DBSession, user: CurrentUser) -> Response:
+    return Response(
+        content=field_operations.export_certifications_csv(db, user),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="safety-credential-status.csv"'},
+    )
 
 
 @router.post("/vehicles", response_model=VehicleRead, status_code=status.HTTP_201_CREATED)

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -395,15 +395,16 @@ def export_certifications_csv(db: Session, user: AuthenticatedUser) -> str:
         "document_id",
         "notes",
     ])
+
     def safe_cell(value: object) -> object:
         if not isinstance(value, str):
             return value
-        return f"'{value}" if value.startswith(("=", "+", "-", "@")) else value
+        return f"'{value}" if value.lstrip().startswith(("=", "+", "-", "@")) else value
 
     for item in certifications:
         employee = employees.get(item.employee_id)
         status = certification_schema(item)
-        writer.writerow([safe_cell(value) for value in [
+        row = [
             f"{employee.first_name} {employee.last_name}" if employee else "Unknown employee",
             employee.status if employee else "unknown",
             employee.role or employee.portal_role if employee else "",
@@ -416,7 +417,8 @@ def export_certifications_csv(db: Session, user: AuthenticatedUser) -> str:
             status.days_until_expiry if status.days_until_expiry is not None else "",
             str(item.document_id) if item.document_id else "",
             item.notes or "",
-        ]])
+        ]
+        writer.writerow([safe_cell(value) for value in row])
     return output.getvalue()
 
 

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -1,4 +1,6 @@
+import csv
 from datetime import UTC, date, datetime, timedelta
+from io import StringIO
 import secrets
 from uuid import UUID
 
@@ -347,13 +349,75 @@ def create_employee(db: Session, payload: EmployeeCreate, user: AuthenticatedUse
     return EmployeeRead.model_validate(item).model_copy(update={"portal_access_created": access_created, "temporary_password": temporary_password if access_created else None})
 
 
-def create_certification(db: Session, payload: CertificationCreate) -> CertificationRead:
+def create_certification(
+    db: Session,
+    payload: CertificationCreate,
+    user: AuthenticatedUser,
+) -> CertificationRead:
+    if user.role not in {"admin", "operations_manager"}:
+        raise AppError("Management access is required to manage safety credentials.", status_code=403)
     require_exists(db, Employee, payload.employee_id, "Employee")
     item = EmployeeCertification(**payload.model_dump())
     db.add(item)
     commit(db)
     db.refresh(item)
     return certification_schema(item)
+
+
+def export_certifications_csv(db: Session, user: AuthenticatedUser) -> str:
+    if user.role not in {"admin", "operations_manager"}:
+        raise AppError("Management access is required to export safety credentials.", status_code=403)
+
+    employees = {
+        item.id: item
+        for item in db.scalars(select(Employee).order_by(Employee.last_name, Employee.first_name))
+    }
+    certifications = db.scalars(
+        select(EmployeeCertification).order_by(
+            EmployeeCertification.employee_id,
+            EmployeeCertification.name,
+            EmployeeCertification.expiry_date,
+        )
+    )
+    output = StringIO()
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow([
+        "employee",
+        "employee_status",
+        "role",
+        "credential",
+        "issuer",
+        "certificate_number",
+        "issued_date",
+        "expiry_date",
+        "operational_status",
+        "days_until_expiry",
+        "document_id",
+        "notes",
+    ])
+    def safe_cell(value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        return f"'{value}" if value.startswith(("=", "+", "-", "@")) else value
+
+    for item in certifications:
+        employee = employees.get(item.employee_id)
+        status = certification_schema(item)
+        writer.writerow([safe_cell(value) for value in [
+            f"{employee.first_name} {employee.last_name}" if employee else "Unknown employee",
+            employee.status if employee else "unknown",
+            employee.role or employee.portal_role if employee else "",
+            item.name,
+            item.issuer or "",
+            item.certificate_number or "",
+            item.issued_date.isoformat() if item.issued_date else "",
+            item.expiry_date.isoformat() if item.expiry_date else "",
+            status.expiry_status,
+            status.days_until_expiry if status.days_until_expiry is not None else "",
+            str(item.document_id) if item.document_id else "",
+            item.notes or "",
+        ]])
+    return output.getvalue()
 
 
 def create_vehicle(db: Session, payload: VehicleCreate) -> VehicleRead:

--- a/docs/safety/training-credential-register.md
+++ b/docs/safety/training-credential-register.md
@@ -5,7 +5,7 @@ This increment advances issue #70 Phase 3 by replacing the browser-local People 
 ## Controls
 
 - Only administrators and operations managers can add credential records or export the company register.
-- Employees and other portal roles continue to receive only the certification records already scoped to their own bootstrap response.
+- Portal roles continue to receive only the certification records allowed by the existing field-operations bootstrap authorization; the company-wide export is management-only.
 - Expiry status is calculated from the stored expiry date: `current`, `expires_soon` (60 days or fewer), `expired`, or `no_expiry`.
 - Management alerts continue to identify credentials expiring within 60 days.
 - The CSV export neutralizes spreadsheet-formula prefixes in user-entered text and is delivered as `safety-credential-status.csv`.

--- a/docs/safety/training-credential-register.md
+++ b/docs/safety/training-credential-register.md
@@ -1,0 +1,28 @@
+# Safety training and credential register
+
+This increment advances issue #70 Phase 3 by replacing the browser-local People & Compliance credential list with company records already stored in `employee_certifications`.
+
+## Controls
+
+- Only administrators and operations managers can add credential records or export the company register.
+- Employees and other portal roles continue to receive only the certification records already scoped to their own bootstrap response.
+- Expiry status is calculated from the stored expiry date: `current`, `expires_soon` (60 days or fewer), `expired`, or `no_expiry`.
+- Management alerts continue to identify credentials expiring within 60 days.
+- The CSV export neutralizes spreadsheet-formula prefixes in user-entered text and is delivered as `safety-credential-status.csv`.
+
+## Deliberate boundary
+
+The register reports operational dates and stored evidence only. It does not decide whether a worker is legally compliant, competent, or authorized for a task. Required-credential policy, regulatory conclusions, disciplinary records, and external reporting remain behind the human approval gate in issue #70.
+
+The company safety manual, worker orientations, supervisor verification, and field controls remain the authoritative operational sources. A credential status cannot release blocked work.
+
+## Validation
+
+Backend tests verify:
+
+- viewer denial for credential creation and company CSV export;
+- operations-manager creation;
+- 60-day status calculation;
+- CSV response headers and exported status evidence.
+
+Frontend validation covers the existing locked Iron House design while replacing the local credential state with the authenticated field-operations API.

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -56,6 +56,19 @@ export type FieldRecord = {
   alert_recipients: string[];
   submitted_by: string | null;
 };
+export type Certification = {
+  id: string;
+  employee_id: string;
+  name: string;
+  issuer: string | null;
+  certificate_number: string | null;
+  issued_date: string | null;
+  expiry_date: string | null;
+  document_id: string | null;
+  notes: string | null;
+  expiry_status: "current" | "expires_soon" | "expired" | "no_expiry";
+  days_until_expiry: number | null;
+};
 export type FieldOperationsBootstrap = {
   employees: Employee[];
   projects: SelectRecord[];
@@ -107,7 +120,7 @@ export type FieldOperationsBootstrap = {
   vehicle_logs: VehicleLog[];
   time_entries: Array<Record<string, unknown>>;
   records: FieldRecord[];
-  certifications: Array<Record<string, unknown>>;
+  certifications: Certification[];
   alerts: Array<{ type: string; severity: string; title: string; recipients: string[] }>;
   toolbox_talk: {
     week_of: string;
@@ -205,5 +218,6 @@ export const fieldOperationsApi = {
   createEmployee: (payload: Record<string, unknown>) =>
     request("/field-operations/employees", { method: "POST", body: JSON.stringify(payload) }),
   createCertification: (payload: Record<string, unknown>) =>
-    request("/field-operations/certifications", { method: "POST", body: JSON.stringify(payload) }),
+    request<Certification>("/field-operations/certifications", { method: "POST", body: JSON.stringify(payload) }),
+  certificationExportUrl: API_BASE_URL + "/field-operations/certifications.csv",
 };

--- a/frontend/src/pages/SafetyProgramPage.tsx
+++ b/frontend/src/pages/SafetyProgramPage.tsx
@@ -5,6 +5,7 @@ import {
   BrainCircuit,
   CheckCircle2,
   ClipboardCheck,
+  Download,
   FileWarning,
   GraduationCap,
   HardHat,
@@ -16,7 +17,10 @@ import {
   Sparkles,
   Users,
 } from "lucide-react";
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import { Certification, Employee, fieldOperationsApi } from "../api/fieldOperations";
+import { useAuth } from "../contexts/AuthContext";
 
 const SAFETY_PROGRAM_URL =
   "https://docs.google.com/document/d/1ApKQs4xIR8axW0lIaeqqATDVaZWs1jvSzaZwYK6wUNw/edit?usp=drivesdk";
@@ -39,8 +43,6 @@ type SafetyRecord = {
   supervisor: string;
   acknowledgedBy: string[];
 };
-type TrainingRecord = { id: string; worker: string; credential: string; expiry: string; status: string };
-
 const procedures = [
   { code: "SWP-001", title: "Excavation and Trenching", category: "Earthworks", status: "Controlled" },
   { code: "SWP-002", title: "Ground Disturbance and Utility Locating", category: "Utilities", status: "Controlled" },
@@ -83,18 +85,43 @@ function StatCard({ label, value, note, icon: Icon }: { label: string; value: st
 }
 
 export function SafetyProgramPage() {
+  const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<Tab>("Overview");
   const [records, setRecords] = useStoredState<SafetyRecord[]>("ihos-safety-records-v2", []);
-  const [training, setTraining] = useStoredState<TrainingRecord[]>("ihos-safety-training", []);
+  const [employees, setEmployees] = useState<Employee[]>([]);
+  const [training, setTraining] = useState<Certification[]>([]);
+  const [credentialError, setCredentialError] = useState<string | null>(null);
+  const [credentialLoading, setCredentialLoading] = useState(true);
+  const [credentialSaving, setCredentialSaving] = useState(false);
   const [search, setSearch] = useState("");
   const [task, setTask] = useState("");
   const [project, setProject] = useState("");
   const [generated, setGenerated] = useState<string[]>([]);
 
+  const canManageCredentials = user?.role === "admin" || user?.role === "operations_manager";
+
+  useEffect(() => {
+    let active = true;
+    fieldOperationsApi.bootstrap()
+      .then((data) => {
+        if (!active) return;
+        setEmployees(data.employees);
+        setTraining(data.certifications);
+        setCredentialError(null);
+      })
+      .catch((current) => {
+        if (active) setCredentialError(current instanceof Error ? current.message : "Unable to load safety credentials.");
+      })
+      .finally(() => {
+        if (active) setCredentialLoading(false);
+      });
+    return () => { active = false; };
+  }, []);
+
   const filteredProcedures = procedures.filter((item) => `${item.code} ${item.title} ${item.category}`.toLowerCase().includes(search.toLowerCase()));
   const openActions = records.filter((record) => record.status !== "Complete").length;
   const incidents = records.filter((record) => record.type === "Incident / Near Miss").length;
-  const expiring = useMemo(() => training.filter((item) => item.status !== "Current").length, [training]);
+  const expiring = useMemo(() => training.filter((item) => ["expires_soon", "expired"].includes(item.expiry_status)).length, [training]);
   const blocked = records.filter((record) => record.release === "Blocked" && record.status !== "Complete").length;
 
   function addRecord(event: FormEvent<HTMLFormElement>) {
@@ -113,14 +140,30 @@ export function SafetyProgramPage() {
     setRecords(records.map((record) => record.id === id ? { ...record, ...patch } : record));
   }
 
-  function addTraining(event: FormEvent<HTMLFormElement>) {
+  async function addTraining(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const data = new FormData(event.currentTarget);
-    const expiry = String(data.get("expiry"));
-    const days = expiry ? Math.ceil((new Date(expiry).getTime() - Date.now()) / 86400000) : 9999;
-    const status = days < 0 ? "Expired" : days <= 60 ? "Expiring" : "Current";
-    setTraining([{ id: crypto.randomUUID(), worker: String(data.get("worker")), credential: String(data.get("credential")), expiry, status }, ...training]);
-    event.currentTarget.reset();
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    setCredentialSaving(true);
+    setCredentialError(null);
+    try {
+      await fieldOperationsApi.createCertification({
+        employee_id: String(data.get("employee_id")),
+        name: String(data.get("credential")),
+        issuer: String(data.get("issuer")) || null,
+        certificate_number: String(data.get("certificate_number")) || null,
+        issued_date: String(data.get("issued_date")) || null,
+        expiry_date: String(data.get("expiry_date")) || null,
+      });
+      const refreshed = await fieldOperationsApi.bootstrap();
+      setEmployees(refreshed.employees);
+      setTraining(refreshed.certifications);
+      form.reset();
+    } catch (current) {
+      setCredentialError(current instanceof Error ? current.message : "Unable to save the safety credential.");
+    } finally {
+      setCredentialSaving(false);
+    }
   }
 
   function generateHazards() {
@@ -139,7 +182,26 @@ export function SafetyProgramPage() {
 
     {activeTab === "Field Forms" && <section className="grid gap-6 xl:grid-cols-[400px_1fr]"><form onSubmit={addRecord} className="space-y-3 rounded-xl border border-iron-100 bg-white p-6 shadow-sm"><div className="flex items-center gap-2"><Plus className="h-5 w-5 text-brand-gold-dark" /><h2 className="font-semibold">Create safety record</h2></div><select name="type" className="w-full rounded-md border border-iron-200 p-2 text-sm">{formTypes.map((type) => <option key={type}>{type}</option>)}</select><input required name="title" placeholder="Task, event or action" className="w-full rounded-md border border-iron-200 p-2 text-sm" /><input name="project" placeholder="Project / location" className="w-full rounded-md border border-iron-200 p-2 text-sm" /><input required name="owner" placeholder="Responsible person" className="w-full rounded-md border border-iron-200 p-2 text-sm" /><input required name="supervisor" placeholder="Reviewing supervisor" className="w-full rounded-md border border-iron-200 p-2 text-sm" /><label className="block text-xs font-semibold text-iron-500">Due date<input name="dueDate" type="date" className="mt-1 w-full rounded-md border border-iron-200 p-2 text-sm" /></label><select name="risk" className="w-full rounded-md border border-iron-200 p-2 text-sm"><option>Normal</option><option>High</option><option>Critical</option></select><select name="release" className="w-full rounded-md border border-iron-200 p-2 text-sm"><option>Blocked</option><option>At risk</option><option>Ready</option></select><button className="w-full rounded-md bg-brand-gold px-4 py-2 text-sm font-semibold text-brand-black">Save record</button></form><article className="rounded-xl border border-iron-100 bg-white p-6 shadow-sm"><h2 className="font-semibold">Field record register</h2><div className="mt-4 space-y-4">{records.length === 0 ? <p className="rounded-md bg-iron-50 p-4 text-sm text-iron-500">No records yet.</p> : records.map((record) => <div key={record.id} className="rounded-lg border border-iron-100 p-4"><div className="flex flex-wrap justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{record.type} · {record.created}</div><h3 className="mt-1 font-semibold">{record.title}</h3><p className="mt-1 text-sm text-iron-500">{record.project || "Company"} · Owner: {record.owner} · Supervisor: {record.supervisor}</p><p className="mt-1 text-xs text-iron-500">Due: {record.dueDate || "Not set"} · Acknowledgements: {record.acknowledgedBy.length}</p></div><span className={`h-fit rounded-full px-2 py-1 text-xs font-semibold ${record.release === "Ready" ? "bg-emerald-100 text-emerald-800" : record.release === "At risk" ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800"}`}>{record.release}</span></div><div className="mt-3 grid gap-2 md:grid-cols-[1fr_auto_auto]"><input defaultValue={record.verificationEvidence} onBlur={(e) => updateRecord(record.id, { verificationEvidence: e.target.value, status: e.target.value ? "Pending verification" : "Open" })} placeholder="Verification evidence / reference" className="rounded-md border border-iron-200 p-2 text-sm" /><button onClick={() => { const name = window.prompt("Worker name acknowledging this record"); if (name) updateRecord(record.id, { acknowledgedBy: [...record.acknowledgedBy, name] }); }} className="rounded-md border px-3 py-2 text-xs font-semibold">Acknowledge</button><button disabled={!record.verificationEvidence} onClick={() => updateRecord(record.id, { status: "Complete", release: "Ready" })} className="rounded-md bg-iron-950 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40">Verify & close</button></div></div>)}</div></article></section>}
 
-    {activeTab === "People & Compliance" && <section className="grid gap-6 xl:grid-cols-[380px_1fr]"><form onSubmit={addTraining} className="space-y-3 rounded-xl border border-iron-100 bg-white p-6 shadow-sm"><div className="flex items-center gap-2"><Users className="h-5 w-5 text-brand-gold-dark" /><h2 className="font-semibold">Add competency record</h2></div><input required name="worker" placeholder="Worker name" className="w-full rounded-md border border-iron-200 p-2 text-sm" /><input required name="credential" placeholder="Ticket, orientation or competency" className="w-full rounded-md border border-iron-200 p-2 text-sm" /><label className="block text-xs font-semibold text-iron-500">Expiry date<input name="expiry" type="date" className="mt-1 w-full rounded-md border border-iron-200 p-2 text-sm" /></label><button className="w-full rounded-md bg-brand-gold px-4 py-2 text-sm font-semibold text-brand-black">Save competency</button></form><article className="rounded-xl border border-iron-100 bg-white p-6 shadow-sm"><h2 className="font-semibold">Training and competency matrix</h2><div className="mt-4 overflow-x-auto"><table className="w-full text-left text-sm"><thead><tr className="border-b text-xs uppercase text-iron-500"><th className="p-2">Worker</th><th className="p-2">Credential</th><th className="p-2">Expiry</th><th className="p-2">Status</th></tr></thead><tbody>{training.map((item) => <tr key={item.id} className="border-b"><td className="p-2 font-medium">{item.worker}</td><td className="p-2">{item.credential}</td><td className="p-2">{item.expiry || "No expiry"}</td><td className="p-2"><span className={`rounded-full px-2 py-1 text-xs font-semibold ${item.status === "Current" ? "bg-emerald-100 text-emerald-800" : item.status === "Expiring" ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800"}`}>{item.status}</span></td></tr>)}</tbody></table>{training.length === 0 && <p className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">No competency records entered.</p>}</div></article></section>}
+    {activeTab === "People & Compliance" && <section className="grid gap-6 xl:grid-cols-[380px_1fr]">
+      <div className="space-y-4">
+        {canManageCredentials ? <form onSubmit={(event) => void addTraining(event)} className="space-y-3 rounded-xl border border-iron-100 bg-white p-6 shadow-sm">
+          <div className="flex items-center gap-2"><Users className="h-5 w-5 text-brand-gold-dark" /><h2 className="font-semibold">Add credential record</h2></div>
+          <select required name="employee_id" defaultValue="" className="w-full rounded-md border border-iron-200 p-2 text-sm"><option value="" disabled>Select worker</option>{employees.map((employee) => <option key={employee.id} value={employee.id}>{employee.first_name} {employee.last_name}</option>)}</select>
+          <input required name="credential" placeholder="Ticket, course or competency" className="w-full rounded-md border border-iron-200 p-2 text-sm" />
+          <input name="issuer" placeholder="Issuer / trainer" className="w-full rounded-md border border-iron-200 p-2 text-sm" />
+          <input name="certificate_number" placeholder="Certificate number" className="w-full rounded-md border border-iron-200 p-2 text-sm" />
+          <label className="block text-xs font-semibold text-iron-500">Issued date<input name="issued_date" type="date" className="mt-1 w-full rounded-md border border-iron-200 p-2 text-sm" /></label>
+          <label className="block text-xs font-semibold text-iron-500">Expiry date<input name="expiry_date" type="date" className="mt-1 w-full rounded-md border border-iron-200 p-2 text-sm" /></label>
+          <button disabled={credentialSaving || !employees.length} className="w-full rounded-md bg-brand-gold px-4 py-2 text-sm font-semibold text-brand-black disabled:opacity-50">{credentialSaving ? "Saving…" : "Save credential"}</button>
+        </form> : <div className="rounded-xl border border-iron-100 bg-white p-5 text-sm text-iron-600 shadow-sm">Credential changes are restricted to administrators and operations managers.</div>}
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-xs leading-5 text-amber-900"><b>Operational status only:</b> this register reports stored dates. It does not determine legal compliance, worker competency, or authorization to perform work.</div>
+      </div>
+      <article className="rounded-xl border border-iron-100 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3"><div><h2 className="font-semibold">Training and credential status</h2><p className="mt-1 text-sm text-iron-500">Live company records with 60-day expiry warnings.</p></div>{canManageCredentials ? <a href={fieldOperationsApi.certificationExportUrl} className="inline-flex items-center gap-2 rounded-md border border-brand-gold px-3 py-2 text-sm font-semibold text-brand-gold-dark"><Download className="h-4 w-4" />Export CSV</a> : null}</div>
+        {credentialError ? <div role="alert" className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{credentialError}</div> : null}
+        <div className="mt-4 overflow-x-auto"><table className="w-full text-left text-sm"><thead><tr className="border-b text-xs uppercase text-iron-500"><th className="p-2">Worker</th><th className="p-2">Credential</th><th className="p-2">Issuer</th><th className="p-2">Expiry</th><th className="p-2">Status</th></tr></thead><tbody>{training.map((item) => { const employee = employees.find((candidate) => candidate.id === item.employee_id); const current = ["current", "no_expiry"].includes(item.expiry_status); const warning = item.expiry_status === "expires_soon"; return <tr key={item.id} className="border-b"><td className="p-2 font-medium">{employee ? `${employee.first_name} ${employee.last_name}` : "Unknown employee"}</td><td className="p-2">{item.name}</td><td className="p-2">{item.issuer || "Not entered"}</td><td className="p-2">{item.expiry_date || "No expiry"}</td><td className="p-2"><span className={`rounded-full px-2 py-1 text-xs font-semibold ${current ? "bg-emerald-100 text-emerald-800" : warning ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800"}`}>{item.expiry_status.replaceAll("_", " ")}</span></td></tr>; })}</tbody></table>{credentialLoading ? <p className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">Loading credential records…</p> : training.length === 0 ? <p className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">No credential records entered.</p> : null}</div>
+      </article>
+    </section>}
 
     {activeTab === "Reporting" && <section className="space-y-5"><div className="grid gap-4 md:grid-cols-4"><StatCard label="Total records" value={records.length} note="All field and management records" icon={BarChart3} /><StatCard label="Incidents" value={incidents} note="Incident and near-miss records" icon={FileWarning} /><StatCard label="Closed records" value={records.filter((r) => r.status === "Complete").length} note="Evidence entered and verified" icon={CheckCircle2} /><StatCard label="Critical records" value={records.filter((r) => r.risk === "Critical").length} note="Immediate management attention" icon={Siren} /></div><article className="rounded-xl border border-iron-100 bg-white p-6 shadow-sm"><h2 className="font-semibold">Safety analytics</h2><div className="mt-5 grid gap-4 md:grid-cols-2">{formTypes.slice(0, 6).map((type) => { const count = records.filter((r) => r.type === type).length; const width = records.length ? Math.max(5, Math.round((count / records.length) * 100)) : 0; return <div key={type}><div className="flex justify-between text-sm"><span>{type}</span><b>{count}</b></div><div className="mt-2 h-2 rounded-full bg-iron-100"><div className="h-2 rounded-full bg-brand-gold" style={{ width: `${width}%` }} /></div></div>; })}</div><p className="mt-5 text-xs text-iron-500">Browser-local analytics remain a staging implementation. Company-wide reporting requires the production database and authentication layer.</p></article><article className="rounded-xl border border-iron-100 bg-white p-6 shadow-sm"><div className="flex items-center gap-3"><QrCode className="text-brand-gold-dark" /><div><h2 className="font-semibold">Field deployment</h2><p className="text-sm text-iron-500">QR-ready links are staged for equipment and procedure records once permanent URLs and asset IDs are confirmed.</p></div></div></article></section>}
 

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -212,7 +212,7 @@ def test_safety_credentials_are_management_only_and_export_operational_status() 
     payload = {
         "employee_id": employee["id"],
         "name": "Occupational First Aid",
-        "issuer": "Approved trainer",
+        "issuer": "=Approved trainer",
         "certificate_number": "FA-100",
         "issued_date": str(date.today() - timedelta(days=335)),
         "expiry_date": str(date.today() + timedelta(days=30)),
@@ -237,6 +237,7 @@ def test_safety_credentials_are_management_only_and_export_operational_status() 
     assert "Crew Member" in exported.text
     assert "Occupational First Aid" in exported.text
     assert "expires_soon" in exported.text
+    assert "'=Approved trainer" in exported.text
 
 
 def test_job_workbook_compares_estimated_installed_and_remaining_quantities() -> None:

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -12,6 +12,21 @@ from app.services.auth import AuthenticatedUser
 client = TestClient(app)
 
 
+def _authenticate_as(role: str) -> None:
+    def override(request: Request) -> AuthenticatedUser:
+        user = AuthenticatedUser(
+            id=UUID("00000000-0000-0000-0000-000000000070"),
+            email=f"{role}@ironhousecontracting.com",
+            display_name=f"Test {role.replace('_', ' ').title()}",
+            role=role,
+            session_version=1,
+        )
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = override
+
+
 def _employee() -> dict:
     response = client.post(
         "/api/v1/field-operations/employees",
@@ -190,6 +205,38 @@ def test_course_ticket_expiry_creates_management_alert() -> None:
     assert response.json()["expiry_status"] == "expires_soon"
     alerts = client.get("/api/v1/field-operations/bootstrap").json()["alerts"]
     assert any(alert["type"] == "ticket_expiry" for alert in alerts)
+
+
+def test_safety_credentials_are_management_only_and_export_operational_status() -> None:
+    employee = _employee()
+    payload = {
+        "employee_id": employee["id"],
+        "name": "Occupational First Aid",
+        "issuer": "Approved trainer",
+        "certificate_number": "FA-100",
+        "issued_date": str(date.today() - timedelta(days=335)),
+        "expiry_date": str(date.today() + timedelta(days=30)),
+        "notes": "Renewal booking is an operational follow-up, not a compliance conclusion.",
+    }
+
+    _authenticate_as("viewer")
+    denied_create = client.post("/api/v1/field-operations/certifications", json=payload)
+    assert denied_create.status_code == 403
+    denied_export = client.get("/api/v1/field-operations/certifications.csv")
+    assert denied_export.status_code == 403
+
+    _authenticate_as("operations_manager")
+    created = client.post("/api/v1/field-operations/certifications", json=payload)
+    assert created.status_code == 201
+    assert created.json()["expiry_status"] == "expires_soon"
+
+    exported = client.get("/api/v1/field-operations/certifications.csv")
+    assert exported.status_code == 200
+    assert exported.headers["content-type"].startswith("text/csv")
+    assert "safety-credential-status.csv" in exported.headers["content-disposition"]
+    assert "Crew Member" in exported.text
+    assert "Occupational First Aid" in exported.text
+    assert "expires_soon" in exported.text
 
 
 def test_job_workbook_compares_estimated_installed_and_remaining_quantities() -> None:


### PR DESCRIPTION
Advances #70 Phase 3.

## Scope
- replaces the browser-local People & Compliance credential list with authenticated company records
- restricts credential creation and company CSV export to administrators and operations managers
- calculates and displays current, expires-soon, expired and no-expiry operational statuses
- adds a management CSV export with spreadsheet-formula neutralization
- preserves the locked Iron House visual design
- documents the explicit boundary: stored dates are not legal-compliance, competency or work-authorization conclusions

## Validation
- local backend Ruff: passed
- local backend pytest: 359 passed, 1 existing warning
- local frontend TypeScript: passed
- local frontend Vitest: 49 passed
- local frontend production build: passed (existing bundle-size warning)
- GitHub CI run 31971503450: passed
- GitHub release-readiness run 31971503448: passed, including staging isolation, browser/mobile/accessibility, disposable production-stack smoke, disposable staging smoke, backup, restore, rollback and evidence gates
- unresolved review threads: none
- submitted reviews: none

## Gates
- Draft PR pending human review and explicit owner authorization before merge.
- No live staging mutation.
- No production deployment.
- No policy language, regulatory conclusion, disciplinary record or external report is changed by this PR.

## Build record
https://docs.google.com/document/d/13zMSNA4_2U5rrOyOChCk-rsrnP11I3-2QufZPblVMec/edit