### PR TITLE
Persist privacy-scoped safety occurrence records

### DIFF
--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -30,6 +30,8 @@ RecordType = Literal[
     "safety_permit",
     "corrective_action",
     "emergency_action_card",
+    "incident",
+    "first_aid_record",
 ]
 
 
@@ -226,6 +228,37 @@ class FieldRecordCreate(BaseModel):
                 raise ValueError("Time-off requests require valid start and end dates.") from exc
             if end < start:
                 raise ValueError("Time-off end date cannot be before the start date.")
+        if self.record_type == "incident":
+            if self.details.get("occurrence_kind") not in {"incident", "near_miss"}:
+                raise ValueError("Select incident or near miss.")
+            required = {
+                "occurred_at": "Enter when the occurrence happened.",
+                "location": "Enter the occurrence location.",
+                "description": "Describe what happened.",
+                "immediate_controls": "Record the immediate controls taken.",
+            }
+            for key, message in required.items():
+                if not str(self.details.get(key) or "").strip():
+                    raise ValueError(message)
+        if self.record_type == "first_aid_record":
+            if not self.employee_id:
+                raise ValueError("Select the worker for the first-aid occurrence.")
+            required = {
+                "occurred_at": "Enter when the occurrence happened.",
+                "location": "Enter the occurrence location.",
+                "first_aid_attendant": "Enter the first-aid attendant.",
+                "general_nature": "Enter the general nature of the occurrence.",
+                "aid_provided": "Record the aid provided.",
+            }
+            for key, message in required.items():
+                if not str(self.details.get(key) or "").strip():
+                    raise ValueError(message)
+            if self.details.get("outcome") not in {
+                "returned_to_work",
+                "referred_for_further_assessment",
+                "transported_for_further_assessment",
+            }:
+                raise ValueError("Select the recorded outcome.")
         return self
 
 
@@ -266,12 +299,21 @@ class FLHARelease(BaseModel):
 
 
 class SafetyRecordUpdate(BaseModel):
-    status: Literal["blocked", "at_risk", "ready", "open", "verification", "closed"]
+    status: Literal[
+        "blocked",
+        "at_risk",
+        "ready",
+        "open",
+        "verification",
+        "reported",
+        "under_review",
+        "closed",
+    ]
     evidence: str | None = Field(default=None, max_length=4000)
 
     @model_validator(mode="after")
     def require_evidence_for_completion(self) -> "SafetyRecordUpdate":
-        if self.status in {"ready", "verification", "closed"} and not (self.evidence or "").strip():
+        if self.status in {"ready", "verification", "under_review", "closed"} and not (self.evidence or "").strip():
             raise ValueError("Verification evidence is required for that status.")
         return self
 

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -4,7 +4,7 @@ from io import StringIO
 import secrets
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -610,12 +610,23 @@ def update_safety_record_status(
         }
         if payload.status not in transitions.get(item.status, set()):
             raise AppError(f"Incident status cannot move from {item.status} to {payload.status}.", status_code=409)
+    previous_status = item.status
     history = list((item.details or {}).get("status_history") or [])
-    history.append({"from": item.status, "to": payload.status, "by": user.display_name, "at": datetime.now(UTC).isoformat(), "evidence": payload.evidence})
-    item.status = payload.status
-    item.details = {**(item.details or {}), "verification_evidence": payload.evidence, "status_history": history}
-    item.resolved_at = datetime.now(UTC) if payload.status in {"ready", "closed"} else None
-    db.add(item)
+    history.append({"from": previous_status, "to": payload.status, "by": user.display_name, "at": datetime.now(UTC).isoformat(), "evidence": payload.evidence})
+    next_details = {**(item.details or {}), "verification_evidence": payload.evidence, "status_history": history}
+    next_resolved_at = datetime.now(UTC) if payload.status in {"ready", "closed"} else None
+    result = db.execute(
+        update(FieldRecord)
+        .where(FieldRecord.id == record_id, FieldRecord.status == previous_status)
+        .values(status=payload.status, details=next_details, resolved_at=next_resolved_at)
+        .execution_options(synchronize_session=False)
+    )
+    if result.rowcount != 1:
+        db.rollback()
+        raise AppError(
+            "Safety record changed while it was being updated. Reload and try again.",
+            status_code=409,
+        )
     commit(db)
     db.refresh(item)
     return FieldRecordRead.model_validate(item)

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -44,6 +44,8 @@ from app.services.cost_codes import get_cost_code_library
 
 
 MANAGEMENT_ALERT_RECIPIENTS = ["Jeremie Peters", "Mac Warren"]
