### PR TITLE
Close safety occurrence privacy and date gaps

### DIFF
--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -240,6 +240,11 @@ class FieldRecordCreate(BaseModel):
             for key, message in required.items():
                 if not str(self.details.get(key) or "").strip():
                     raise ValueError(message)
+            try:
+                occurred_at = datetime.fromisoformat(str(self.details["occurred_at"]).replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError("Enter a valid occurrence date and time.") from exc
+            self.work_date = occurred_at.date()
         if self.record_type == "first_aid_record":
             if not self.employee_id:
                 raise ValueError("Select the worker for the first-aid occurrence.")

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -160,17 +160,22 @@ def get_bootstrap(db: Session, user: AuthenticatedUser) -> FieldOperationsBootst
     vehicles = list(db.scalars(select(Vehicle).order_by(Vehicle.unit_number)))
     vehicle_logs = list(db.scalars(select(VehicleLog).order_by(VehicleLog.entry_date.desc()).limit(100)))
     time_entries = list(db.scalars(select(TimeEntry).order_by(TimeEntry.work_date.desc()).limit(200)))
-    records = list(db.scalars(select(FieldRecord).order_by(FieldRecord.work_date.desc(), FieldRecord.created_at.desc()).limit(200)))
+    records_query = select(FieldRecord)
+    if user.role == "estimator" or (
+        user.role == "viewer" and field_role in {"foreman", "management"}
+    ):
+        records_query = records_query.where(
+            FieldRecord.record_type.not_in(SENSITIVE_OCCURRENCE_TYPES)
+        )
+    records = list(db.scalars(
+        records_query.order_by(FieldRecord.work_date.desc(), FieldRecord.created_at.desc()).limit(200)
+    ))
     certifications = list(db.scalars(select(EmployeeCertification).order_by(EmployeeCertification.expiry_date)))
     workbooks, production_items = build_job_workbooks(db)
     material_movement_summary = build_material_movement_summary(db)
     milestone_recognitions = build_milestone_recognitions(db)
     paperwork_recognitions = build_paperwork_recognitions(db, employees)
-    if user.role == "estimator":
-        records = [item for item in records if item.record_type not in SENSITIVE_OCCURRENCE_TYPES]
-    elif user.role == "viewer" and field_role in {"foreman", "management"}:
-        records = [item for item in records if item.record_type not in SENSITIVE_OCCURRENCE_TYPES]
-    elif user.role == "viewer" and profile is None:
+    if user.role == "viewer" and profile is None:
         employees = []
         time_entries = []
         records = []

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -169,7 +169,7 @@ def get_bootstrap(db: Session, user: AuthenticatedUser) -> FieldOperationsBootst
     if user.role == "estimator":
         records = [item for item in records if item.record_type not in SENSITIVE_OCCURRENCE_TYPES]
     elif user.role == "viewer" and field_role in {"foreman", "management"}:
-        records = [item for item in records if item.record_type != "first_aid_record"]
+        records = [item for item in records if item.record_type not in SENSITIVE_OCCURRENCE_TYPES]
     elif user.role == "viewer" and profile is None:
         employees = []
         time_entries = []

--- a/frontend/src/pages/EmployeePortalPage.test.tsx
+++ b/frontend/src/pages/EmployeePortalPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
-import { EmployeePortalPage } from "./EmployeePortalPage";
+import { EmployeePortalPage, incidentWorkDate } from "./EmployeePortalPage";
 
 describe("EmployeePortalPage", () => {
   it("presents separate linked workspaces instead of one long employee page", () => {
@@ -12,5 +12,11 @@ describe("EmployeePortalPage", () => {
     expect(screen.getByRole("link", { name: /my time/i })).toHaveAttribute("href", "/employee-portal/time");
     expect(screen.getByRole("link", { name: /safety and toolbox talks/i })).toHaveAttribute("href", "/employee-portal/safety");
     expect(screen.getByRole("link", { name: /small equipment inspections/i })).toHaveAttribute("href", "/employee-portal/small-equipment");
+  });
+
+  it("derives an incident work date from the captured occurrence time", () => {
+    expect(incidentWorkDate("2026-08-11T06:45", "2026-08-18")).toBe("2026-08-11");
+    expect(incidentWorkDate("", "2026-08-18")).toBe("2026-08-18");
+    expect(incidentWorkDate("2026-02-30T06:45", "2026-08-18")).toBe("2026-08-18");
   });
 });

--- a/frontend/src/pages/EmployeePortalPage.tsx
+++ b/frontend/src/pages/EmployeePortalPage.tsx
@@ -39,6 +39,15 @@ const SAFETY_PROGRAM_URL =
 const today = () => new Date().toISOString().slice(0, 10);
 const money = new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" });
 
+export function incidentWorkDate(occurredAt: string, fallback = today()) {
+  const datePart = occurredAt.match(/^(\d{4}-\d{2}-\d{2})T/)?.[1];
+  if (!datePart) return fallback;
+  const parsed = new Date(`${datePart}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === datePart
+    ? datePart
+    : fallback;
+}
+
 function useFieldOperations() {
   const [data, setData] = useState<FieldOperationsBootstrap | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -575,7 +584,7 @@ function RecordForm({ data, mode, onSaved, onError }: { data: FieldOperationsBoo
       const record = await fieldOperationsApi.createRecord({
         record_type: recordType, project_id: projectId || null, employee_id: employeeId || null,
         equipment_id: equipmentId || null, supplier_id: supplierId || null, cost_code: costCode || null,
-        work_date: today(), title, severity,
+        work_date: recordType === "incident" ? incidentWorkDate(occurredAt) : today(), title, severity,
         details: recordType === "incident"
           ? {
               occurrence_kind: occurrenceKind,

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -296,6 +296,24 @@ def test_incident_status_update_rejects_stale_concurrent_transition(monkeypatch:
 
 def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> None:
     worker = _employee()
+    incident_response = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "incident",
+            "employee_id": worker["id"],
+            "work_date": str(date.today()),
+            "title": "Worker incident",
+            "details": {
+                "occurrence_kind": "incident",
+                "occurred_at": f"{date.today()}T09:45",
+                "location": "Field Operations Test",
+                "description": "An occurrence requiring management review.",
+                "immediate_controls": "Work stopped and the area was secured.",
+            },
+        },
+    )
+    assert incident_response.status_code == 201
+    incident = incident_response.json()
     created = client.post(
         "/api/v1/field-operations/records",
         json={
@@ -326,7 +344,9 @@ def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> No
 
     _authenticate_as("estimator")
     estimator_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
-    assert record["id"] not in {item["id"] for item in estimator_records}
+    estimator_record_ids = {item["id"] for item in estimator_records}
+    assert record["id"] not in estimator_record_ids
+    assert incident["id"] not in estimator_record_ids
     denied = client.post(
         "/api/v1/field-operations/records",
         json={
@@ -353,11 +373,21 @@ def test_first_aid_occurrences_are_management_created_and_privacy_scoped() -> No
 
     _authenticate_as("viewer", "foreperson@ironhousecontracting.com")
     foreperson_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
-    assert record["id"] not in {item["id"] for item in foreperson_records}
+    foreperson_record_ids = {item["id"] for item in foreperson_records}
+    assert record["id"] not in foreperson_record_ids
+    assert incident["id"] not in foreperson_record_ids
 
     _authenticate_as("viewer", worker["email"])
     worker_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
-    assert record["id"] in {item["id"] for item in worker_records}
+    worker_record_ids = {item["id"] for item in worker_records}
+    assert record["id"] in worker_record_ids
+    assert incident["id"] in worker_record_ids
+
+    _authenticate_as("operations_manager")
+    management_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    management_record_ids = {item["id"] for item in management_records}
+    assert record["id"] in management_record_ids
+    assert incident["id"] in management_record_ids
 
 
 def test_foreperson_can_submit_incident_but_not_first_aid_record() -> None:

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -462,6 +462,54 @@ def test_foreperson_can_submit_incident_but_not_first_aid_record() -> None:
     assert first_aid.status_code == 403
 
 
+def test_sensitive_occurrences_are_filtered_before_the_bootstrap_limit() -> None:
+    worker = _employee()
+    foreperson = client.post(
+        "/api/v1/field-operations/employees",
+        json={
+            "first_name": "Field",
+            "last_name": "Foreperson",
+            "email": "limit.foreperson@ironhousecontracting.com",
+            "portal_role": "foreman",
+        },
+    ).json()
+    journal = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "journal",
+            "employee_id": worker["id"],
+            "work_date": "2026-08-10",
+            "title": "Older safe journal",
+        },
+    ).json()
+    for index in range(201):
+        response = client.post(
+            "/api/v1/field-operations/records",
+            json={
+                "record_type": "incident",
+                "employee_id": worker["id"],
+                "work_date": "2026-08-11",
+                "title": f"Sensitive incident {index}",
+                "details": {
+                    "occurrence_kind": "near_miss",
+                    "occurred_at": "2026-08-11T09:30",
+                    "location": "Field Operations Test",
+                    "description": "A test occurrence used to exercise the bootstrap limit.",
+                    "immediate_controls": "Test controls recorded.",
+                },
+            },
+        )
+        assert response.status_code == 201
+
+    _authenticate_as("estimator")
+    estimator_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    assert journal["id"] in {item["id"] for item in estimator_records}
+
+    _authenticate_as("viewer", foreperson["email"])
+    foreperson_records = client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    assert journal["id"] in {item["id"] for item in foreperson_records}
+
+
 def test_course_ticket_expiry_creates_management_alert() -> None:
     employee = _employee()
     response = client.post(

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -198,6 +198,7 @@ def test_safety_status_endpoint_rejects_non_safety_records() -> None:
 
 def test_incident_records_are_durable_alert_management_and_require_ordered_review() -> None:
     employee = _employee()
+    occurrence_date = date(2026, 8, 11)
     created = client.post(
         "/api/v1/field-operations/records",
         json={
@@ -208,7 +209,7 @@ def test_incident_records_are_durable_alert_management_and_require_ordered_revie
             "severity": "high",
             "details": {
                 "occurrence_kind": "near_miss",
-                "occurred_at": f"{date.today()}T09:30",
+                "occurred_at": f"{occurrence_date}T09:30",
                 "location": "Field Operations Test",
                 "description": "A worker entered the swing-radius boundary.",
                 "immediate_controls": "Work stopped and the exclusion zone was re-established.",
@@ -218,6 +219,7 @@ def test_incident_records_are_durable_alert_management_and_require_ordered_revie
     assert created.status_code == 201
     record = created.json()
     assert record["status"] == "reported"
+    assert record["work_date"] == str(occurrence_date)
     assert record["alert_recipients"] == ["Jeremie Peters", "Mac Warren"]
     assert record["details"]["reported_by"] == "Test Administrator"
 
@@ -247,6 +249,24 @@ def test_incident_records_are_durable_alert_management_and_require_ordered_revie
     assert closed.status_code == 200
     assert closed.json()["status"] == "closed"
     assert [event["to"] for event in closed.json()["details"]["status_history"]] == ["under_review", "closed"]
+
+    invalid_occurrence_time = client.post(
+        "/api/v1/field-operations/records",
+        json={
+            "record_type": "incident",
+            "employee_id": employee["id"],
+            "work_date": str(date.today()),
+            "title": "Invalid occurrence time",
+            "details": {
+                "occurrence_kind": "incident",
+                "occurred_at": "not-a-date",
+                "location": "Field Operations Test",
+                "description": "Invalid timestamps must not reach the register.",
+                "immediate_controls": "Submission blocked.",
+            },
+        },
+    )
+    assert invalid_occurrence_time.status_code == 422
 
 
 


### PR DESCRIPTION
Closes #192
Follow-up to #190 and merged PR #191.

## Summary
- excludes both `incident` and `first_aid_record` entries from estimator and foreperson/management viewer bootstrap responses
- applies the sensitive-record predicate in the database query before the 200-record limit
- preserves full occurrence access for `admin` and `operations_manager` accounts
- preserves linked-worker access to the worker’s own occurrence records
- derives incident `work_date` from the captured `occurred_at` value in both the UI and API boundary
- rejects invalid incident timestamps and adds privacy, pagination, and date regression coverage

## Root cause and impact
PR #191 filtered first-aid records from foreperson bootstrap data but did not apply the same sensitive-occurrence set to incidents. Its foreperson form also always sent the submission date as `work_date`. GitHub Copilot identified both gaps after the PR became ready for review; PR #191 was subsequently merged while the threads remained unresolved.

Copilot’s review of this follow-up identified that post-query filtering could hide older safe records when 200 newer sensitive records filled the result window. The current head moves that privacy predicate into SQL before pagination and includes a regression test.

## Local validation
- Ruff — passed
- backend suite — 327 passed
- targeted field-operations backend tests — 25 passed
- frontend Vitest — 51 passed across 23 files
- targeted Employee Portal tests — 2 passed
- TypeScript — passed
- Vite production build — passed
- locked visual-design check — passed
- React Router/RSC boundary — passed across 116 files

## Security and deployment controls
- no production data, secrets, certificates, backups, infrastructure, DNS, deployment files, or schema migrations changed
- no live staging or production deployment performed
- merge and production remain separate protected approvals

## Rollback
Revert this PR. No migration or irreversible operation is included.