+MANAGEMENT_ROLES = {"admin", "operations_manager"}
+SENSITIVE_OCCURRENCE_TYPES = {"incident", "first_aid_record"}
 FLHA_SCREENING_ITEMS = [
     "first_aid_equipment",
     "overhead_hazards",
@@ -155,6 +157,17 @@ def get_bootstrap(db: Session, user: AuthenticatedUser) -> FieldOperationsBootst
     material_movement_summary = build_material_movement_summary(db)
     milestone_recognitions = build_milestone_recognitions(db)
     paperwork_recognitions = build_paperwork_recognitions(db, employees)
+    if user.role == "estimator":
+        records = [item for item in records if item.record_type not in SENSITIVE_OCCURRENCE_TYPES]
+    elif user.role == "viewer" and field_role in {"foreman", "management"}:
+        records = [item for item in records if item.record_type != "first_aid_record"]
+    elif user.role == "viewer" and profile is None:
+        employees = []
+        time_entries = []
+        records = []
+        certifications = []
+        milestone_recognitions = []
+        paperwork_recognitions = []
     if user.role == "viewer" and field_role in {"employee", "operator"}:
         employee_id = profile.id if profile else None
         employees = [profile] if profile else []
@@ -533,6 +546,31 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
         defaults = {"safety_permit": "blocked", "corrective_action": "open", "emergency_action_card": "ready"}
         values["status"] = defaults[payload.record_type]
         values["details"] = {**payload.details, "created_by": user.display_name, "created_at": datetime.now(UTC).isoformat()}
+    if payload.record_type == "incident":
+        if user.role not in MANAGEMENT_ROLES and (
+            profile is None or profile.portal_role not in {"foreman", "management"}
+        ):
+            raise AppError("Foreperson or management access is required to report an incident or near miss.", status_code=403)
+        if user.role == "estimator":
+            raise AppError("Management access is required to report an incident or near miss.", status_code=403)
+        values["status"] = "reported"
+        alerts = MANAGEMENT_ALERT_RECIPIENTS
+        values["details"] = {
+            **payload.details,
+            "reported_by": user.display_name,
+            "reported_at": datetime.now(UTC).isoformat(),
+            "status_history": [],
+        }
+    if payload.record_type == "first_aid_record":
+        if user.role not in MANAGEMENT_ROLES:
+            raise AppError("Management access is required to create a first-aid occurrence record.", status_code=403)
+        values["status"] = "recorded"
+        alerts = []
+        values["details"] = {
+            **payload.details,
+            "recorded_by": user.display_name,
+            "recorded_at": datetime.now(UTC).isoformat(),
+        }
     values["document_ids"] = [str(document_id) for document_id in payload.document_ids]
     values["alert_recipients"] = alerts
     item = FieldRecord(**values, submitted_by=user.email)
@@ -549,8 +587,10 @@ def update_safety_record_status(
     user: AuthenticatedUser,
 ) -> FieldRecordRead:
     item = require_exists(db, FieldRecord, record_id, "Safety record")
-    if item.record_type not in {"safety_permit", "corrective_action", "emergency_action_card"}:
+    if item.record_type not in {"safety_permit", "corrective_action", "emergency_action_card", "incident"}:
         raise AppError("That record is not a safety-control record.", status_code=400)
+    if item.record_type == "incident" and user.role not in MANAGEMENT_ROLES:
+        raise AppError("Management access is required to review an incident or near miss.", status_code=403)
     profile = db.scalar(select(Employee).where(Employee.email.ilike(user.email)))
     if user.role not in {"admin", "operations_manager"} and (profile is None or profile.portal_role not in {"foreman", "management"}):
         raise AppError("Foreperson or management access is required to verify safety-control records.", status_code=403)
@@ -558,9 +598,18 @@ def update_safety_record_status(
         "safety_permit": {"blocked", "at_risk", "ready"},
         "corrective_action": {"open", "verification", "closed"},
         "emergency_action_card": {"ready"},
+        "incident": {"reported", "under_review", "closed"},
     }
     if payload.status not in allowed[item.record_type]:
         raise AppError("That status is not valid for this safety record.", status_code=400)
+    if item.record_type == "incident":
+        transitions = {
+            "reported": {"under_review"},
+            "under_review": {"closed"},
+            "closed": set(),
+        }
+        if payload.status not in transitions.get(item.status, set()):
+            raise AppError(f"Incident status cannot move from {item.status} to {payload.status}.", status_code=409)
     history = list((item.details or {}).get("status_history") or [])
     history.append({"from": item.status, "to": payload.status, "by": user.display_name, "at": datetime.now(UTC).isoformat(), "evidence": payload.evidence})
     item.status = payload.status

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -46,6 +46,15 @@ from app.services.cost_codes import get_cost_code_library
 MANAGEMENT_ALERT_RECIPIENTS = ["Jeremie Peters", "Mac Warren"]
 MANAGEMENT_ROLES = {"admin", "operations_manager"}
 SENSITIVE_OCCURRENCE_TYPES = {"incident", "first_aid_record"}
+FIRST_AID_DETAIL_FIELDS = {
+    "occurred_at",
+    "location",
+    "first_aid_attendant",
+    "general_nature",
+    "aid_provided",
+    "outcome",
+    "follow_up",
+}
 FLHA_SCREENING_ITEMS = [
     "first_aid_equipment",
     "overhead_hazards",
@@ -567,7 +576,11 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
         values["status"] = "recorded"
         alerts = []
         values["details"] = {
-            **payload.details,
+            **{
+                key: value
+                for key, value in payload.details.items()
+                if key in FIRST_AID_DETAIL_FIELDS
+            },
             "recorded_by": user.display_name,
             "recorded_at": datetime.now(UTC).isoformat(),
         }

--- a/docs/safety/incident-and-first-aid-occurrence-records.md
+++ b/docs/safety/incident-and-first-aid-occurrence-records.md
@@ -1,0 +1,23 @@
+# Incident and first-aid occurrence records
+
+Iron House OS stores incident, near-miss, and first-aid occurrence records in the authenticated Safety Operations workflow. These are operational records; they do not make regulatory, medical, causation, disciplinary, or return-to-work determinations.
+
+## Incident and near-miss workflow
+
+- Administrators, operations managers, and linked forepersons can submit an incident or near miss.
+- New occurrences start as `reported` and notify the configured management recipients.
+- Management records initial review evidence before moving an occurrence to `under_review`.
+- Closure requires verification evidence. Status changes preserve the prior state, next state, actor, timestamp, and evidence.
+- Estimator accounts cannot create, review, or receive incident details through the field-operations bootstrap.
+
+## First-aid privacy boundary
+
+- Only administrators and operations managers can create or view the company first-aid occurrence register.
+- Linked workers can receive only first-aid records tied to their own employee profile. Forepersons cannot read first-aid details through the bootstrap.
+- The record captures a minimum operational data set: worker, time, location, attendant, general nature, aid provided, recorded outcome, and optional operational follow-up.
+- Do not enter diagnoses, unrelated health history, medical opinions, regulatory conclusions, or disciplinary findings.
+- First-aid occurrence records are recorded evidence and do not use the incident closure workflow.
+
+## Deployment and review
+
+This change adds record types within the existing field-record table and does not require a database migration. Validate authorization tests and the mobile Safety Operations layout in staging before any production approval.

--- a/docs/safety/phase-2-safety-control-records.md
+++ b/docs/safety/phase-2-safety-control-records.md
@@ -11,3 +11,5 @@ High-risk permit readiness, corrective actions, and emergency action cards are a
 - Emergency cards are operational information only. The responsible supervisor must confirm the site details with the crew whenever conditions change.
 
 These workflows preserve the approved Iron House interface and do not publish new safety policy or regulatory conclusions.
+
+Incident, near-miss, and privacy-scoped first-aid occurrence controls are documented separately in [incident-and-first-aid-occurrence-records.md](incident-and-first-aid-occurrence-records.md).

--- a/frontend/src/modules.ts
+++ b/frontend/src/modules.ts
@@ -86,7 +86,7 @@ export const modules: AppModule[] = [
     label: "Safety Operations",
     path: "/safety-operations",
     icon: Siren,
-    description: "High-risk permits, corrective actions, emergency cards and field release controls.",
+    description: "High-risk permits, corrective actions, emergency cards, incident review and privacy-scoped first-aid records.",
     status: "Build 221 active",
   },
   {

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -559,6 +559,10 @@ function RecordForm({ data, mode, onSaved, onError }: { data: FieldOperationsBoo
   const [severity, setSeverity] = useState("none");
   const [quantity, setQuantity] = useState("");
   const [weather, setWeather] = useState("");
+  const [occurrenceKind, setOccurrenceKind] = useState("near_miss");
+  const [occurredAt, setOccurredAt] = useState("");
+  const [occurrenceLocation, setOccurrenceLocation] = useState("");
+  const [immediateControls, setImmediateControls] = useState("");
   const [files, setFiles] = useState<File[]>([]);
   const [attendees, setAttendees] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
@@ -572,11 +576,21 @@ function RecordForm({ data, mode, onSaved, onError }: { data: FieldOperationsBoo
         record_type: recordType, project_id: projectId || null, employee_id: employeeId || null,
         equipment_id: equipmentId || null, supplier_id: supplierId || null, cost_code: costCode || null,
         work_date: today(), title, severity,
-        details: { notes, quantity: quantity || null, weather: weather || null, attendees },
+        details: recordType === "incident"
+          ? {
+              occurrence_kind: occurrenceKind,
+              occurred_at: occurredAt,
+              location: occurrenceLocation,
+              description: notes,
+              immediate_controls: immediateControls,
+              attendees,
+            }
+          : { notes, quantity: quantity || null, weather: weather || null, attendees },
         document_ids: documentIds,
       });
       await linkPhotos(documentIds, "field_record", record.id);
       setTitle(""); setNotes(""); setQuantity(""); setWeather(""); setFiles([]); setAttendees([]); setSeverity("none");
+      setOccurrenceKind("near_miss"); setOccurredAt(""); setOccurrenceLocation(""); setImmediateControls("");
       await onSaved();
     } catch (current) { onError(current instanceof Error ? current.message : "Unable to save field record."); }
     finally { setSaving(false); }
@@ -595,13 +609,19 @@ function RecordForm({ data, mode, onSaved, onError }: { data: FieldOperationsBoo
         <Select label="Issue severity" value={severity} onChange={setSeverity} options={[["none", "No issue"], ["low", "Low"], ["medium", "Medium — alert"], ["high", "High — alert"], ["critical", "Critical — alert"]]} />
         <Input label="Quantity / hours / amount" value={quantity} onChange={setQuantity} />
         <Input label="Weather / temperature" value={weather} onChange={setWeather} />
-        <Input label="Journal, hazards and controls" value={notes} onChange={setNotes} />
+        <Input label={recordType === "incident" ? "What happened" : "Journal, hazards and controls"} value={notes} onChange={setNotes} />
+        {recordType === "incident" ? <>
+          <Select label="Occurrence type" value={occurrenceKind} onChange={setOccurrenceKind} options={[["near_miss", "Near miss"], ["incident", "Incident"]]} />
+          <Input label="Occurred at" value={occurredAt} onChange={setOccurredAt} type="datetime-local" />
+          <Input label="Location" value={occurrenceLocation} onChange={setOccurrenceLocation} />
+          <Input label="Immediate controls taken" value={immediateControls} onChange={setImmediateControls} />
+        </> : null}
         <FilePicker files={files} onChange={setFiles} />
       </div>
       {["daily_hazard_assessment", "toolbox_talk"].includes(recordType) ? (
         <EmployeeChecklist employees={data.employees} selected={attendees} onChange={setAttendees} />
       ) : null}
-      <PrimaryButton disabled={saving || !title}>{saving ? "Saving and uploading…" : "Submit field record"}</PrimaryButton>
+      <PrimaryButton disabled={saving || !title || (recordType === "incident" && (!notes || !occurredAt || !occurrenceLocation || !immediateControls))}>{saving ? "Saving and uploading…" : "Submit field record"}</PrimaryButton>
     </form>
   );
 }

--- a/frontend/src/pages/SafetyOperationsPage.test.tsx
+++ b/frontend/src/pages/SafetyOperationsPage.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fieldOperationsApi } from "../api/fieldOperations";
+import { SafetyOperationsPage } from "./SafetyOperationsPage";
+
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { role: "operations_manager" } }),
+}));
+
+vi.mock("../api/fieldOperations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/fieldOperations")>();
+  return {
+    ...actual,
+    fieldOperationsApi: {
+      ...actual.fieldOperationsApi,
+      bootstrap: vi.fn(),
+      createRecord: vi.fn(),
+      updateSafetyStatus: vi.fn(),
+    },
+  };
+});
+
+describe("SafetyOperationsPage", () => {
+  beforeEach(() => {
+    vi.mocked(fieldOperationsApi.bootstrap).mockResolvedValue({
+      employees: [{ id: "worker-1", first_name: "Crew", last_name: "Member", email: "crew@example.com" }],
+      records: [{
+        id: "incident-1",
+        record_type: "incident",
+        project_id: null,
+        employee_id: "worker-1",
+        equipment_id: null,
+        supplier_id: null,
+        cost_code: null,
+        work_date: "2026-08-17",
+        title: "Excavator swing near miss",
+        status: "reported",
+        severity: "high",
+        details: {
+          occurrence_kind: "near_miss",
+          location: "Field Operations Test",
+          description: "A worker entered the boundary.",
+          immediate_controls: "Work stopped and the boundary was reset.",
+        },
+        document_ids: [],
+        signatures: [],
+        alert_recipients: ["Jeremie Peters", "Mac Warren"],
+        submitted_by: "manager@example.com",
+      }],
+    } as never);
+  });
+
+  it("shows durable incident review and management-only first-aid workflows", async () => {
+    const user = userEvent.setup();
+    render(<SafetyOperationsPage />);
+
+    expect(await screen.findByText("Open incidents")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Incidents / near misses" }));
+    expect(screen.getByText("Excavator swing near miss")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start review" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "First-aid occurrences" }));
+    expect(screen.getByText(/Minimum necessary operational record/)).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Crew Member" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save confidential record" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SafetyOperationsPage.tsx
+++ b/frontend/src/pages/SafetyOperationsPage.tsx
@@ -1,61 +1,184 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
-import { AlertTriangle, ClipboardList, Radio, ShieldAlert, Siren } from "lucide-react";
-import { FieldRecord, fieldOperationsApi } from "../api/fieldOperations";
+import { AlertTriangle, ClipboardList, FileWarning, HeartPulse, Radio, ShieldAlert, Siren } from "lucide-react";
 
-type View = "permits" | "actions" | "emergency";
-const TYPES = ["safety_permit", "corrective_action", "emergency_action_card"];
+import { Employee, FieldRecord, fieldOperationsApi } from "../api/fieldOperations";
+import { useAuth } from "../contexts/AuthContext";
+
+type View = "permits" | "actions" | "emergency" | "incidents" | "first-aid";
+const TYPES = ["safety_permit", "corrective_action", "emergency_action_card", "incident", "first_aid_record"];
 
 export function SafetyOperationsPage() {
+  const { user } = useAuth();
   const [records, setRecords] = useState<FieldRecord[]>([]);
+  const [employees, setEmployees] = useState<Employee[]>([]);
   const [view, setView] = useState<View>("permits");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  async function refresh() { try { const data = await fieldOperationsApi.bootstrap(); setRecords(data.records.filter((r) => TYPES.includes(r.record_type))); setError(null); } catch (failure) { setError(message(failure)); } finally { setLoading(false); } }
+  const canManageOccurrences = user?.role === "admin" || user?.role === "operations_manager";
+
+  async function refresh() {
+    try {
+      const data = await fieldOperationsApi.bootstrap();
+      setEmployees(data.employees);
+      setRecords(data.records.filter((record) => TYPES.includes(record.record_type)));
+      setError(null);
+    } catch (failure) {
+      setError(message(failure));
+    } finally {
+      setLoading(false);
+    }
+  }
+
   useEffect(() => { void refresh(); }, []);
-  const permits = records.filter((r) => r.record_type === "safety_permit");
-  const actions = records.filter((r) => r.record_type === "corrective_action");
-  const cards = records.filter((r) => r.record_type === "emergency_action_card");
-  const overdue = useMemo(() => actions.filter((r) => r.status !== "closed" && detail(r,"due") && new Date(detail(r,"due")).getTime() < Date.now()).length, [actions]);
+
+  const permits = records.filter((record) => record.record_type === "safety_permit");
+  const actions = records.filter((record) => record.record_type === "corrective_action");
+  const cards = records.filter((record) => record.record_type === "emergency_action_card");
+  const incidents = records.filter((record) => record.record_type === "incident");
+  const firstAid = records.filter((record) => record.record_type === "first_aid_record");
+  const overdue = useMemo(
+    () => actions.filter((record) => record.status !== "closed" && detail(record, "due") && new Date(detail(record, "due")).getTime() < Date.now()).length,
+    [actions],
+  );
 
   async function create(event: FormEvent<HTMLFormElement>, recordType: string, titleField: string) {
-    event.preventDefault(); const form = event.currentTarget; const data = new FormData(form);
-    const details = Object.fromEntries([...data.entries()].map(([key,value]) => [key,String(value)]));
-    try { await fieldOperationsApi.createRecord({ record_type: recordType, work_date: new Date().toISOString().slice(0,10), title: String(data.get(titleField)), severity: recordType === "emergency_action_card" ? "medium" : "high", details }); form.reset(); await refresh(); }
-    catch (failure) { setError(message(failure)); }
-  }
-  async function transition(record: FieldRecord, status: string, prompt: string) {
-    const evidence = window.prompt(prompt, String(record.details.verification_evidence ?? "")); if (!evidence?.trim()) return;
-    try { await fieldOperationsApi.updateSafetyStatus(record.id, status, evidence); await refresh(); } catch (failure) { setError(message(failure)); }
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = new FormData(form);
+    const employeeId = String(data.get("employee_id") ?? "");
+    const details = Object.fromEntries(
+      [...data.entries()]
+        .filter(([key]) => key !== "employee_id")
+        .map(([key, value]) => [key, String(value)]),
+    );
+    const occurredAt = String(data.get("occurred_at") ?? "");
+    try {
+      await fieldOperationsApi.createRecord({
+        record_type: recordType,
+        employee_id: employeeId || null,
+        work_date: occurredAt.slice(0, 10) || new Date().toISOString().slice(0, 10),
+        title: String(data.get(titleField)),
+        severity: recordType === "first_aid_record" ? "none" : recordType === "emergency_action_card" ? "medium" : "high",
+        details,
+      });
+      form.reset();
+      await refresh();
+    } catch (failure) {
+      setError(message(failure));
+    }
   }
 
+  async function transition(record: FieldRecord, status: string, prompt: string) {
+    const evidence = window.prompt(prompt, String(record.details.verification_evidence ?? ""));
+    if (!evidence?.trim()) return;
+    try {
+      await fieldOperationsApi.updateSafetyStatus(record.id, status, evidence);
+      await refresh();
+    } catch (failure) {
+      setError(message(failure));
+    }
+  }
+
+  const navigation: Array<[View, string]> = [
+    ["permits", "High-risk permits"],
+    ["actions", "Corrective actions"],
+    ["emergency", "Emergency cards"],
+    ["incidents", "Incidents / near misses"],
+    ...(canManageOccurrences ? [["first-aid", "First-aid occurrences"] as [View, string]] : []),
+  ];
+
   return <section className="space-y-6">
-    <header className="ihos-brand-surface rounded-xl border border-brand-gold/30 p-6 text-white shadow-brand"><div className="text-xs font-semibold uppercase tracking-[0.22em] text-brand-gold">Build 221</div><h1 className="mt-2 text-3xl font-semibold text-brand-silver">Safety Operations Control</h1><p className="mt-2 max-w-3xl text-sm text-iron-100">Database-backed permit readiness, corrective-action verification and project emergency action cards.</p></header>
+    <header className="ihos-brand-surface rounded-xl border border-brand-gold/30 p-6 text-white shadow-brand">
+      <div className="text-xs font-semibold uppercase tracking-[0.22em] text-brand-gold">Build 221</div>
+      <h1 className="mt-2 text-3xl font-semibold text-brand-silver">Safety Operations Control</h1>
+      <p className="mt-2 max-w-3xl text-sm text-iron-100">Database-backed permit readiness, corrective actions, emergency cards, incident review and privacy-scoped first-aid occurrence records.</p>
+    </header>
     {error ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">{error}</div> : null}
-    <div className="grid gap-4 md:grid-cols-3"><Metric label="Blocked permits" value={permits.filter((p) => p.status === "blocked").length} icon={<ShieldAlert />} /><Metric label="Overdue actions" value={overdue} icon={<AlertTriangle />} /><Metric label="Emergency cards" value={cards.length} icon={<Siren />} /></div>
-    <nav aria-label="Safety operations sections" className="flex gap-2 overflow-x-auto rounded-xl border border-iron-100 bg-white p-2">{[["permits","High-risk permits"],["actions","Corrective actions"],["emergency","Emergency cards"]].map(([key,label]) => <button key={key} onClick={() => setView(key as View)} className={`min-h-11 rounded-md px-4 py-2 text-sm font-semibold ${view === key ? "bg-brand-gold text-brand-black" : "text-iron-600"}`}>{label}</button>)}</nav>
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+      <Metric label="Blocked permits" value={permits.filter((permit) => permit.status === "blocked").length} icon={<ShieldAlert />} />
+      <Metric label="Overdue actions" value={overdue} icon={<AlertTriangle />} />
+      <Metric label="Emergency cards" value={cards.length} icon={<Siren />} />
+      <Metric label="Open incidents" value={incidents.filter((record) => record.status !== "closed").length} icon={<FileWarning />} />
+      {canManageOccurrences ? <Metric label="First-aid records" value={firstAid.length} icon={<HeartPulse />} /> : null}
+    </div>
+    <nav aria-label="Safety operations sections" className="flex gap-2 overflow-x-auto rounded-xl border border-iron-100 bg-white p-2">
+      {navigation.map(([key, label]) => <button key={key} type="button" onClick={() => setView(key)} className={`min-h-11 shrink-0 rounded-md px-4 py-2 text-sm font-semibold ${view === key ? "bg-brand-gold text-brand-black" : "text-iron-600"}`}>{label}</button>)}
+    </nav>
     {loading ? <p className="rounded-xl border bg-white p-6 text-sm text-iron-500">Loading safety records…</p> : null}
     {!loading && view === "permits" ? <PermitView records={permits} create={create} transition={transition} /> : null}
     {!loading && view === "actions" ? <ActionView records={actions} create={create} transition={transition} /> : null}
     {!loading && view === "emergency" ? <EmergencyView records={cards} create={create} /> : null}
+    {!loading && view === "incidents" ? <IncidentView records={incidents} employees={employees} canCreate={canManageOccurrences} create={create} transition={transition} /> : null}
+    {!loading && view === "first-aid" && canManageOccurrences ? <FirstAidView records={firstAid} employees={employees} create={create} /> : null}
   </section>;
 }
 
 type Create = (event: FormEvent<HTMLFormElement>, recordType: string, titleField: string) => Promise<void>;
 type Transition = (record: FieldRecord, status: string, prompt: string) => Promise<void>;
 
-function PermitView({records,create,transition}:{records:FieldRecord[];create:Create;transition:Transition}) { return <Grid><form onSubmit={(e) => void create(e,"safety_permit","project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create permit readiness record</h2><select name="type" className="control"><option>Ground Disturbance</option><option>Confined Space</option><option>Lockout / Energy Isolation</option><option>Critical Lift</option><option>Traffic Control</option></select><Input name="project" placeholder="Project / location" /><Area name="task" placeholder="Task and work limits" /><Input name="supervisor" placeholder="Responsible supervisor" /><Area name="controls" placeholder="Controls and verification evidence required" /><label className="block text-xs font-semibold text-iron-500">Permit expiry<input name="expires" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save blocked permit</Save></form><Register empty="No permit readiness records." items={records.map((r) => <article key={r.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{detail(r,"type")} · {r.work_date}</div><h3 className="font-semibold">{detail(r,"project")}</h3><p className="text-sm text-iron-600">{detail(r,"task")}</p><p className="mt-2 text-xs text-iron-500">Supervisor: {detail(r,"supervisor")} · Expires: {detail(r,"expires") || "Not set"}</p></div><Status value={r.status} /></div><p className="mt-3 rounded-md bg-iron-50 p-3 text-sm">{detail(r,"controls")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(r,"at_risk","Record the review evidence and remaining risk.")}>Mark at risk</Small><Small dark onClick={() => void transition(r,"ready","Record the field verification that supports release.")}>Verify ready</Small></div></article>)} /></Grid>; }
+function PermitView({ records, create, transition }: { records: FieldRecord[]; create: Create; transition: Transition }) {
+  return <Grid><form onSubmit={(event) => void create(event, "safety_permit", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create permit readiness record</h2><select name="type" className="control"><option>Ground Disturbance</option><option>Confined Space</option><option>Lockout / Energy Isolation</option><option>Critical Lift</option><option>Traffic Control</option></select><Input name="project" placeholder="Project / location" /><Area name="task" placeholder="Task and work limits" /><Input name="supervisor" placeholder="Responsible supervisor" /><Area name="controls" placeholder="Controls and verification evidence required" /><label className="block text-xs font-semibold text-iron-500">Permit expiry<input name="expires" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save blocked permit</Save></form><Register empty="No permit readiness records." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{detail(record, "type")} · {record.work_date}</div><h3 className="font-semibold">{detail(record, "project")}</h3><p className="text-sm text-iron-600">{detail(record, "task")}</p><p className="mt-2 text-xs text-iron-500">Supervisor: {detail(record, "supervisor")} · Expires: {detail(record, "expires") || "Not set"}</p></div><Status value={record.status} /></div><p className="mt-3 rounded-md bg-iron-50 p-3 text-sm">{detail(record, "controls")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "at_risk", "Record the review evidence and remaining risk.")}>Mark at risk</Small><Small dark onClick={() => void transition(record, "ready", "Record the field verification that supports release.")}>Verify ready</Small></div></article>)} /></Grid>;
+}
 
-function ActionView({records,create,transition}:{records:FieldRecord[];create:Create;transition:Transition}) { return <Grid><form onSubmit={(e) => void create(e,"corrective_action","finding")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create corrective action</h2>{[["finding","Finding"],["risk","Risk / consequence"],["immediate","Immediate control"],["permanent","Permanent action"],["owner","Action owner"]].map(([name,placeholder]) => <Input key={name} name={name} placeholder={placeholder} />)}<label className="block text-xs font-semibold text-iron-500">Due date<input required name="due" type="date" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save action</Save></form><Register empty="No corrective actions." items={records.map((r) => <article key={r.id} className="rounded-lg border p-4"><div className="flex justify-between"><div><h3 className="font-semibold">{detail(r,"finding")}</h3><p className="text-sm text-iron-500">Owner: {detail(r,"owner")} · Due: {detail(r,"due")}</p></div><Status value={r.status} /></div><p className="mt-3 text-sm"><b>Immediate:</b> {detail(r,"immediate")}</p><p className="mt-1 text-sm"><b>Permanent:</b> {detail(r,"permanent")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(r,"verification","Record completion evidence for management verification.")}>Submit evidence</Small><Small dark onClick={() => void transition(r,"closed","Record how effectiveness was verified before closure.")}>Verify and close</Small></div></article>)} /></Grid>; }
+function ActionView({ records, create, transition }: { records: FieldRecord[]; create: Create; transition: Transition }) {
+  return <Grid><form onSubmit={(event) => void create(event, "corrective_action", "finding")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create corrective action</h2>{[["finding", "Finding"], ["risk", "Risk / consequence"], ["immediate", "Immediate control"], ["permanent", "Permanent action"], ["owner", "Action owner"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} />)}<label className="block text-xs font-semibold text-iron-500">Due date<input required name="due" type="date" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save action</Save></form><Register empty="No corrective actions." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between"><div><h3 className="font-semibold">{detail(record, "finding")}</h3><p className="text-sm text-iron-500">Owner: {detail(record, "owner")} · Due: {detail(record, "due")}</p></div><Status value={record.status} /></div><p className="mt-3 text-sm"><b>Immediate:</b> {detail(record, "immediate")}</p><p className="mt-1 text-sm"><b>Permanent:</b> {detail(record, "permanent")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "verification", "Record completion evidence for management verification.")}>Submit evidence</Small><Small dark onClick={() => void transition(record, "closed", "Record how effectiveness was verified before closure.")}>Verify and close</Small></div></article>)} /></Grid>;
+}
 
-function EmergencyView({records,create}:{records:FieldRecord[];create:Create}) { return <Grid><form onSubmit={(e) => void create(e,"emergency_action_card","project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create emergency action card</h2>{[["project","Project"],["address","Site address / access point"],["muster","Muster point"],["firstAid","First aid location and attendant"],["emergencyLead","Emergency lead and contact"],["rescue","Rescue / evacuation method"]].map(([name,placeholder]) => <Input key={name} name={name} placeholder={placeholder} />)}<Save>Save emergency card</Save></form><Register empty="No emergency cards." items={records.map((r) => <article key={r.id} className="rounded-lg border border-red-200 bg-red-50 p-5"><div className="flex items-center gap-2"><Radio className="text-red-700" /><h3 className="font-semibold text-red-950">{detail(r,"project")}</h3></div><dl className="mt-4 grid gap-2 text-sm"><div><b>Address/access:</b> {detail(r,"address")}</div><div><b>Muster point:</b> {detail(r,"muster")}</div><div><b>First aid:</b> {detail(r,"firstAid")}</div><div><b>Emergency lead:</b> {detail(r,"emergencyLead")}</div><div><b>Rescue/evacuation:</b> {detail(r,"rescue")}</div></dl><p className="mt-3 text-xs text-red-800">Created {r.work_date}. Confirm with the crew and replace when conditions change.</p></article>)} /></Grid>; }
+function EmergencyView({ records, create }: { records: FieldRecord[]; create: Create }) {
+  return <Grid><form onSubmit={(event) => void create(event, "emergency_action_card", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create emergency action card</h2>{[["project", "Project"], ["address", "Site address / access point"], ["muster", "Muster point"], ["firstAid", "First aid location and attendant"], ["emergencyLead", "Emergency lead and contact"], ["rescue", "Rescue / evacuation method"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} />)}<Save>Save emergency card</Save></form><Register empty="No emergency cards." items={records.map((record) => <article key={record.id} className="rounded-lg border border-red-200 bg-red-50 p-5"><div className="flex items-center gap-2"><Radio className="text-red-700" /><h3 className="font-semibold text-red-950">{detail(record, "project")}</h3></div><dl className="mt-4 grid gap-2 text-sm"><div><b>Address/access:</b> {detail(record, "address")}</div><div><b>Muster point:</b> {detail(record, "muster")}</div><div><b>First aid:</b> {detail(record, "firstAid")}</div><div><b>Emergency lead:</b> {detail(record, "emergencyLead")}</div><div><b>Rescue/evacuation:</b> {detail(record, "rescue")}</div></dl><p className="mt-3 text-xs text-red-800">Created {record.work_date}. Confirm with the crew and replace when conditions change.</p></article>)} /></Grid>;
+}
 
-function detail(record:FieldRecord,key:string) { const value=record.details[key]; return typeof value === "string" ? value : ""; }
-function message(value:unknown) { return value instanceof Error ? value.message : "Unable to complete the safety operation."; }
-function Grid({children}:{children:ReactNode}) { return <div className="grid gap-6 xl:grid-cols-[390px_1fr]">{children}</div>; }
-function Input(props:{name:string;placeholder:string}) { return <input required {...props} className="w-full rounded-md border p-2 text-sm" />; }
-function Area(props:{name:string;placeholder:string}) { return <textarea required {...props} className="h-24 w-full rounded-md border p-2 text-sm" />; }
-function Save({children}:{children:ReactNode}) { return <button className="w-full rounded-md bg-brand-gold p-2 text-sm font-semibold">{children}</button>; }
-function Small({children,dark=false,onClick}:{children:ReactNode;dark?:boolean;onClick:()=>void}) { return <button onClick={onClick} className={`min-h-11 rounded-md px-3 text-xs font-semibold ${dark ? "bg-iron-950 text-white" : "border"}`}>{children}</button>; }
-function Metric({label,value,icon}:{label:string;value:number;icon:ReactNode}) { return <article className="rounded-xl border bg-white p-5"><div className="flex items-center justify-between text-sm font-medium text-iron-500"><span>{label}</span>{icon}</div><div className="mt-2 text-3xl font-semibold">{value}</div></article>; }
-function Status({value}:{value:string}) { return <span className={`h-fit rounded-full px-2 py-1 text-xs font-semibold ${value === "ready" || value === "closed" ? "bg-emerald-100 text-emerald-800" : value === "at_risk" || value === "verification" ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800"}`}>{value.replace("_"," ")}</span>; }
-function Register({items,empty}:{items:ReactNode[];empty:string}) { return <section className="rounded-xl border bg-white p-6"><div className="flex items-center gap-2"><ClipboardList className="text-brand-gold-dark" /><h2 className="font-semibold">Register</h2></div><div className="mt-4 space-y-3">{items.length ? items : <p className="rounded-md bg-iron-50 p-4 text-sm text-iron-500">{empty}</p>}</div></section>; }
+function IncidentView({ records, employees, canCreate, create, transition }: { records: FieldRecord[]; employees: Employee[]; canCreate: boolean; create: Create; transition: Transition }) {
+  return <Grid>
+    {canCreate ? <form onSubmit={(event) => void create(event, "incident", "title")} className="space-y-3 rounded-xl border bg-white p-6">
+      <h2 className="font-semibold">Report incident or near miss</h2>
+      <select required name="occurrence_kind" className="w-full rounded-md border p-2 text-sm"><option value="near_miss">Near miss</option><option value="incident">Incident</option></select>
+      <Input name="title" placeholder="Short operational title" />
+      <EmployeeSelect employees={employees} optional />
+      <label className="block text-xs font-semibold text-iron-500">Occurred at<input required name="occurred_at" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label>
+      <Input name="location" placeholder="Project / location" />
+      <Area name="description" placeholder="What happened" />
+      <Area name="immediate_controls" placeholder="Immediate controls taken" />
+      <Input name="witnesses" placeholder="Witnesses, if any" required={false} />
+      <Save>Save reported occurrence</Save>
+    </form> : <RestrictedNotice>Incident and near-miss creation is limited to operations management here. Forepersons can submit from their portal.</RestrictedNotice>}
+    <Register empty="No incident or near-miss records." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold uppercase text-brand-gold-dark">{detail(record, "occurrence_kind").replace("_", " ")} · {record.work_date}</div><h3 className="font-semibold">{record.title}</h3><p className="text-sm text-iron-500">{detail(record, "location")}{employeeName(record.employee_id, employees) ? ` · ${employeeName(record.employee_id, employees)}` : ""}</p></div><Status value={record.status} /></div><p className="mt-3 text-sm">{detail(record, "description")}</p><p className="mt-2 rounded-md bg-iron-50 p-3 text-sm"><b>Immediate controls:</b> {detail(record, "immediate_controls")}</p><div className="mt-3 flex gap-2">{record.status === "reported" ? <Small onClick={() => void transition(record, "under_review", "Record the initial review assignment or evidence.")}>Start review</Small> : null}{record.status === "under_review" ? <Small dark onClick={() => void transition(record, "closed", "Record the evidence and management verification supporting closure.")}>Verify and close</Small> : null}</div></article>)} />
+  </Grid>;
+}
+
+function FirstAidView({ records, employees, create }: { records: FieldRecord[]; employees: Employee[]; create: Create }) {
+  return <Grid>
+    <form onSubmit={(event) => void create(event, "first_aid_record", "title")} className="space-y-3 rounded-xl border bg-white p-6">
+      <h2 className="font-semibold">Record first-aid occurrence</h2>
+      <p className="rounded-md bg-amber-50 p-3 text-xs leading-5 text-amber-900">Minimum necessary operational record. Do not enter a diagnosis, medical conclusion, or unrelated health history.</p>
+      <Input name="title" placeholder="Record title" />
+      <EmployeeSelect employees={employees} />
+      <label className="block text-xs font-semibold text-iron-500">Occurred at<input required name="occurred_at" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label>
+      <Input name="location" placeholder="Project / location" />
+      <Input name="first_aid_attendant" placeholder="First-aid attendant" />
+      <Area name="general_nature" placeholder="General nature of occurrence — no diagnosis" />
+      <Area name="aid_provided" placeholder="Aid provided" />
+      <select required name="outcome" defaultValue="" className="w-full rounded-md border p-2 text-sm"><option value="" disabled>Recorded outcome</option><option value="returned_to_work">Returned to work</option><option value="referred_for_further_assessment">Referred for further assessment</option><option value="transported_for_further_assessment">Transported for further assessment</option></select>
+      <Input name="follow_up" placeholder="Operational follow-up, if any" required={false} />
+      <Save>Save confidential record</Save>
+    </form>
+    <Register empty="No first-aid occurrence records." items={records.map((record) => <article key={record.id} className="rounded-lg border border-amber-200 bg-amber-50/40 p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{record.work_date} · {employeeName(record.employee_id, employees) || "Worker record"}</div><h3 className="font-semibold">{record.title}</h3><p className="text-sm text-iron-500">{detail(record, "location")} · Attendant: {detail(record, "first_aid_attendant")}</p></div><Status value={record.status} /></div><p className="mt-3 text-sm"><b>General nature:</b> {detail(record, "general_nature")}</p><p className="mt-2 text-sm"><b>Aid provided:</b> {detail(record, "aid_provided")}</p><p className="mt-2 text-xs text-iron-500">Outcome: {detail(record, "outcome").replaceAll("_", " ")}</p></article>)} />
+  </Grid>;
+}
+
+function EmployeeSelect({ employees, optional = false }: { employees: Employee[]; optional?: boolean }) {
+  return <select required={!optional} name="employee_id" defaultValue="" className="w-full rounded-md border p-2 text-sm"><option value="">{optional ? "Affected worker, if applicable" : "Select worker"}</option>{employees.map((employee) => <option key={employee.id} value={employee.id}>{employee.first_name} {employee.last_name}</option>)}</select>;
+}
+
+function detail(record: FieldRecord, key: string) { const value = record.details[key]; return typeof value === "string" ? value : ""; }
+function employeeName(id: string | null, employees: Employee[]) { const employee = employees.find((item) => item.id === id); return employee ? `${employee.first_name} ${employee.last_name}` : ""; }
+function message(value: unknown) { return value instanceof Error ? value.message : "Unable to complete the safety operation."; }
+function Grid({ children }: { children: ReactNode }) { return <div className="grid gap-6 xl:grid-cols-[390px_1fr]">{children}</div>; }
+function Input({ required = true, ...props }: { name: string; placeholder: string; type?: string; required?: boolean }) { return <input required={required} {...props} className="w-full rounded-md border p-2 text-sm" />; }
+function Area(props: { name: string; placeholder: string }) { return <textarea required {...props} className="h-24 w-full rounded-md border p-2 text-sm" />; }
+function Save({ children }: { children: ReactNode }) { return <button className="w-full rounded-md bg-brand-gold p-2 text-sm font-semibold">{children}</button>; }
+function Small({ children, dark = false, onClick }: { children: ReactNode; dark?: boolean; onClick: () => void }) { return <button type="button" onClick={onClick} className={`min-h-11 rounded-md px-3 text-xs font-semibold ${dark ? "bg-iron-950 text-white" : "border"}`}>{children}</button>; }
+function Metric({ label, value, icon }: { label: string; value: number; icon: ReactNode }) { return <article className="rounded-xl border bg-white p-5"><div className="flex items-center justify-between text-sm font-medium text-iron-500"><span>{label}</span>{icon}</div><div className="mt-2 text-3xl font-semibold">{value}</div></article>; }
+function RestrictedNotice({ children }: { children: ReactNode }) { return <div className="h-fit rounded-xl border border-iron-100 bg-white p-5 text-sm text-iron-600">{children}</div>; }
+function Status({ value }: { value: string }) { return <span className={`h-fit rounded-full px-2 py-1 text-xs font-semibold ${value === "ready" || value === "closed" || value === "recorded" ? "bg-emerald-100 text-emerald-800" : value === "at_risk" || value === "verification" || value === "under_review" ? "bg-amber-100 text-amber-800" : "bg-red-100 text-red-800"}`}>{value.replaceAll("_", " ")}</span>; }
+function Register({ items, empty }: { items: ReactNode[]; empty: string }) { return <section className="rounded-xl border bg-white p-6"><div className="flex items-center gap-2"><ClipboardList className="text-brand-gold-dark" /><h2 className="font-semibold">Register</h2></div><div className="mt-4 space-y-3">{items.length ? items : <p className="rounded-md bg-iron-50 p-4 text-sm text-iron-500">{empty}</p>}</div></section>; }

--- a/frontend/src/pages/SafetyProgramPage.tsx
+++ b/frontend/src/pages/SafetyProgramPage.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 
-import { Certification, Employee, fieldOperationsApi } from "../api/fieldOperations";
+import { Certification, Employee, FieldRecord, fieldOperationsApi } from "../api/fieldOperations";
 import { useAuth } from "../contexts/AuthContext";
 
 const SAFETY_PROGRAM_URL =
@@ -54,7 +54,7 @@ const procedures = [
   { code: "SWP-008", title: "Lifting, Rigging and Suspended Loads", category: "Equipment", status: "Controlled" },
 ];
 
-const formTypes = ["FLHA", "Toolbox Talk", "Equipment Inspection", "Incident / Near Miss", "Corrective Action", "Ground Disturbance Permit", "Confined Space Permit", "First Aid Record"];
+const formTypes = ["FLHA", "Toolbox Talk", "Equipment Inspection", "Corrective Action", "Ground Disturbance Permit", "Confined Space Permit"];
 const hazardLibrary: Record<string, string[]> = {
   excavation: ["Underground utilities", "Cave-in or ground collapse", "Mobile equipment interaction", "Access and egress", "Water accumulation"],
   trenching: ["Cave-in or ground collapse", "Spoil pile surcharge", "Atmospheric hazard", "Falling material", "Restricted access"],
@@ -90,6 +90,7 @@ export function SafetyProgramPage() {
   const [records, setRecords] = useStoredState<SafetyRecord[]>("ihos-safety-records-v2", []);
   const [employees, setEmployees] = useState<Employee[]>([]);
   const [training, setTraining] = useState<Certification[]>([]);
+  const [operationalRecords, setOperationalRecords] = useState<FieldRecord[]>([]);
   const [credentialError, setCredentialError] = useState<string | null>(null);
   const [credentialLoading, setCredentialLoading] = useState(true);
   const [credentialSaving, setCredentialSaving] = useState(false);
@@ -111,6 +112,7 @@ export function SafetyProgramPage() {
         if (!active) return;
         setEmployees(data.employees);
         setTraining(data.certifications);
+        setOperationalRecords(data.records);
         setCredentialError(null);
       })
       .catch((current) => {
@@ -124,7 +126,7 @@ export function SafetyProgramPage() {
 
   const filteredProcedures = procedures.filter((item) => `${item.code} ${item.title} ${item.category}`.toLowerCase().includes(search.toLowerCase()));
   const openActions = records.filter((record) => record.status !== "Complete").length;
-  const incidents = records.filter((record) => record.type === "Incident / Near Miss").length;
+  const incidents = operationalRecords.filter((record) => record.record_type === "incident").length;
   const expiring = useMemo(() => training.filter((item) => ["expires_soon", "expired"].includes(item.expiry_status)).length, [training]);
   const blocked = records.filter((record) => record.release === "Blocked" && record.status !== "Complete").length;
 

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -310,6 +310,9 @@ def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> No
                 "general_nature": "Minor hand contact",
                 "aid_provided": "Area was cleaned and covered.",
                 "outcome": "returned_to_work",
+                "follow_up": "Supervisor check-in before the next shift.",
+                "diagnosis": "Must not be stored.",
+                "medical_history": "Must not be stored.",
             },
         },
     )
@@ -317,6 +320,9 @@ def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> No
     record = created.json()
     assert record["status"] == "recorded"
     assert record["alert_recipients"] == []
+    assert record["details"]["follow_up"] == "Supervisor check-in before the next shift."
+    assert "diagnosis" not in record["details"]
+    assert "medical_history" not in record["details"]
 
     _authenticate_as("estimator")
     estimator_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -12,11 +12,11 @@ from app.services.auth import AuthenticatedUser
 client = TestClient(app)
 
 
-def _authenticate_as(role: str) -> None:
+def _authenticate_as(role: str, email: str | None = None) -> None:
     def override(request: Request) -> AuthenticatedUser:
         user = AuthenticatedUser(
             id=UUID("00000000-0000-0000-0000-000000000070"),
-            email=f"{role}@ironhousecontracting.com",
+            email=email or f"{role}@ironhousecontracting.com",
             display_name=f"Test {role.replace('_', ' ').title()}",
             role=role,
             session_version=1,
@@ -189,6 +189,171 @@ def test_safety_status_endpoint_rejects_non_safety_records() -> None:
         json={"status": "closed", "evidence": "Not applicable."},
     )
     assert response.status_code == 400
+
+
+def test_incident_records_are_durable_alert_management_and_require_ordered_review() -> None:
+    employee = _employee()
+    created = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "incident",
+            "employee_id": employee["id"],
+            "work_date": str(date.today()),
+            "title": "Excavator swing near miss",
+            "severity": "high",
+            "details": {
+                "occurrence_kind": "near_miss",
+                "occurred_at": f"{date.today()}T09:30",
+                "location": "Field Operations Test",
+                "description": "A worker entered the swing-radius boundary.",
+                "immediate_controls": "Work stopped and the exclusion zone was re-established.",
+            },
+        },
+    )
+    assert created.status_code == 201
+    record = created.json()
+    assert record["status"] == "reported"
+    assert record["alert_recipients"] == ["Jeremie Peters", "Mac Warren"]
+    assert record["details"]["reported_by"] == "Test Administrator"
+
+    missing_review_evidence = client.patch(
+        f"/api/v1/field-operations/records/{record['id']}/safety-status",
+        json={"status": "under_review"},
+    )
+    assert missing_review_evidence.status_code == 422
+
+    skipped_review = client.patch(
+        f"/api/v1/field-operations/records/{record['id']}/safety-status",
+        json={"status": "closed", "evidence": "Management reviewed the occurrence."},
+    )
+    assert skipped_review.status_code == 409
+
+    under_review = client.patch(
+        f"/api/v1/field-operations/records/{record['id']}/safety-status",
+        json={"status": "under_review", "evidence": "Assigned to the operations manager."},
+    )
+    assert under_review.status_code == 200
+    assert under_review.json()["status"] == "under_review"
+
+    closed = client.patch(
+        f"/api/v1/field-operations/records/{record['id']}/safety-status",
+        json={"status": "closed", "evidence": "Boundary controls were verified with the crew."},
+    )
+    assert closed.status_code == 200
+    assert closed.json()["status"] == "closed"
+    assert [event["to"] for event in closed.json()["details"]["status_history"]] == ["under_review", "closed"]
+
+
+def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> None:
+    worker = _employee()
+    created = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "first_aid_record",
+            "employee_id": worker["id"],
+            "work_date": str(date.today()),
+            "title": "First-aid occurrence",
+            "details": {
+                "occurred_at": f"{date.today()}T10:15",
+                "location": "Field Operations Test",
+                "first_aid_attendant": "Qualified Attendant",
+                "general_nature": "Minor hand contact",
+                "aid_provided": "Area was cleaned and covered.",
+                "outcome": "returned_to_work",
+            },
+        },
+    )
+    assert created.status_code == 201
+    record = created.json()
+    assert record["status"] == "recorded"
+    assert record["alert_recipients"] == []
+
+    _authenticate_as("estimator")
+    estimator_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    assert record["id"] not in {item["id"] for item in estimator_records}
+    denied = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "first_aid_record",
+            "employee_id": worker["id"],
+            "work_date": str(date.today()),
+            "title": "Denied record",
+            "details": record["details"],
+        },
+    )
+    assert denied.status_code == 403
+
+    _authenticate_as("admin")
+    foreperson = client.post(
+        "/api/v1/field-operations/employees",
+        json={
+            "first_name": "Field",
+            "last_name": "Foreperson",
+            "email": "foreperson@ironhousecontracting.com",
+            "portal_role": "foreman",
+        },
+    )
+    assert foreperson.status_code == 201
+
+    _authenticate_as("viewer", "foreperson@ironhousecontracting.com")
+    foreperson_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    assert record["id"] not in {item["id"] for item in foreperson_records}
+
+    _authenticate_as("viewer", worker["email"])
+    worker_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    assert record["id"] in {item["id"] for item in worker_records}
+
+
+def test_foreperson_can_submit_incident_but_not_first_aid_record() -> None:
+    foreperson = client.post(
+        "/api/v1/field-operations/employees",
+        json={
+            "first_name": "Field",
+            "last_name": "Foreperson",
+            "email": "foreperson@ironhousecontracting.com",
+            "portal_role": "foreman",
+        },
+    ).json()
+    _authenticate_as("viewer", foreperson["email"])
+    incident_payload = {
+        "record_type": "incident",
+        "employee_id": foreperson["id"],
+        "work_date": str(date.today()),
+        "title": "Crew near miss",
+        "details": {
+            "occurrence_kind": "near_miss",
+            "occurred_at": f"{date.today()}T11:00",
+            "location": "Crew work area",
+            "description": "A temporary boundary was crossed.",
+            "immediate_controls": "Work stopped and the boundary was reset.",
+        },
+    }
+    incident = client.post("/api/v1/field-operations/records", json=incident_payload)
+    assert incident.status_code == 201
+
+    denied_review = client.patch(
+        f"/api/v1/field-operations/records/{incident.json()['id']}/safety-status",
+        json={"status": "under_review", "evidence": "Foreperson review attempt."},
+    )
+    assert denied_review.status_code == 403
+
+    first_aid = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            **incident_payload,
+            "record_type": "first_aid_record",
+            "title": "Denied first-aid record",
+            "details": {
+                "occurred_at": f"{date.today()}T11:00",
+                "location": "Crew work area",
+                "first_aid_attendant": "Qualified Attendant",
+                "general_nature": "Operational occurrence",
+                "aid_provided": "First aid provided.",
+                "outcome": "returned_to_work",
+            },
+        },
+    )
+    assert first_aid.status_code == 403
 
 
 def test_course_ticket_expiry_creates_management_alert() -> None:

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -1,10 +1,15 @@
 from datetime import date, timedelta
+from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
 from fastapi import Request
 from uuid import UUID
 
 from app.main import app
+from app.core.errors import AppError
+from app.schemas.field_operations import SafetyRecordUpdate
+from app.services import field_operations
 from app.api.dependencies.auth import require_authenticated_user
 from app.services.auth import AuthenticatedUser
 
@@ -243,6 +248,51 @@ def test_incident_records_are_durable_alert_management_and_require_ordered_revie
     assert closed.json()["status"] == "closed"
     assert [event["to"] for event in closed.json()["details"]["status_history"]] == ["under_review", "closed"]
 
+
+
+def test_incident_status_update_rejects_stale_concurrent_transition(monkeypatch: pytest.MonkeyPatch) -> None:
+    item = SimpleNamespace(
+        record_type="incident",
+        status="reported",
+        details={"status_history": []},
+    )
+
+    class ConflictSession:
+        rolled_back = False
+
+        def scalar(self, _statement: object) -> None:
+            return None
+
+        def execute(self, _statement: object) -> SimpleNamespace:
+            return SimpleNamespace(rowcount=0)
+
+        def rollback(self) -> None:
+            self.rolled_back = True
+
+    db = ConflictSession()
+    monkeypatch.setattr(field_operations, "require_exists", lambda *_args, **_kwargs: item)
+    payload = SafetyRecordUpdate(
+        status="under_review",
+        evidence="Assigned to the operations manager.",
+    )
+    user = AuthenticatedUser(
+        id=UUID("00000000-0000-0000-0000-000000000071"),
+        email="admin@ironhousecontracting.com",
+        display_name="Test Administrator",
+        role="admin",
+        session_version=1,
+    )
+
+    with pytest.raises(AppError) as raised:
+        field_operations.update_safety_record_status(
+            db,  # type: ignore[arg-type]
+            UUID("00000000-0000-0000-0000-000000000072"),
+            payload,
+            user,
+        )
+
+    assert raised.value.status_code == 409
+    assert db.rolled_back is True
 
 def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> None:
     worker = _employee()


### PR DESCRIPTION
Closes #190
Follow-up to #70.

## Summary
- adds durable `incident` and `first_aid_record` field-record types
- fixes the foreperson portal incident form/backend contract that previously returned schema validation errors
- enforces a server-managed `reported → under_review → closed` incident lifecycle with evidence and append-only status history
- permits forepersons to report incidents while restricting review/closure and first-aid record creation to admin/operations management
- filters sensitive occurrence records from estimator and foreperson bootstrap responses; linked workers receive only records tied to their own profile
- replaces the browser-local incident/first-aid entry paths with database-backed Safety Operations registers while preserving the locked IHOS design
- documents the minimum-necessary first-aid data boundary and explicitly avoids medical, regulatory, causation, or disciplinary conclusions

## Root cause and impact
The foreperson portal exposed `incident`, but the backend `RecordType` did not accept it. Incident and first-aid entries in the Safety Program were browser-local prototypes, and the general field-record bootstrap did not have a first-aid privacy boundary. This PR makes those workflows durable and permission-scoped without adding a database migration.

## Validation
- targeted field-operations backend tests — 23 passed after final authorization/lifecycle changes
- full backend suite — 325 passed
- Ruff — passed
- React Router/RSC boundary — passed across 116 files
- frontend Vitest — 50 passed across 23 files
- TypeScript and Vite production build — passed
- CI run 786 — success
- Release Readiness run 294 — success, including locked-design, browser/mobile/accessibility, disposable-staging rollback, production-stack smoke simulation, and immutable evidence gates

## Security and production gates
- first-aid records are management-created and excluded from estimator/foreperson bootstrap data
- estimator accounts cannot create or review incidents
- forepersons may report incidents but cannot review or close them
- no production data, secrets, certificates, backups, infrastructure, DNS, or deployment files changed
- no live staging or production deployment was performed
- live staging mutation remains behind explicit owner approval; merge and production are separate approvals

## Rollback
Revert the PR. No schema migration or irreversible data operation is included; the new values use the existing field-record table.

## Evidence
- governance build record: https://docs.google.com/document/d/1SA7nbbE2m_pMPDhJX3prRROUQwA7qaRA55b6W3T0pHc/edit
- Release Readiness artifacts are recorded in the verification comment below.