### PR TITLE
Drive: rebuild staging-only tender metadata importer (#129)

### DIFF
--- a/backend/app/data/drive_tenders_manifest.json
+++ b/backend/app/data/drive_tenders_manifest.json
@@ -1,0 +1,1070 @@
+{
+  "source": "google_drive",
+  "source_folder_id": "1IA8M5FkHvNE9XDeoyWU5lNQfqkB3OkpW",
+  "source_url": "https://drive.google.com/drive/folders/1IA8M5FkHvNE9XDeoyWU5lNQfqkB3OkpW",
+  "generated_at": "2026-08-19T00:57:57.406Z",
+  "generated_by": "ChatGPT Work connected Google Drive metadata scan",
+  "refresh_note": "Non-secret metadata snapshot. Refresh from connected Drive before a staging apply when source contents change.",
+  "folders": [
+    {
+      "drive_folder_id": "1s-cOa0Arng7FB1sa7Bf0Ducw4hqrAwzS",
+      "name": "Lytton FN culverts",
+      "url": "https://drive.google.com/drive/folders/1s-cOa0Arng7FB1sa7Bf0Ducw4hqrAwzS",
+      "created_time": "2026-08-07T11:31:23.767Z",
+      "modified_time": "2026-08-07T11:31:23.767Z",
+      "files": [
+        {
+          "drive_file_id": "17wehlpmcNrKN0b03dhPZ-VxtTDj9SAiE",
+          "name": "Lytton First Nation- Atmospheric River Culvert Replacement - Addendum 2.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/17wehlpmcNrKN0b03dhPZ-VxtTDj9SAiE/view?usp=drivesdk",
+          "created_time": "2026-08-07T11:32:09.819Z",
+          "modified_time": "2026-08-07T11:32:09.819Z",
+          "source_path": "Lytton FN culverts/Lytton First Nation- Atmospheric River Culvert Replacement - Addendum 2.pdf"
+        },
+        {
+          "drive_file_id": "1FiJi2hgBg9Xxbwf2D7miVvUEUuu_eo55",
+          "name": "Lytton First Nation- Atmospheric River Culvert Replacement - Addendum 2.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1FiJi2hgBg9Xxbwf2D7miVvUEUuu_eo55/view?usp=drivesdk",
+          "created_time": "2026-08-07T11:31:27.422Z",
+          "modified_time": "2026-08-07T11:31:27.422Z",
+          "source_path": "Lytton FN culverts/Lytton First Nation- Atmospheric River Culvert Replacement - Addendum 2.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "13e_CHHMMJXE_XN-9JhS-xG_EssxzopN-",
+      "name": "26-204 - Township of Langley - Drainage Culverts Condition Assessment - Due 2026-08-26",
+      "url": "https://drive.google.com/drive/folders/13e_CHHMMJXE_XN-9JhS-xG_EssxzopN-",
+      "created_time": "2026-08-07T10:15:08.177Z",
+      "modified_time": "2026-08-07T10:38:39.946Z",
+      "files": [
+        {
+          "drive_file_id": "1AfEyVVAVW6GFFc2f0JeRxaW83OLQO7Vx",
+          "name": "26-204 - Drainage Culverts Condition Assessment.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1AfEyVVAVW6GFFc2f0JeRxaW83OLQO7Vx/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:15:12.802Z",
+          "modified_time": "2026-08-07T10:15:12.802Z",
+          "source_path": "26-204 - Township of Langley - Drainage Culverts Condition Assessment - Due 2026-08-26/01 Tender Docs/26-204 - Drainage Culverts Condition Assessment.pdf"
+        },
+        {
+          "drive_file_id": "1B0Nk0B3zrKj48bkj8jsDm3YCl5KJZ7Mz",
+          "name": "26-204 - Culvert Inspection Map 2026.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1B0Nk0B3zrKj48bkj8jsDm3YCl5KJZ7Mz/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:16:14.424Z",
+          "modified_time": "2026-08-07T10:39:30.731Z",
+          "source_path": "26-204 - Township of Langley - Drainage Culverts Condition Assessment - Due 2026-08-26/02 Drawings/26-204 - Culvert Inspection Map 2026.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1kpPZSTPwxwGaxdk7BMF3vvRezw0EpLu0",
+      "name": "Yorkson Park",
+      "url": "https://drive.google.com/drive/folders/1kpPZSTPwxwGaxdk7BMF3vvRezw0EpLu0",
+      "created_time": "2026-08-07T10:17:06.777Z",
+      "modified_time": "2026-08-07T10:17:06.777Z",
+      "files": [
+        {
+          "drive_file_id": "1yRKkZD4uTF4Gw7Bk2WoAd5TnYaCU10Y_",
+          "name": "Addl Info - YCP South Geo Tech report 2023.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1yRKkZD4uTF4Gw7Bk2WoAd5TnYaCU10Y_/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:20:53.887Z",
+          "modified_time": "2026-08-07T10:20:53.887Z",
+          "source_path": "Yorkson Park/Addl Info - YCP South Geo Tech report 2023.pdf"
+        },
+        {
+          "drive_file_id": "1jdYWXXP289UhU9dzMSE8XknCJV0WpHb_",
+          "name": "Addl Info - YCP South Fields Irrigation As built.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1jdYWXXP289UhU9dzMSE8XknCJV0WpHb_/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:20:21.742Z",
+          "modified_time": "2026-08-07T10:20:21.742Z",
+          "source_path": "Yorkson Park/Addl Info - YCP South Fields Irrigation As built.pdf"
+        },
+        {
+          "drive_file_id": "1gE_jgfzD8io-CwGMbT6yeL-WBp4Ib8G9",
+          "name": "Addl Info - YCP South Environmental Constraints Assessment.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1gE_jgfzD8io-CwGMbT6yeL-WBp4Ib8G9/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:19:58.373Z",
+          "modified_time": "2026-08-07T10:19:58.373Z",
+          "source_path": "Yorkson Park/Addl Info - YCP South Environmental Constraints Assessment.pdf"
+        },
+        {
+          "drive_file_id": "16NmQcksfE4tUDnyYxijo25vg_EQENcYx",
+          "name": "Addl Info - YCP Geo Tech Report 2014.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/16NmQcksfE4tUDnyYxijo25vg_EQENcYx/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:19:31.329Z",
+          "modified_time": "2026-08-07T10:19:31.329Z",
+          "source_path": "Yorkson Park/Addl Info - YCP Geo Tech Report 2014.pdf"
+        },
+        {
+          "drive_file_id": "1D4HAe38mpuY5zuGA69ozNr0lan07E4jh",
+          "name": "Addl Info - YCP Geo Tech Preload Test report 2015.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1D4HAe38mpuY5zuGA69ozNr0lan07E4jh/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:19:07.720Z",
+          "modified_time": "2026-08-07T10:19:07.720Z",
+          "source_path": "Yorkson Park/Addl Info - YCP Geo Tech Preload Test report 2015.pdf"
+        },
+        {
+          "drive_file_id": "15voBMqPrT40BkfSe5WeC9CWAWvlSysBo",
+          "name": "Addl Info - YCP South Detention Tank Record Drawings.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/15voBMqPrT40BkfSe5WeC9CWAWvlSysBo/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:18:43.004Z",
+          "modified_time": "2026-08-07T10:18:43.004Z",
+          "source_path": "Yorkson Park/Addl Info - YCP South Detention Tank Record Drawings.pdf"
+        },
+        {
+          "drive_file_id": "1bNt8m2frrRhRYsSNC31GDdzfKN0X3sx7",
+          "name": "26-207 Yorkson Community Park South Lane and Utilities Portfolio.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1bNt8m2frrRhRYsSNC31GDdzfKN0X3sx7/view?usp=drivesdk",
+          "created_time": "2026-08-07T10:17:28.700Z",
+          "modified_time": "2026-08-07T10:17:28.700Z",
+          "source_path": "Yorkson Park/26-207 Yorkson Community Park South Lane and Utilities Portfolio.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1xF8DFji3oQfDxzhbNZjB4coKbXICDkxU",
+      "name": "Hope GC erosion control",
+      "url": "https://drive.google.com/drive/folders/1xF8DFji3oQfDxzhbNZjB4coKbXICDkxU",
+      "created_time": "2026-08-05T17:14:43.234Z",
+      "modified_time": "2026-08-05T17:14:43.234Z",
+      "files": [
+        {
+          "drive_file_id": "1yZvL3nQyg504nmzHwq-4MSx3tXQPbzNO",
+          "name": "IHOS_Hope_GC_Erosion_Protection_Bid.xlsx",
+          "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "url": "https://docs.google.com/spreadsheets/d/1yZvL3nQyg504nmzHwq-4MSx3tXQPbzNO/edit?usp=drivesdk&ouid=107231313353501423718&rtpof=true&sd=true",
+          "created_time": "2026-08-05T17:21:07.577Z",
+          "modified_time": "2026-08-05T17:21:07.577Z",
+          "source_path": "Hope GC erosion control/IHOS_Hope_GC_Erosion_Protection_Bid.xlsx"
+        },
+        {
+          "drive_file_id": "1_tcjwb6v6Z3t4_tKjAlixMu_BG_GDpQG",
+          "name": "LCI_2026-LCI-02.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1_tcjwb6v6Z3t4_tKjAlixMu_BG_GDpQG/view?usp=drivesdk",
+          "created_time": "2026-08-05T17:14:49.633Z",
+          "modified_time": "2026-08-05T17:14:49.633Z",
+          "source_path": "Hope GC erosion control/LCI_2026-LCI-02.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1x8jdyiBthezgTOHUrluRJXy8AHff9vaT",
+      "name": "City of Fernie - 2026 Sanitary Manhole Infiltration Repair",
+      "url": "https://drive.google.com/drive/folders/1x8jdyiBthezgTOHUrluRJXy8AHff9vaT",
+      "created_time": "2026-08-01T01:25:05.856Z",
+      "modified_time": "2026-08-01T01:25:05.856Z",
+      "files": [
+        {
+          "drive_file_id": "1En-woddcXcOEySHB7F1Ps7hoqwm9ynnDIgnI7jwfVEc",
+          "name": "City of Fernie - 2026 Manhole Infiltration Repair - Estimate",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1En-woddcXcOEySHB7F1Ps7hoqwm9ynnDIgnI7jwfVEc/edit?usp=drivesdk",
+          "created_time": "2026-08-01T01:25:12.929Z",
+          "modified_time": "2026-08-02T16:26:18.550Z",
+          "source_path": "City of Fernie - 2026 Sanitary Manhole Infiltration Repair/City of Fernie - 2026 Manhole Infiltration Repair - Estimate"
+        },
+        {
+          "drive_file_id": "1bKp0GweJp4fSpFPCL3qfguJRqOvxWjUoi9XJLNqpt5w",
+          "name": "City of Fernie - 2026 Manhole Infiltration Repair - Proposal",
+          "mime_type": "application/vnd.google-apps.document",
+          "url": "https://docs.google.com/document/d/1bKp0GweJp4fSpFPCL3qfguJRqOvxWjUoi9XJLNqpt5w/edit?usp=drivesdk",
+          "created_time": "2026-08-01T01:25:22.930Z",
+          "modified_time": "2026-08-02T16:12:02.583Z",
+          "source_path": "City of Fernie - 2026 Sanitary Manhole Infiltration Repair/City of Fernie - 2026 Manhole Infiltration Repair - Proposal"
+        },
+        {
+          "drive_file_id": "1OVQvFtntl_XhcLGjRJanMJXeNGgAJyHY",
+          "name": "City of Fernie - 2026 Manhole Infiltration Repair - Proposal.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1OVQvFtntl_XhcLGjRJanMJXeNGgAJyHY/view?usp=drivesdk",
+          "created_time": "2026-08-01T01:25:32.019Z",
+          "modified_time": "2026-08-01T01:25:32.019Z",
+          "source_path": "City of Fernie - 2026 Sanitary Manhole Infiltration Repair/City of Fernie - 2026 Manhole Infiltration Repair - Proposal.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "15tpur5YZr-UzF7I_zlNemhTGEWhOwsyg",
+      "name": "Village of Cumberland - 2026 Sewer Separation - ITT-2602",
+      "url": "https://drive.google.com/drive/folders/15tpur5YZr-UzF7I_zlNemhTGEWhOwsyg",
+      "created_time": "2026-08-01T01:04:27.079Z",
+      "modified_time": "2026-08-01T01:04:27.079Z",
+      "files": [
+        {
+          "drive_file_id": "1efwwTWRatBtACJo8uEaXDUQ5pc6ansPr",
+          "name": "ITT-2602 Cumberland Sewer Separation - Tender Draft.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1efwwTWRatBtACJo8uEaXDUQ5pc6ansPr/view?usp=drivesdk",
+          "created_time": "2026-08-01T01:04:54.838Z",
+          "modified_time": "2026-08-01T01:04:54.838Z",
+          "source_path": "Village of Cumberland - 2026 Sewer Separation - ITT-2602/ITT-2602 Cumberland Sewer Separation - Tender Draft.pdf"
+        },
+        {
+          "drive_file_id": "1LuCXt9GdQgwlEf2KBzV3dWTL5UrVYSayobtLuItoU-c",
+          "name": "ITT-2602 Cumberland Sewer Separation - Tender Draft",
+          "mime_type": "application/vnd.google-apps.document",
+          "url": "https://docs.google.com/document/d/1LuCXt9GdQgwlEf2KBzV3dWTL5UrVYSayobtLuItoU-c/edit?usp=drivesdk",
+          "created_time": "2026-08-01T01:04:45.443Z",
+          "modified_time": "2026-08-01T01:04:47.711Z",
+          "source_path": "Village of Cumberland - 2026 Sewer Separation - ITT-2602/ITT-2602 Cumberland Sewer Separation - Tender Draft"
+        },
+        {
+          "drive_file_id": "1d6sRDMNPmHI6Cwaup6Zrlv4OuaD0oMhvqKEqXeRuF8Q",
+          "name": "ITT-2602 Cumberland Sewer Separation - Estimate",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1d6sRDMNPmHI6Cwaup6Zrlv4OuaD0oMhvqKEqXeRuF8Q/edit?usp=drivesdk",
+          "created_time": "2026-08-01T01:04:38.947Z",
+          "modified_time": "2026-08-01T01:04:39.961Z",
+          "source_path": "Village of Cumberland - 2026 Sewer Separation - ITT-2602/ITT-2602 Cumberland Sewer Separation - Estimate"
+        },
+        {
+          "drive_file_id": "1lD-lRPLJQF4IDBieSHAlP2VJEjcdLTOb",
+          "name": "ITT-2026_VoC_Sewer_Separation_Drawings.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1lD-lRPLJQF4IDBieSHAlP2VJEjcdLTOb/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:56:47.345Z",
+          "modified_time": "2026-08-01T00:56:47.345Z",
+          "source_path": "Village of Cumberland - 2026 Sewer Separation - ITT-2602/ITT-2026_VoC_Sewer_Separation_Drawings.pdf"
+        },
+        {
+          "drive_file_id": "1g4C5YlvUvePOUJOsLrIRBGOgr-dG0imq",
+          "name": "ITT-2602_VoC_Sewer_Separation.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1g4C5YlvUvePOUJOsLrIRBGOgr-dG0imq/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:55:52.375Z",
+          "modified_time": "2026-08-01T00:55:52.375Z",
+          "source_path": "Village of Cumberland - 2026 Sewer Separation - ITT-2602/ITT-2602_VoC_Sewer_Separation.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1OTshIHFPyj4UR_NyjH957-_HJ2FjhBo4",
+      "name": "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00",
+      "url": "https://drive.google.com/drive/folders/1OTshIHFPyj4UR_NyjH957-_HJ2FjhBo4",
+      "created_time": "2026-08-01T01:01:11.985Z",
+      "modified_time": "2026-08-01T01:01:11.985Z",
+      "files": [
+        {
+          "drive_file_id": "1e0gSzlfyRvDQ4lmmobHb0VmlJyK4GMXt",
+          "name": "Hillcrest Avenue Storm Rehabilitation - Tender Draft.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1e0gSzlfyRvDQ4lmmobHb0VmlJyK4GMXt/view?usp=drivesdk",
+          "created_time": "2026-08-01T01:02:37.522Z",
+          "modified_time": "2026-08-01T01:02:37.522Z",
+          "source_path": "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00/Hillcrest Avenue Storm Rehabilitation - Tender Draft.pdf"
+        },
+        {
+          "drive_file_id": "1pDrUv-FLtYGZA2vAMdGrJ2q076HZDILTY9hrkatXsFU",
+          "name": "Hillcrest Avenue Storm Rehabilitation - Tender Draft",
+          "mime_type": "application/vnd.google-apps.document",
+          "url": "https://docs.google.com/document/d/1pDrUv-FLtYGZA2vAMdGrJ2q076HZDILTY9hrkatXsFU/edit?usp=drivesdk",
+          "created_time": "2026-08-01T01:01:30.429Z",
+          "modified_time": "2026-08-01T01:01:32.408Z",
+          "source_path": "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00/Hillcrest Avenue Storm Rehabilitation - Tender Draft"
+        },
+        {
+          "drive_file_id": "1iDicCh09dw-_UAPaV4QYb0Zbwxv1-jhqq0rEaxuFtko",
+          "name": "Hillcrest Avenue Storm Rehabilitation - Estimate",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1iDicCh09dw-_UAPaV4QYb0Zbwxv1-jhqq0rEaxuFtko/edit?usp=drivesdk",
+          "created_time": "2026-08-01T01:01:22.612Z",
+          "modified_time": "2026-08-01T01:01:23.802Z",
+          "source_path": "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00/Hillcrest Avenue Storm Rehabilitation - Estimate"
+        },
+        {
+          "drive_file_id": "1G7qrSqrd5tqcTTQYgsVoL6hRjmRD_jCX",
+          "name": "District_of_Port_Edward_Hillcrest_Storm_Tender_Package.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1G7qrSqrd5tqcTTQYgsVoL6hRjmRD_jCX/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:51:31.994Z",
+          "modified_time": "2026-08-01T00:51:31.994Z",
+          "source_path": "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00/District_of_Port_Edward_Hillcrest_Storm_Tender_Package.pdf"
+        },
+        {
+          "drive_file_id": "13PaSN-Ka_NadtgYg_pK9VZpWXpe4st6C",
+          "name": "10482-C_SERIES_IFT_Rev1_sealed.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/13PaSN-Ka_NadtgYg_pK9VZpWXpe4st6C/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:50:51.864Z",
+          "modified_time": "2026-08-01T00:50:51.864Z",
+          "source_path": "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00/10482-C_SERIES_IFT_Rev1_sealed.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1o8lg-hZ9klNFfEVGmnogfvasH8NoAaS0",
+      "name": "Cumberland sewer separation",
+      "url": "https://drive.google.com/drive/folders/1o8lg-hZ9klNFfEVGmnogfvasH8NoAaS0",
+      "created_time": "2026-08-01T00:55:43.106Z",
+      "modified_time": "2026-08-01T00:55:43.106Z",
+      "files": []
+    },
+    {
+      "drive_folder_id": "1XJck5GY1eT18ZWTdNqRHi2xwQzMBKPkF",
+      "name": "Edward sewer",
+      "url": "https://drive.google.com/drive/folders/1XJck5GY1eT18ZWTdNqRHi2xwQzMBKPkF",
+      "created_time": "2026-08-01T00:50:44.840Z",
+      "modified_time": "2026-08-01T00:50:44.840Z",
+      "files": [
+        {
+          "drive_file_id": "1rYPIQFGbP5Mz2KKzmzFljUA-rrw5xHXY",
+          "name": "District_of_Port_Edward_Hillcrest_Storm_Tender_Package.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1rYPIQFGbP5Mz2KKzmzFljUA-rrw5xHXY/view?usp=drivesdk",
+          "created_time": "2026-08-01T01:10:17.459Z",
+          "modified_time": "2026-08-01T01:10:17.459Z",
+          "source_path": " Edward sewer/District_of_Port_Edward_Hillcrest_Storm_Tender_Package.pdf"
+        },
+        {
+          "drive_file_id": "1fOgYDpC2mLlgGHWhq2eNheoItc9nMv7L",
+          "name": "10482-C_SERIES_IFT_Rev1_sealed.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1fOgYDpC2mLlgGHWhq2eNheoItc9nMv7L/view?usp=drivesdk",
+          "created_time": "2026-08-01T01:09:35.655Z",
+          "modified_time": "2026-08-01T01:09:35.655Z",
+          "source_path": " Edward sewer/10482-C_SERIES_IFT_Rev1_sealed.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "14gJumcOdON6NZH6AyrYw3rEjLtTZjXQl",
+      "name": "Q26 335 - Firehall 3 Concrete Driveway",
+      "url": "https://drive.google.com/drive/folders/14gJumcOdON6NZH6AyrYw3rEjLtTZjXQl",
+      "created_time": "2026-08-01T00:50:26.157Z",
+      "modified_time": "2026-08-01T00:50:26.157Z",
+      "files": [
+        {
+          "drive_file_id": "1MbYGfY-viJIuIWbRHTqcUHrp-REiOWdTdDlg4jCkprg",
+          "name": "Q26 335 - Firehall 3 Concrete Driveway Quotation",
+          "mime_type": "application/vnd.google-apps.document",
+          "url": "https://docs.google.com/document/d/1MbYGfY-viJIuIWbRHTqcUHrp-REiOWdTdDlg4jCkprg/edit?usp=drivesdk",
+          "created_time": "2026-08-01T00:50:43.627Z",
+          "modified_time": "2026-08-01T00:50:44.769Z",
+          "source_path": "Q26 335 - Firehall 3 Concrete Driveway/Q26 335 - Firehall 3 Concrete Driveway Quotation"
+        },
+        {
+          "drive_file_id": "1Tfoy5F53o_UzOQSggXJknjhIxfHoFDDePGOoDxXXXcc",
+          "name": "Q26 335 - Firehall 3 Concrete Driveway Estimate",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1Tfoy5F53o_UzOQSggXJknjhIxfHoFDDePGOoDxXXXcc/edit?usp=drivesdk",
+          "created_time": "2026-08-01T00:50:35.244Z",
+          "modified_time": "2026-08-01T00:50:36.427Z",
+          "source_path": "Q26 335 - Firehall 3 Concrete Driveway/Q26 335 - Firehall 3 Concrete Driveway Estimate"
+        },
+        {
+          "drive_file_id": "1Dc11hj5aeAMNevk1I2sPhnnJ6B6E9lQ3",
+          "name": "Q26_335_Firehall__3_Concrete_Driveway.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1Dc11hj5aeAMNevk1I2sPhnnJ6B6E9lQ3/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:28:12.624Z",
+          "modified_time": "2026-08-01T00:28:12.624Z",
+          "source_path": "Q26 335 - Firehall 3 Concrete Driveway/Q26_335_Firehall__3_Concrete_Driveway.pdf"
+        },
+        {
+          "drive_file_id": "1NWoJaEcCcLpDH8f2Voyxvvu9VWLrPeRa",
+          "name": "Q26_335_Appendix_A.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1NWoJaEcCcLpDH8f2Voyxvvu9VWLrPeRa/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:27:40.363Z",
+          "modified_time": "2026-08-01T00:27:40.363Z",
+          "source_path": "Q26 335 - Firehall 3 Concrete Driveway/Q26_335_Appendix_A.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1dA9BCow-rTCqivIR0lZ-GcS4lTciN8MT",
+      "name": "Sani manhole repair Fernie",
+      "url": "https://drive.google.com/drive/folders/1dA9BCow-rTCqivIR0lZ-GcS4lTciN8MT",
+      "created_time": "2026-08-01T00:32:37.341Z",
+      "modified_time": "2026-08-01T00:32:37.341Z",
+      "files": [
+        {
+          "drive_file_id": "1HonTJWNVl370Q28zBwNx-Cc4Nu-2HLeF",
+          "name": "ID__1117.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1HonTJWNVl370Q28zBwNx-Cc4Nu-2HLeF/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:47:03.646Z",
+          "modified_time": "2026-08-01T00:47:03.646Z",
+          "source_path": "Sani manhole repair Fernie /ID__1117.MOV"
+        },
+        {
+          "drive_file_id": "1oR8ni5zhlthWO2GpQF_0Le4eHCjDBKXL",
+          "name": "ID__784.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1oR8ni5zhlthWO2GpQF_0Le4eHCjDBKXL/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:46:03.785Z",
+          "modified_time": "2026-08-01T00:46:03.785Z",
+          "source_path": "Sani manhole repair Fernie /ID__784.MOV"
+        },
+        {
+          "drive_file_id": "1yECiP6lbWWRfJsGj8LbOzuvIlFzh9nhV",
+          "name": "ID__623.MP4",
+          "mime_type": "video/mp4",
+          "url": "https://drive.google.com/file/d/1yECiP6lbWWRfJsGj8LbOzuvIlFzh9nhV/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:45:04.416Z",
+          "modified_time": "2026-08-01T00:45:04.416Z",
+          "source_path": "Sani manhole repair Fernie /ID__623.MP4"
+        },
+        {
+          "drive_file_id": "1X0--t5xfAQUrcYeM0b_VQIeVSovklGYP",
+          "name": "ID__575.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1X0--t5xfAQUrcYeM0b_VQIeVSovklGYP/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:43:47.081Z",
+          "modified_time": "2026-08-01T00:43:47.081Z",
+          "source_path": "Sani manhole repair Fernie /ID__575.MOV"
+        },
+        {
+          "drive_file_id": "1heWH3TIey8U23Ga4OwNYAKNfp5ChvbwG",
+          "name": "ID__407.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1heWH3TIey8U23Ga4OwNYAKNfp5ChvbwG/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:42:53.132Z",
+          "modified_time": "2026-08-01T00:42:53.132Z",
+          "source_path": "Sani manhole repair Fernie /ID__407.MOV"
+        },
+        {
+          "drive_file_id": "17Hyi8DmfQRkBxWd9dEuOqTHzLVMYkTN5",
+          "name": "ID__401.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/17Hyi8DmfQRkBxWd9dEuOqTHzLVMYkTN5/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:41:59.137Z",
+          "modified_time": "2026-08-01T00:41:59.137Z",
+          "source_path": "Sani manhole repair Fernie /ID__401.MOV"
+        },
+        {
+          "drive_file_id": "1H3FWz7BwspoBP2nye3Sadr6RCaO0y8qe",
+          "name": "ID__272__2_.mp4",
+          "mime_type": "video/mp4",
+          "url": "https://drive.google.com/file/d/1H3FWz7BwspoBP2nye3Sadr6RCaO0y8qe/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:40:54.569Z",
+          "modified_time": "2026-08-01T00:40:54.569Z",
+          "source_path": "Sani manhole repair Fernie /ID__272__2_.mp4"
+        },
+        {
+          "drive_file_id": "1MeE9M116HdqxDl_0Tvmuxe_c7GSzrqhc",
+          "name": "ID__272.MP4",
+          "mime_type": "video/mp4",
+          "url": "https://drive.google.com/file/d/1MeE9M116HdqxDl_0Tvmuxe_c7GSzrqhc/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:39:56.159Z",
+          "modified_time": "2026-08-01T00:39:56.159Z",
+          "source_path": "Sani manhole repair Fernie /ID__272.MP4"
+        },
+        {
+          "drive_file_id": "1SOhB-iG-GTTNTJ7tLVJkUk0UZe1HzN2L",
+          "name": "ID__269.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1SOhB-iG-GTTNTJ7tLVJkUk0UZe1HzN2L/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:39:13.989Z",
+          "modified_time": "2026-08-01T00:39:13.989Z",
+          "source_path": "Sani manhole repair Fernie /ID__269.MOV"
+        },
+        {
+          "drive_file_id": "1ovQgYBAedZS1Z-IIJb4e7IfhV2OVvX5K",
+          "name": "ID__238.mp4",
+          "mime_type": "video/mp4",
+          "url": "https://drive.google.com/file/d/1ovQgYBAedZS1Z-IIJb4e7IfhV2OVvX5K/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:37:49.779Z",
+          "modified_time": "2026-08-01T00:37:49.779Z",
+          "source_path": "Sani manhole repair Fernie /ID__238.mp4"
+        },
+        {
+          "drive_file_id": "1-C-CHBwPJHLBwYqkW_Ww3-sRXt0e2-Wn",
+          "name": "ID__237__2_.mp4",
+          "mime_type": "video/mp4",
+          "url": "https://drive.google.com/file/d/1-C-CHBwPJHLBwYqkW_Ww3-sRXt0e2-Wn/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:36:38.918Z",
+          "modified_time": "2026-08-01T00:36:38.918Z",
+          "source_path": "Sani manhole repair Fernie /ID__237__2_.mp4"
+        },
+        {
+          "drive_file_id": "1OV-D_DueW2aa-9BERf4Nwn44lqKojYMT",
+          "name": "ID__237.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1OV-D_DueW2aa-9BERf4Nwn44lqKojYMT/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:35:15.952Z",
+          "modified_time": "2026-08-01T00:35:15.952Z",
+          "source_path": "Sani manhole repair Fernie /ID__237.MOV"
+        },
+        {
+          "drive_file_id": "1bWhxL3v8NcQjsLRF_WowI3Z4mIfkjDE-",
+          "name": "ID__218.MOV",
+          "mime_type": "video/quicktime",
+          "url": "https://drive.google.com/file/d/1bWhxL3v8NcQjsLRF_WowI3Z4mIfkjDE-/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:34:01.170Z",
+          "modified_time": "2026-08-01T00:34:01.170Z",
+          "source_path": "Sani manhole repair Fernie /ID__218.MOV"
+        },
+        {
+          "drive_file_id": "1L6SBz65W8PfC_2Aq5PWRa8T_Pi1WSRcK",
+          "name": "2026_Manhole_Infiltration_Repair_Program_RFP.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1L6SBz65W8PfC_2Aq5PWRa8T_Pi1WSRcK/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:32:42.777Z",
+          "modified_time": "2026-08-01T00:32:42.777Z",
+          "source_path": "Sani manhole repair Fernie /2026_Manhole_Infiltration_Repair_Program_RFP.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1B8ZcMgd5-cEU28TrTlefxcOlRbCqOKX6",
+      "name": "We fireball",
+      "url": "https://drive.google.com/drive/folders/1B8ZcMgd5-cEU28TrTlefxcOlRbCqOKX6",
+      "created_time": "2026-08-01T00:27:35.492Z",
+      "modified_time": "2026-08-01T00:27:35.492Z",
+      "files": []
+    },
+    {
+      "drive_folder_id": "1c8bVsnECh-fgKLdc_sAx-fyEWpl2QGkC",
+      "name": "Parksville",
+      "url": "https://drive.google.com/drive/folders/1c8bVsnECh-fgKLdc_sAx-fyEWpl2QGkC",
+      "created_time": "2026-08-01T00:20:38.841Z",
+      "modified_time": "2026-08-01T00:20:38.841Z",
+      "files": [
+        {
+          "drive_file_id": "1DpLb9TN_14glv_oK62oqlcNIKQO7As8d",
+          "name": "5330-20-STANFORD-ELECTRICAL_IFT.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1DpLb9TN_14glv_oK62oqlcNIKQO7As8d/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:22:44.643Z",
+          "modified_time": "2026-08-01T00:22:44.643Z",
+          "source_path": "Parksville /5330-20-STANFORD-ELECTRICAL_IFT.pdf"
+        },
+        {
+          "drive_file_id": "170g48dOqmf8XOipYHBmBZfxtIUAQwuqz",
+          "name": "5330-20-STANFORD-LANDSCAPE_IFT.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/170g48dOqmf8XOipYHBmBZfxtIUAQwuqz/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:21:56.964Z",
+          "modified_time": "2026-08-01T00:21:56.964Z",
+          "source_path": "Parksville /5330-20-STANFORD-LANDSCAPE_IFT.pdf"
+        },
+        {
+          "drive_file_id": "10mZrtJX3notqpu1p7_sr1o63OAgLYbRK",
+          "name": "5330-20-STANFORD-CIVIL_IFT.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/10mZrtJX3notqpu1p7_sr1o63OAgLYbRK/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:21:19.749Z",
+          "modified_time": "2026-08-01T00:21:19.749Z",
+          "source_path": "Parksville /5330-20-STANFORD-CIVIL_IFT.pdf"
+        },
+        {
+          "drive_file_id": "1BvLO5L_oiHRHRyvRjRaeMJn9JL-Sx_Jo",
+          "name": "5330-20-STANFORD_TenderDocuments.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1BvLO5L_oiHRHRyvRjRaeMJn9JL-Sx_Jo/view?usp=drivesdk",
+          "created_time": "2026-08-01T00:20:46.884Z",
+          "modified_time": "2026-08-01T00:20:46.884Z",
+          "source_path": "Parksville /5330-20-STANFORD_TenderDocuments.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1E9HmYXU39jghxu0xNorCqsEegV7cui3N",
+      "name": "Braidwood",
+      "url": "https://drive.google.com/drive/folders/1E9HmYXU39jghxu0xNorCqsEegV7cui3N",
+      "created_time": "2026-07-27T13:20:43.286Z",
+      "modified_time": "2026-07-27T13:20:50.069Z",
+      "files": [
+        {
+          "drive_file_id": "1zC0CKUizVFKEGutIKGv3mW-PyZspzlVz",
+          "name": "IH-Estimate-BraidwoodRoad-C26-085-2026-07-27-v1.xlsx",
+          "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "url": "https://docs.google.com/spreadsheets/d/1zC0CKUizVFKEGutIKGv3mW-PyZspzlVz/edit?usp=drivesdk&ouid=107231313353501423718&rtpof=true&sd=true",
+          "created_time": "2026-07-29T14:21:55.021Z",
+          "modified_time": "2026-07-29T14:21:55.021Z",
+          "source_path": "Braidwood/IH-Estimate-BraidwoodRoad-C26-085-2026-07-27-v1.xlsx"
+        },
+        {
+          "drive_file_id": "19khYzx_ykK6fn7PJjoKMZ4iERXUtfDUH",
+          "name": "raw.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/19khYzx_ykK6fn7PJjoKMZ4iERXUtfDUH/view?usp=drivesdk",
+          "created_time": "2026-07-27T14:15:01.030Z",
+          "modified_time": "2026-07-27T14:15:01.030Z",
+          "source_path": "Braidwood/raw.pdf"
+        },
+        {
+          "drive_file_id": "1EQWB05ae1Y2W3UzUS51lKNvZK9sIQp-6",
+          "name": "Contract_Drawings.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1EQWB05ae1Y2W3UzUS51lKNvZK9sIQp-6/view?usp=drivesdk",
+          "created_time": "2026-07-27T13:21:03.656Z",
+          "modified_time": "2026-07-27T13:21:03.656Z",
+          "source_path": "Braidwood/Braidwood/Contract_Drawings.pdf"
+        },
+        {
+          "drive_file_id": "1XWXR3kVarmTldtRIjm4RldkuSo0d4dXt",
+          "name": "C26-085_Braidwood_Road_Corridor_Improvements_Tender_Package.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1XWXR3kVarmTldtRIjm4RldkuSo0d4dXt/view?usp=drivesdk",
+          "created_time": "2026-07-27T13:20:59.556Z",
+          "modified_time": "2026-07-27T13:20:59.556Z",
+          "source_path": "Braidwood/Braidwood/C26-085_Braidwood_Road_Corridor_Improvements_Tender_Package.pdf"
+        },
+        {
+          "drive_file_id": "1h5rZANlPhUtlktdPGIsqaVFzS2LKSEnT",
+          "name": "Geotechnical_Assessment.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1h5rZANlPhUtlktdPGIsqaVFzS2LKSEnT/view?usp=drivesdk",
+          "created_time": "2026-07-27T13:20:57.806Z",
+          "modified_time": "2026-07-27T13:20:57.806Z",
+          "source_path": "Braidwood/Braidwood/Geotechnical_Assessment.pdf"
+        },
+        {
+          "drive_file_id": "1hcr5tD_2-Cz1pnnWhYTJIgeBFdk80Fxx",
+          "name": "Archaeological_Chance_Find_Procedure.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1hcr5tD_2-Cz1pnnWhYTJIgeBFdk80Fxx/view?usp=drivesdk",
+          "created_time": "2026-07-27T13:20:56.286Z",
+          "modified_time": "2026-07-27T13:20:56.286Z",
+          "source_path": "Braidwood/Braidwood/Archaeological_Chance_Find_Procedure.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "14RLoWDd7OZ0aeIa60QQu9yB-U2vmWXcM",
+      "name": "McLeod Lake Watermain",
+      "url": "https://drive.google.com/drive/folders/14RLoWDd7OZ0aeIa60QQu9yB-U2vmWXcM",
+      "created_time": "2026-07-19T17:55:21.036Z",
+      "modified_time": "2026-07-24T14:29:01.678Z",
+      "files": [
+        {
+          "drive_file_id": "1Av4uMt5Lm7HR3IVC_OiFIsCdHAmiC9wO",
+          "name": "MLIB_Water_System_Improvements_-_Phase_1_-_Civil_Tender_-_2026-07-14.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1Av4uMt5Lm7HR3IVC_OiFIsCdHAmiC9wO/view?usp=drivesdk",
+          "created_time": "2026-07-19T17:55:57.096Z",
+          "modified_time": "2026-07-19T17:55:57.096Z",
+          "source_path": "McLeod Lake Watermain/MLIB_Water_System_Improvements_-_Phase_1_-_Civil_Tender_-_2026-07-14.pdf"
+        },
+        {
+          "drive_file_id": "14e9boKVnRoaBVNYtYS1wjgkSOD-vTxZ7",
+          "name": "a7f70533-02cc-4887-9b98-f55582e46568.html",
+          "mime_type": "text/html",
+          "url": "https://drive.google.com/file/d/14e9boKVnRoaBVNYtYS1wjgkSOD-vTxZ7/view?usp=drivesdk",
+          "created_time": "2026-07-19T17:55:54.633Z",
+          "modified_time": "2026-07-19T17:55:54.633Z",
+          "source_path": "McLeod Lake Watermain/a7f70533-02cc-4887-9b98-f55582e46568.html"
+        },
+        {
+          "drive_file_id": "1vlFXtL63p8LV33l3sDbjquhsrgMbo8NQ",
+          "name": "037fac8d-4042-4ceb-a33c-4e07aca22fc3.html",
+          "mime_type": "text/html",
+          "url": "https://drive.google.com/file/d/1vlFXtL63p8LV33l3sDbjquhsrgMbo8NQ/view?usp=drivesdk",
+          "created_time": "2026-07-19T17:55:53.265Z",
+          "modified_time": "2026-07-19T17:55:53.265Z",
+          "source_path": "McLeod Lake Watermain/037fac8d-4042-4ceb-a33c-4e07aca22fc3.html"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1Oeov9EaULG-h5Cfcrru7oaJFkLnBFmXM",
+      "name": "Cassidys",
+      "url": "https://drive.google.com/drive/folders/1Oeov9EaULG-h5Cfcrru7oaJFkLnBFmXM",
+      "created_time": "2026-07-22T15:36:33.530Z",
+      "modified_time": "2026-07-22T15:36:33.530Z",
+      "files": [
+        {
+          "drive_file_id": "1_wIz8solYz6yhYhQKFRWDP5lNQLSp4g_aJfPiS2ehXU",
+          "name": "IH-Estimate-Cassidys-Full-Bid-Workbook-2026-07-23-v2",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1_wIz8solYz6yhYhQKFRWDP5lNQLSp4g_aJfPiS2ehXU/edit?usp=drivesdk",
+          "created_time": "2026-07-23T19:30:49.812Z",
+          "modified_time": "2026-07-23T19:32:58.875Z",
+          "source_path": "Cassidys/IH-Estimate-Cassidys-Full-Bid-Workbook-2026-07-23-v2"
+        },
+        {
+          "drive_file_id": "1jA3vYKJkgcuOeaZc8_LQ4c8i8vHatJNA",
+          "name": "IMG_3115.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1jA3vYKJkgcuOeaZc8_LQ4c8i8vHatJNA/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:15.235Z",
+          "modified_time": "2026-07-22T16:15:15.235Z",
+          "source_path": "Cassidys/IMG_3115.HEIC"
+        },
+        {
+          "drive_file_id": "1rRKPYFzKaKQXb_Ujq8Zvpmf3s519lZlt",
+          "name": "IMG_3120.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1rRKPYFzKaKQXb_Ujq8Zvpmf3s519lZlt/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:14.464Z",
+          "modified_time": "2026-07-22T16:15:14.464Z",
+          "source_path": "Cassidys/IMG_3120.HEIC"
+        },
+        {
+          "drive_file_id": "1M1nwsqgsJ5FFs_ZDPrCePV36cu3K-IF7",
+          "name": "IMG_3116.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1M1nwsqgsJ5FFs_ZDPrCePV36cu3K-IF7/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:12.265Z",
+          "modified_time": "2026-07-22T16:15:12.265Z",
+          "source_path": "Cassidys/IMG_3116.HEIC"
+        },
+        {
+          "drive_file_id": "1YQv5KtrA5xuuHQpY2s9mbYSPDhKT5N-n",
+          "name": "IMG_3119.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1YQv5KtrA5xuuHQpY2s9mbYSPDhKT5N-n/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:11.276Z",
+          "modified_time": "2026-07-22T16:15:11.276Z",
+          "source_path": "Cassidys/IMG_3119.HEIC"
+        },
+        {
+          "drive_file_id": "1X9GPx3IM7-1Cil5yulTL5-TpzzEH6fd1",
+          "name": "IMG_3118.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1X9GPx3IM7-1Cil5yulTL5-TpzzEH6fd1/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:08.811Z",
+          "modified_time": "2026-07-22T16:15:08.811Z",
+          "source_path": "Cassidys/IMG_3118.HEIC"
+        },
+        {
+          "drive_file_id": "1fVXUk6ip3rVJdFaJuxp1ekwOcEnnJbTV",
+          "name": "IMG_3114.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1fVXUk6ip3rVJdFaJuxp1ekwOcEnnJbTV/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:06.143Z",
+          "modified_time": "2026-07-22T16:15:06.143Z",
+          "source_path": "Cassidys/IMG_3114.HEIC"
+        },
+        {
+          "drive_file_id": "1iuf5Qxqah0pxDgjRmFZpi7UuRGh_K-pl",
+          "name": "IMG_3117.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1iuf5Qxqah0pxDgjRmFZpi7UuRGh_K-pl/view?usp=drivesdk",
+          "created_time": "2026-07-22T16:15:03.168Z",
+          "modified_time": "2026-07-22T16:15:03.168Z",
+          "source_path": "Cassidys/IMG_3117.HEIC"
+        },
+        {
+          "drive_file_id": "1BqDtgI--KGBnyhIxDL9z2-ivZEj8tXAV",
+          "name": "IMG_3112.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1BqDtgI--KGBnyhIxDL9z2-ivZEj8tXAV/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:38:13.966Z",
+          "modified_time": "2026-07-22T15:38:13.966Z",
+          "source_path": "Cassidys/IMG_3112.HEIC"
+        },
+        {
+          "drive_file_id": "15iA8_fqHlFo7CnQ515uSi8Y3-Dw_a5XJ",
+          "name": "IMG_3113.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/15iA8_fqHlFo7CnQ515uSi8Y3-Dw_a5XJ/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:38:13.607Z",
+          "modified_time": "2026-07-22T15:38:13.607Z",
+          "source_path": "Cassidys/IMG_3113.HEIC"
+        },
+        {
+          "drive_file_id": "1Nh5TfRf-_9CjvwJn9b2A088HhDUMc7Ok",
+          "name": "IMG_3106.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1Nh5TfRf-_9CjvwJn9b2A088HhDUMc7Ok/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:38:12.703Z",
+          "modified_time": "2026-07-22T15:38:12.703Z",
+          "source_path": "Cassidys/IMG_3106.HEIC"
+        },
+        {
+          "drive_file_id": "1kMQ9XAT67uudXZHqcCIx8BSZENzJ6Tvq",
+          "name": "IMG_3105.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1kMQ9XAT67uudXZHqcCIx8BSZENzJ6Tvq/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:38:11.236Z",
+          "modified_time": "2026-07-22T15:38:11.236Z",
+          "source_path": "Cassidys/IMG_3105.HEIC"
+        },
+        {
+          "drive_file_id": "1jW57cSS-td-P-8_FrjollMSkL2VjthGE",
+          "name": "IMG_3098.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1jW57cSS-td-P-8_FrjollMSkL2VjthGE/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:38:10.169Z",
+          "modified_time": "2026-07-22T15:38:10.169Z",
+          "source_path": "Cassidys/IMG_3098.HEIC"
+        },
+        {
+          "drive_file_id": "19p7K04zElz6M1WBgMVOLSwu1hGMfq9Tn",
+          "name": "IMG_3103.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/19p7K04zElz6M1WBgMVOLSwu1hGMfq9Tn/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:56.653Z",
+          "modified_time": "2026-07-22T15:37:56.653Z",
+          "source_path": "Cassidys/IMG_3103.HEIC"
+        },
+        {
+          "drive_file_id": "10pY2CEisjhv9CTQEU6ou2RpidDxgM_co",
+          "name": "IMG_3099.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/10pY2CEisjhv9CTQEU6ou2RpidDxgM_co/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:51.252Z",
+          "modified_time": "2026-07-22T15:37:51.252Z",
+          "source_path": "Cassidys/IMG_3099.HEIC"
+        },
+        {
+          "drive_file_id": "13lcVzhhAkWzayIU2r6OHW8O67Vp6lCgA",
+          "name": "IMG_3096.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/13lcVzhhAkWzayIU2r6OHW8O67Vp6lCgA/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:50.938Z",
+          "modified_time": "2026-07-22T15:37:50.938Z",
+          "source_path": "Cassidys/IMG_3096.HEIC"
+        },
+        {
+          "drive_file_id": "1qXqtW78N9mKkjouDf6jDPXY3UzswFxKt",
+          "name": "IMG_3100.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1qXqtW78N9mKkjouDf6jDPXY3UzswFxKt/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:47.813Z",
+          "modified_time": "2026-07-22T15:37:47.813Z",
+          "source_path": "Cassidys/IMG_3100.HEIC"
+        },
+        {
+          "drive_file_id": "1u_smn_hcDvQXdP2oPcDn-bX4ySjJfF8p",
+          "name": "IMG_3101.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1u_smn_hcDvQXdP2oPcDn-bX4ySjJfF8p/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:34.932Z",
+          "modified_time": "2026-07-22T15:37:34.932Z",
+          "source_path": "Cassidys/IMG_3101.HEIC"
+        },
+        {
+          "drive_file_id": "1nhVHzs_tNIygmxEuC-zZMQmENwxmAL58",
+          "name": "IMG_3095.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1nhVHzs_tNIygmxEuC-zZMQmENwxmAL58/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:32.898Z",
+          "modified_time": "2026-07-22T15:37:32.898Z",
+          "source_path": "Cassidys/IMG_3095.HEIC"
+        },
+        {
+          "drive_file_id": "1RPH4En2mWEpGdKfvjqBeP0dwkyOKk9K1",
+          "name": "IMG_3097.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1RPH4En2mWEpGdKfvjqBeP0dwkyOKk9K1/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:31.838Z",
+          "modified_time": "2026-07-22T15:37:31.838Z",
+          "source_path": "Cassidys/IMG_3097.HEIC"
+        },
+        {
+          "drive_file_id": "1A5n1nQc0B_8fDFAbyo0isYvvObN3AwtB",
+          "name": "IMG_3104.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1A5n1nQc0B_8fDFAbyo0isYvvObN3AwtB/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:26.160Z",
+          "modified_time": "2026-07-22T15:37:26.160Z",
+          "source_path": "Cassidys/IMG_3104.HEIC"
+        },
+        {
+          "drive_file_id": "1-bPYAGweJjCuJph7p6xyaVYx1X6qnCRf",
+          "name": "IMG_3102.HEIC",
+          "mime_type": "image/heif",
+          "url": "https://drive.google.com/file/d/1-bPYAGweJjCuJph7p6xyaVYx1X6qnCRf/view?usp=drivesdk",
+          "created_time": "2026-07-22T15:37:19.443Z",
+          "modified_time": "2026-07-22T15:37:19.443Z",
+          "source_path": "Cassidys/IMG_3102.HEIC"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1rD6tekhy7se2oBgNbR4G3qTcmkFjkev9",
+      "name": "Elk River FSR",
+      "url": "https://drive.google.com/drive/folders/1rD6tekhy7se2oBgNbR4G3qTcmkFjkev9",
+      "created_time": "2026-07-21T18:17:40.719Z",
+      "modified_time": "2026-07-21T18:17:40.719Z",
+      "files": [
+        {
+          "drive_file_id": "1NUXVsqoD5deZPW8CXLxCdQASpWH6Cx00",
+          "name": "a1108d16-afd6-4aa8-85f0-7e7290a06924",
+          "mime_type": "application/octet-stream",
+          "url": "https://drive.google.com/file/d/1NUXVsqoD5deZPW8CXLxCdQASpWH6Cx00/view?usp=drivesdk",
+          "created_time": "2026-07-21T18:19:47.250Z",
+          "modified_time": "2026-07-21T18:19:47.250Z",
+          "source_path": "Elk River FSR/a1108d16-afd6-4aa8-85f0-7e7290a06924"
+        },
+        {
+          "drive_file_id": "1M-GGdVIdc6Oy2zg0LUDRKMJXYNHekTES",
+          "name": "997a83b9-0deb-4269-aa96-c5a791fe9af0",
+          "mime_type": "application/octet-stream",
+          "url": "https://drive.google.com/file/d/1M-GGdVIdc6Oy2zg0LUDRKMJXYNHekTES/view?usp=drivesdk",
+          "created_time": "2026-07-21T18:19:25.537Z",
+          "modified_time": "2026-07-21T18:19:25.537Z",
+          "source_path": "Elk River FSR/997a83b9-0deb-4269-aa96-c5a791fe9af0"
+        },
+        {
+          "drive_file_id": "1a94Um4nGUK04GNlGqeNKb9y1PNePAy3G",
+          "name": "997a83b9-0deb-4269-aa96-c5a791fe9af0",
+          "mime_type": "application/octet-stream",
+          "url": "https://drive.google.com/file/d/1a94Um4nGUK04GNlGqeNKb9y1PNePAy3G/view?usp=drivesdk",
+          "created_time": "2026-07-21T18:18:36.088Z",
+          "modified_time": "2026-07-21T18:18:36.088Z",
+          "source_path": "Elk River FSR/997a83b9-0deb-4269-aa96-c5a791fe9af0"
+        },
+        {
+          "drive_file_id": "1LMyow3IxZt9V7yWaduUlwXVt-ivxMBoI",
+          "name": "66ae7357-e173-4d07-9035-9917778f8b83",
+          "mime_type": "application/octet-stream",
+          "url": "https://drive.google.com/file/d/1LMyow3IxZt9V7yWaduUlwXVt-ivxMBoI/view?usp=drivesdk",
+          "created_time": "2026-07-21T18:18:15.231Z",
+          "modified_time": "2026-07-21T18:18:15.231Z",
+          "source_path": "Elk River FSR/66ae7357-e173-4d07-9035-9917778f8b83"
+        },
+        {
+          "drive_file_id": "1aFqUfyOL0eXGsD0JvBgEBNotLiDar0XT",
+          "name": "19452ef1-ebf6-466b-858f-7222e0f181be",
+          "mime_type": "application/octet-stream",
+          "url": "https://drive.google.com/file/d/1aFqUfyOL0eXGsD0JvBgEBNotLiDar0XT/view?usp=drivesdk",
+          "created_time": "2026-07-21T18:17:45.785Z",
+          "modified_time": "2026-07-21T18:17:45.785Z",
+          "source_path": "Elk River FSR/19452ef1-ebf6-466b-858f-7222e0f181be"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1SlGpPpOsdbsaQyihZkDSgIqOsaEIZhb4",
+      "name": "TFN path",
+      "url": "https://drive.google.com/drive/folders/1SlGpPpOsdbsaQyihZkDSgIqOsaEIZhb4",
+      "created_time": "2026-07-21T10:39:16.173Z",
+      "modified_time": "2026-07-21T10:39:16.173Z",
+      "files": [
+        {
+          "drive_file_id": "1n54gmRDDvse6NToVx8Fue6MRLNhYlgsW",
+          "name": "RFP_2026-003_Construction_Services_for_MUP.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1n54gmRDDvse6NToVx8Fue6MRLNhYlgsW/view?usp=drivesdk",
+          "created_time": "2026-07-21T10:40:07.796Z",
+          "modified_time": "2026-07-21T10:40:07.796Z",
+          "source_path": "TFN path/RFP_2026-003_Construction_Services_for_MUP.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1nBDbFY39zN5yiDDlyj6hR88Asjmxi783",
+      "name": "Downes Rd MOT",
+      "url": "https://drive.google.com/drive/folders/1nBDbFY39zN5yiDDlyj6hR88Asjmxi783",
+      "created_time": "2026-07-17T19:20:39.475Z",
+      "modified_time": "2026-07-17T19:20:39.475Z",
+      "files": [
+        {
+          "drive_file_id": "11bynWvwCt4fswG5miWLGgHSM2-DveWp7mWgf5ryjfPM",
+          "name": "Downes Road MOT - Estimate Draft",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/11bynWvwCt4fswG5miWLGgHSM2-DveWp7mWgf5ryjfPM/edit?usp=drivesdk",
+          "created_time": "2026-07-17T19:28:45.366Z",
+          "modified_time": "2026-07-20T12:25:11.592Z",
+          "source_path": "Downes Rd MOT/Downes Road MOT - Estimate Draft"
+        },
+        {
+          "drive_file_id": "1e7NbmlpDtNbCYaytBRohjQG1HTT1CA6t",
+          "name": "PatchDrainReinstatement_260211.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1e7NbmlpDtNbCYaytBRohjQG1HTT1CA6t/view?usp=drivesdk",
+          "created_time": "2026-07-17T19:22:12.264Z",
+          "modified_time": "2026-07-17T19:22:12.264Z",
+          "source_path": "Downes Rd MOT/PatchDrainReinstatement_260211.pdf"
+        },
+        {
+          "drive_file_id": "10k31piaOZAwGj-BqTpDbxgNrMCDOh5jv",
+          "name": "PatchDrainReinstatement_260211.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/10k31piaOZAwGj-BqTpDbxgNrMCDOh5jv/view?usp=drivesdk",
+          "created_time": "2026-07-17T19:21:50.388Z",
+          "modified_time": "2026-07-17T19:21:50.388Z",
+          "source_path": "Downes Rd MOT/PatchDrainReinstatement_260211.pdf"
+        },
+        {
+          "drive_file_id": "1YLBZ5ih-KHuRl58Ud_7TF4wpZGl_QYNK",
+          "name": "Hello,.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1YLBZ5ih-KHuRl58Ud_7TF4wpZGl_QYNK/view?usp=drivesdk",
+          "created_time": "2026-07-17T19:20:46.616Z",
+          "modified_time": "2026-07-17T19:20:46.616Z",
+          "source_path": "Downes Rd MOT/Hello,.pdf"
+        }
+      ]
+    },
+    {
+      "drive_folder_id": "1ZKHtT_Gm2ljkmdyQGDkfiVHZUSvv2MsU",
+      "name": "IHCC-TEST-001_Test_Municipal_Road_Improvements",
+      "url": "https://drive.google.com/drive/folders/1ZKHtT_Gm2ljkmdyQGDkfiVHZUSvv2MsU",
+      "created_time": "2026-07-03T17:09:57.353Z",
+      "modified_time": "2026-07-03T17:09:57.353Z",
+      "files": [
+        {
+          "drive_file_id": "1DsgAKIbAQgnyDwXQYKKIZdyaeqffqPvGoB0KrEUgIrI",
+          "name": "IHCC-TEST-001 - Estimate Workbook",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1DsgAKIbAQgnyDwXQYKKIZdyaeqffqPvGoB0KrEUgIrI/edit?usp=drivesdk",
+          "created_time": "2026-07-03T17:11:07.391Z",
+          "modified_time": "2026-07-03T17:11:07.391Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/09_Estimate/IHCC-TEST-001 - Estimate Workbook"
+        },
+        {
+          "drive_file_id": "1Q5RFRm-4WXaDGqYojGCvnBIECmsqr2b_",
+          "name": "text.txt",
+          "mime_type": "text/plain",
+          "url": "https://drive.google.com/file/d/1Q5RFRm-4WXaDGqYojGCvnBIECmsqr2b_/view?usp=drivesdk",
+          "created_time": "2026-07-06T17:09:05.774Z",
+          "modified_time": "2026-07-06T17:09:05.774Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/01_Tender_Documents/text.txt"
+        },
+        {
+          "drive_file_id": "1PbZdT9ZC6qU67RC-ehoV4kY1QlhNSo0o",
+          "name": "Tender_Form_26-151.xlsx",
+          "mime_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "url": "https://docs.google.com/spreadsheets/d/1PbZdT9ZC6qU67RC-ehoV4kY1QlhNSo0o/edit?usp=drivesdk&ouid=107231313353501423718&rtpof=true&sd=true",
+          "created_time": "2026-07-06T17:08:30.034Z",
+          "modified_time": "2026-07-06T17:08:30.034Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/01_Tender_Documents/Tender_Form_26-151.xlsx"
+        },
+        {
+          "drive_file_id": "1sC9Yx7tvZ8Gw2Fq9HfDiIty1j8ZBlfPj",
+          "name": "T2026-017_-_Drawings_IFT.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/1sC9Yx7tvZ8Gw2Fq9HfDiIty1j8ZBlfPj/view?usp=drivesdk",
+          "created_time": "2026-07-05T00:03:44.575Z",
+          "modified_time": "2026-07-05T00:03:44.575Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/01_Tender_Documents/T2026-017_204_Street_Logan_Avenue_Roadworks/02_Drawings/T2026-017_-_Drawings_IFT.pdf"
+        },
+        {
+          "drive_file_id": "1NlC-6_ZvZfdECvc646xXVpOhA61DVOwHs1Ao5ymzDT8",
+          "name": "T2026-017 - 204 Street and Logan Avenue Estimate",
+          "mime_type": "application/vnd.google-apps.spreadsheet",
+          "url": "https://docs.google.com/spreadsheets/d/1NlC-6_ZvZfdECvc646xXVpOhA61DVOwHs1Ao5ymzDT8/edit?usp=drivesdk",
+          "created_time": "2026-07-03T17:38:58.582Z",
+          "modified_time": "2026-08-01T02:34:00.894Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/01_Tender_Documents/T2026-017_204_Street_Logan_Avenue_Roadworks/09_Estimate/T2026-017 - 204 Street and Logan Avenue Estimate"
+        },
+        {
+          "drive_file_id": "1GkhgGwJwZ3v9cuTNCE3jI3wIj9WG3WIm",
+          "name": "text.txt",
+          "mime_type": "text/plain",
+          "url": "https://drive.google.com/file/d/1GkhgGwJwZ3v9cuTNCE3jI3wIj9WG3WIm/view?usp=drivesdk",
+          "created_time": "2026-07-06T17:07:22.674Z",
+          "modified_time": "2026-07-06T17:07:22.674Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/01_Tender_Documents/T2026-017_204_Street_Logan_Avenue_Roadworks/01_Tender_Documents/text.txt"
+        },
+        {
+          "drive_file_id": "15xlXnLqtpA90scVWxpLHR_9Vy8DJjwjg",
+          "name": "T2026-017_Tender_Document_204_Street_and_Logan_Avenue_Roadworks.pdf",
+          "mime_type": "application/pdf",
+          "url": "https://drive.google.com/file/d/15xlXnLqtpA90scVWxpLHR_9Vy8DJjwjg/view?usp=drivesdk",
+          "created_time": "2026-07-05T00:01:12.224Z",
+          "modified_time": "2026-07-05T00:01:12.224Z",
+          "source_path": "IHCC-TEST-001_Test_Municipal_Road_Improvements/01_Tender_Documents/T2026-017_204_Street_Logan_Avenue_Roadworks/01_Tender_Documents/T2026-017_Tender_Document_204_Street_and_Logan_Avenue_Roadworks.pdf"
+        }
+      ]
+    }
+  ]
+}

--- a/backend/app/services/drive_tender_import.py
+++ b/backend/app/services/drive_tender_import.py
@@ -1,0 +1,573 @@
+"""Staging-only, idempotent import of non-secret Google Drive tender metadata.
+
+The importer stores links and metadata only. It never receives Drive credentials,
+downloads a source file, or mutates Drive. Dry-run is the default at the command
+layer; applying is restricted to an explicit staging invocation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from pathlib import Path
+
+from app.models.document import Document
+from app.models.project import Project
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+SOURCE_KEY = "drive_tender_import"
+DRIVE_FOLDER_URL = "https://drive.google.com/drive/folders/{}"
+_DRIVE_ID = re.compile(r"^[A-Za-z0-9_-]{10,}$")
+
+
+class ImportValidationError(ValueError):
+    """Raised when the checked-in metadata manifest is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class DriveFile:
+    drive_file_id: str
+    name: str
+    mime_type: str
+    url: str
+    created_time: str | None = None
+    modified_time: str | None = None
+    source_path: str | None = None
+
+
+@dataclass(frozen=True)
+class TenderFolder:
+    drive_folder_id: str
+    name: str
+    url: str
+    files: tuple[DriveFile | Mapping[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class ImportDecision:
+    action: str
+    canonical_name: str
+    source_folder_ids: tuple[str, ...]
+    reason: str
+    reference: str | None = None
+    files: tuple[DriveFile, ...] = field(default=(), compare=False, repr=False)
+    folders: tuple[TenderFolder, ...] = field(default=(), compare=False, repr=False)
+
+
+def normalize_tender_name(value: str) -> str:
+    value = value.casefold().strip()
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    replacements = {
+        "sani": "sanitary",
+        "voc": "village of cumberland",
+        "itt": "",
+    }
+    tokens = [replacements.get(token, token) for token in value.split()]
+    return " ".join(token for token in tokens if token)
+
+
+def extract_reference(value: str) -> str | None:
+    references = extract_references(value)
+    return references[0] if references else None
+
+
+def extract_references(value: str) -> tuple[str, ...]:
+    patterns = (
+        r"\bITT[- _]?\d{3,}\b",
+        r"\bQ\d{2}[- _]?\d{3}\b",
+        r"\b\d{4}-\d{4,}-\d{2}\b",
+        r"\b(?:RFP|T)[- _]?\d{4}[- _]\d{3,}\b",
+        r"\bIHCC[- _][A-Z]+[- _]\d+\b",
+        r"\b[A-Z]\d{2}[- _]\d{3}\b",
+        r"\b\d{4}-\d{2}-[A-Z0-9-]+\b",
+    )
+    upper = value.upper()
+    found: list[str] = []
+    for pattern in patterns:
+        for match in re.finditer(pattern, upper):
+            reference = re.sub(r"[- _]+", "-", match.group(0))
+            if reference not in found:
+                found.append(reference)
+    return tuple(found)
+
+
+def load_manifest(path: Path) -> tuple[TenderFolder, ...]:
+    with path.open(encoding="utf-8") as source:
+        payload = json.load(source)
+    return parse_manifest(payload)
+
+
+def parse_manifest(payload: Mapping[str, object]) -> tuple[TenderFolder, ...]:
+    if payload.get("source") != "google_drive":
+        raise ImportValidationError("Manifest source must be google_drive.")
+    raw_folders = payload.get("folders")
+    if not isinstance(raw_folders, list):
+        raise ImportValidationError("Manifest folders must be a list.")
+
+    folders: list[TenderFolder] = []
+    seen_folder_ids: set[str] = set()
+    seen_file_ids: set[str] = set()
+    for raw_folder in raw_folders:
+        if not isinstance(raw_folder, Mapping):
+            raise ImportValidationError("Every manifest folder must be an object.")
+        folder_id = _required_text(raw_folder, "drive_folder_id")
+        _validate_drive_id(folder_id, "folder")
+        if folder_id in seen_folder_ids:
+            raise ImportValidationError(f"Duplicate Drive folder ID: {folder_id}")
+        seen_folder_ids.add(folder_id)
+        folder_url = _required_https_url(raw_folder, "url")
+        files: list[DriveFile] = []
+        raw_files = raw_folder.get("files", [])
+        if not isinstance(raw_files, list):
+            raise ImportValidationError(f"Files for {folder_id} must be a list.")
+        for raw_file in raw_files:
+            if not isinstance(raw_file, Mapping):
+                raise ImportValidationError(f"Every file in {folder_id} must be an object.")
+            file_id = _required_text(raw_file, "drive_file_id")
+            _validate_drive_id(file_id, "file")
+            if file_id in seen_file_ids:
+                raise ImportValidationError(f"Duplicate Drive file ID: {file_id}")
+            seen_file_ids.add(file_id)
+            files.append(
+                DriveFile(
+                    drive_file_id=file_id,
+                    name=_required_text(raw_file, "name"),
+                    mime_type=_required_text(raw_file, "mime_type"),
+                    url=_required_https_url(raw_file, "url"),
+                    created_time=_optional_text(raw_file.get("created_time")),
+                    modified_time=_optional_text(raw_file.get("modified_time")),
+                    source_path=_optional_text(raw_file.get("source_path")),
+                )
+            )
+        folders.append(
+            TenderFolder(
+                drive_folder_id=folder_id,
+                name=_required_text(raw_folder, "name"),
+                url=folder_url,
+                files=tuple(files),
+            )
+        )
+    return tuple(folders)
+
+
+def plan_import(folders: Iterable[TenderFolder]) -> list[ImportDecision]:
+    """Return deterministic consolidate/create-or-update/ambiguous decisions."""
+    ordered = sorted((_coerce_folder(folder) for folder in folders), key=lambda item: item.drive_folder_id)
+    groups: list[list[TenderFolder]] = []
+    for folder in ordered:
+        matching = [group for group in groups if any(_strong_match(folder, item) for item in group)]
+        if not matching:
+            groups.append([folder])
+            continue
+        primary = matching[0]
+        primary.append(folder)
+        for duplicate in matching[1:]:
+            primary.extend(duplicate)
+            groups.remove(duplicate)
+
+    ambiguous_ids: set[str] = set()
+    for group in groups:
+        if len(group) != 1 or group[0].files:
+            continue
+        folder = group[0]
+        possible = [
+            other
+            for other in groups
+            if other is not group and any(_weak_alias(folder.name, candidate.name) for candidate in other)
+        ]
+        if possible:
+            ambiguous_ids.add(folder.drive_folder_id)
+
+    decisions: list[ImportDecision] = []
+    for group in groups:
+        group = sorted(group, key=lambda item: item.drive_folder_id)
+        if len(group) == 1 and group[0].drive_folder_id in ambiguous_ids:
+            folder = group[0]
+            decisions.append(
+                ImportDecision(
+                    action="ambiguous",
+                    canonical_name=folder.name.strip(),
+                    source_folder_ids=(folder.drive_folder_id,),
+                    reason="empty folder has a probable name alias but no reference or files to verify it",
+                    folders=(folder,),
+                )
+            )
+            continue
+        canonical = max(group, key=_canonical_rank)
+        files = _unique_files(group)
+        action = "consolidate" if len(group) > 1 else "create_or_update"
+        decisions.append(
+            ImportDecision(
+                action=action,
+                canonical_name=canonical.name.strip(),
+                source_folder_ids=tuple(item.drive_folder_id for item in group),
+                reason=(
+                    "matching tender/reference, normalized identity, or repeated source filenames"
+                    if len(group) > 1
+                    else "distinct Drive tender folder"
+                ),
+                reference=_canonical_reference(canonical, group),
+                files=files,
+                folders=tuple(group),
+            )
+        )
+    return sorted(decisions, key=lambda item: (item.canonical_name.casefold(), item.source_folder_ids))
+
+
+def import_drive_tenders(
+    db: Session,
+    folders: Sequence[TenderFolder],
+    *,
+    actor: str,
+    apply: bool = False,
+    imported_at: datetime | None = None,
+) -> dict[str, object]:
+    """Plan or apply the import in the caller's transaction.
+
+    The caller owns commit/rollback. Applying flushes IDs for the report but never
+    commits, allowing the command to keep the whole import atomic.
+    """
+    actor = actor.strip()
+    if not actor:
+        raise ImportValidationError("An audit actor is required.")
+    timestamp = (imported_at or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+    projects = list(db.scalars(select(Project)).all())
+    documents = list(db.scalars(select(Document)).all())
+    documents_by_drive_id = _documents_by_drive_id(documents)
+
+    project_items: list[dict[str, object]] = []
+    unresolved: list[dict[str, object]] = []
+    consolidated: list[dict[str, object]] = []
+    summary = {"create": 0, "update": 0, "documents_create": 0, "documents_update": 0, "ambiguous": 0}
+
+    for decision in plan_import(folders):
+        if decision.action == "ambiguous":
+            summary["ambiguous"] += 1
+            unresolved.append(
+                {
+                    "name": decision.canonical_name,
+                    "source_folder_ids": list(decision.source_folder_ids),
+                    "reason": decision.reason,
+                }
+            )
+            continue
+
+        matches = _matching_projects(projects, decision)
+        if len(matches) > 1:
+            summary["ambiguous"] += 1
+            unresolved.append(
+                {
+                    "name": decision.canonical_name,
+                    "source_folder_ids": list(decision.source_folder_ids),
+                    "reason": "multiple existing IHOS projects match this tender",
+                    "project_ids": [str(project.id) for project in matches],
+                }
+            )
+            continue
+
+        action = "update" if matches else "create"
+        summary[action] += 1
+        project = matches[0] if matches else None
+        if apply:
+            if project is None:
+                project = Project(
+                    name=decision.canonical_name,
+                    client_owner=_infer_client(decision),
+                    tender_number=decision.reference,
+                    tender_source="Google Drive",
+                    status="tendering",
+                    metadata_json={},
+                )
+                db.add(project)
+                projects.append(project)
+            else:
+                if not project.client_owner:
+                    project.client_owner = _infer_client(decision)
+                if not project.tender_number:
+                    project.tender_number = decision.reference
+                if not project.tender_source:
+                    project.tender_source = "Google Drive"
+            project.metadata_json = _project_metadata(project, decision, actor, timestamp)
+            db.flush()
+
+        document_counts = {"create": 0, "update": 0}
+        document_conflicts: list[dict[str, str]] = []
+        for drive_file in decision.files:
+            existing = documents_by_drive_id.get(drive_file.drive_file_id, [])
+            if len(existing) > 1 or (existing and (project is None or existing[0].project_id != project.id)):
+                document_conflicts.append(
+                    {
+                        "drive_file_id": drive_file.drive_file_id,
+                        "name": drive_file.name,
+                        "reason": "Drive file ID is already linked outside the matched project",
+                    }
+                )
+                continue
+            document_action = "update" if existing else "create"
+            document_counts[document_action] += 1
+            summary[f"documents_{document_action}"] += 1
+            if not apply:
+                continue
+            if existing:
+                document = existing[0]
+                document.metadata_json = _document_metadata(document, drive_file, decision, actor, timestamp)
+            else:
+                document = Document(
+                    title=drive_file.name,
+                    category=_document_category(drive_file),
+                    status="registered",
+                    project_id=project.id,
+                    storage_uri=None,
+                    description="Linked Google Drive source; the original remains immutable.",
+                    metadata_json=_document_metadata(None, drive_file, decision, actor, timestamp),
+                )
+                db.add(document)
+                documents.append(document)
+                documents_by_drive_id[drive_file.drive_file_id] = [document]
+
+        if document_conflicts:
+            unresolved.extend(document_conflicts)
+        if apply:
+            db.flush()
+        project_items.append(
+            {
+                "action": action,
+                "project_id": str(project.id) if project is not None else None,
+                "name": project.name if project is not None else decision.canonical_name,
+                "tender_reference": decision.reference,
+                "source_folder_ids": list(decision.source_folder_ids),
+                "file_count": len(decision.files),
+                "document_actions": document_counts,
+            }
+        )
+        if decision.action == "consolidate":
+            consolidated.append(
+                {
+                    "project_name": decision.canonical_name,
+                    "source_folder_ids": list(decision.source_folder_ids),
+                    "reason": decision.reason,
+                }
+            )
+
+    return {
+        "status": "applied" if apply else "dry_run",
+        "source": "google_drive",
+        "actor": actor,
+        "imported_at": timestamp,
+        "summary": summary,
+        "projects": project_items,
+        "consolidated_folders": consolidated,
+        "unresolved": unresolved,
+    }
+
+
+def _coerce_folder(folder: TenderFolder) -> TenderFolder:
+    files: list[DriveFile] = []
+    for raw in folder.files:
+        if isinstance(raw, DriveFile):
+            files.append(raw)
+        else:
+            file_id = raw.get("drive_file_id") or raw.get("id")
+            name = raw.get("name") or raw.get("title")
+            if not file_id or not name:
+                continue
+            files.append(
+                DriveFile(
+                    drive_file_id=str(file_id),
+                    name=str(name),
+                    mime_type=str(raw.get("mime_type") or "application/octet-stream"),
+                    url=str(raw.get("url") or ""),
+                    created_time=_optional_text(raw.get("created_time")),
+                    modified_time=_optional_text(raw.get("modified_time")),
+                    source_path=_optional_text(raw.get("source_path")),
+                )
+            )
+    return TenderFolder(folder.drive_folder_id, folder.name, folder.url, tuple(files))
+
+
+def _strong_match(left: TenderFolder, right: TenderFolder) -> bool:
+    left_references = _folder_references(left)
+    right_references = _folder_references(right)
+    if left_references & right_references:
+        return True
+    if _names_overlap(normalize_tender_name(left.name), normalize_tender_name(right.name)):
+        return True
+    left_names = {_file_signature(item.name) for item in left.files}
+    right_names = {_file_signature(item.name) for item in right.files}
+    return len((left_names & right_names) - {""}) >= 2
+
+
+def _weak_alias(left: str, right: str) -> bool:
+    left_tokens = [token for token in normalize_tender_name(left).split() if len(token) >= 4]
+    right_tokens = [token for token in normalize_tender_name(right).split() if len(token) >= 4]
+    return any(SequenceMatcher(None, a, b).ratio() >= 0.78 for a in left_tokens for b in right_tokens)
+
+
+def _names_overlap(left: str, right: str) -> bool:
+    left_tokens = set(left.split())
+    right_tokens = set(right.split())
+    significant = {"sewer", "separation", "sanitary", "manhole", "fernie", "cumberland", "firehall", "storm"}
+    common = left_tokens & right_tokens
+    return len(common) >= 3 or len(common & significant) >= 2
+
+
+def _folder_references(folder: TenderFolder) -> set[str]:
+    references = set(extract_references(folder.name))
+    for drive_file in folder.files:
+        references.update(extract_references(drive_file.name))
+    return references
+
+
+def _canonical_reference(canonical: TenderFolder, group: Sequence[TenderFolder]) -> str | None:
+    reference = extract_reference(canonical.name)
+    if reference:
+        return reference
+    for folder in group:
+        reference = extract_reference(folder.name)
+        if reference:
+            return reference
+    for drive_file in _unique_files(group):
+        reference = extract_reference(drive_file.name)
+        if reference:
+            return reference
+    return None
+
+
+def _canonical_rank(folder: TenderFolder) -> tuple[int, int, int, str]:
+    return (bool(extract_reference(folder.name)), len(folder.name.strip()), len(folder.files), folder.name)
+
+
+def _unique_files(group: Sequence[TenderFolder]) -> tuple[DriveFile, ...]:
+    by_id: dict[str, DriveFile] = {}
+    for folder in group:
+        for drive_file in folder.files:
+            if isinstance(drive_file, DriveFile):
+                by_id.setdefault(drive_file.drive_file_id, drive_file)
+    return tuple(sorted(by_id.values(), key=lambda item: (item.name.casefold(), item.drive_file_id)))
+
+
+def _file_signature(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.casefold())
+
+
+def _matching_projects(projects: Sequence[Project], decision: ImportDecision) -> list[Project]:
+    folder_ids = set(decision.source_folder_ids)
+    matches: list[Project] = []
+    for project in projects:
+        metadata = project.metadata_json or {}
+        source = metadata.get(SOURCE_KEY, {}) if isinstance(metadata, Mapping) else {}
+        existing_ids = set(source.get("source_folder_ids", [])) if isinstance(source, Mapping) else set()
+        reference_match = bool(
+            decision.reference and project.tender_number and decision.reference == project.tender_number.upper()
+        )
+        name_match = normalize_tender_name(project.name) == normalize_tender_name(decision.canonical_name)
+        if folder_ids & existing_ids or reference_match or name_match:
+            matches.append(project)
+    return matches
+
+
+def _documents_by_drive_id(documents: Sequence[Document]) -> dict[str, list[Document]]:
+    indexed: dict[str, list[Document]] = {}
+    for document in documents:
+        metadata = document.metadata_json or {}
+        drive_file_id = metadata.get("drive_file_id") if isinstance(metadata, Mapping) else None
+        if isinstance(drive_file_id, str):
+            indexed.setdefault(drive_file_id, []).append(document)
+    return indexed
+
+
+def _project_metadata(
+    project: Project,
+    decision: ImportDecision,
+    actor: str,
+    timestamp: str,
+) -> dict[str, object]:
+    metadata = dict(project.metadata_json or {})
+    metadata[SOURCE_KEY] = {
+        "source_folder_ids": list(decision.source_folder_ids),
+        "source_folder_urls": [folder.url for folder in decision.folders],
+        "imported_at": timestamp,
+        "audit_actor": actor,
+        "source_immutable": True,
+    }
+    return metadata
+
+
+def _document_metadata(
+    document: Document | None,
+    drive_file: DriveFile,
+    decision: ImportDecision,
+    actor: str,
+    timestamp: str,
+) -> dict[str, object]:
+    metadata = dict(document.metadata_json or {}) if document is not None else {}
+    metadata.update(
+        {
+            "external_provider": "google_drive",
+            "drive_file_id": drive_file.drive_file_id,
+            "drive_url": drive_file.url,
+            "mime_type": drive_file.mime_type,
+            "original_filename": drive_file.name,
+            "drive_created_time": drive_file.created_time,
+            "drive_modified_time": drive_file.modified_time,
+            "source_path": drive_file.source_path,
+            "source_folder_ids": list(decision.source_folder_ids),
+            "imported_at": timestamp,
+            "audit_actor": actor,
+            "source_immutable": True,
+        }
+    )
+    return metadata
+
+
+def _document_category(drive_file: DriveFile) -> str:
+    name = drive_file.name.casefold()
+    if "drawing" in name or "_ift" in name or "-ift" in name:
+        return "drawing"
+    if "geotech" in name:
+        return "geotechnical"
+    if "addend" in name:
+        return "addendum"
+    if "spec" in name:
+        return "specification"
+    return "other"
+
+
+def _infer_client(decision: ImportDecision) -> str | None:
+    haystack = " ".join([decision.canonical_name, *(item.name for item in decision.files)]).casefold()
+    clients = (
+        ("fernie", "City of Fernie"),
+        ("cumberland", "Village of Cumberland"),
+        ("port edward", "District of Port Edward"),
+        ("parksville", "City of Parksville"),
+        ("mcleod lake", "McLeod Lake Indian Band"),
+    )
+    return next((client for marker, client in clients if marker in haystack), None)
+
+
+def _required_text(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ImportValidationError(f"Manifest field {key} must be non-empty text.")
+    return value.strip()
+
+
+def _required_https_url(payload: Mapping[str, object], key: str) -> str:
+    value = _required_text(payload, key)
+    if not value.startswith("https://"):
+        raise ImportValidationError(f"Manifest field {key} must be an HTTPS URL.")
+    return value
+
+
+def _optional_text(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _validate_drive_id(value: str, kind: str) -> None:
+    if not _DRIVE_ID.fullmatch(value):
+        raise ImportValidationError(f"Invalid Drive {kind} ID: {value}")

--- a/backend/app/tools/drive_tender_import.py
+++ b/backend/app/tools/drive_tender_import.py
@@ -1,0 +1,84 @@
+"""Staging-only admin command for the Google Drive tender metadata import."""
+
+import fcntl
+import json
+import sys
+from argparse import ArgumentParser
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TextIO
+
+from app.core.config import get_settings
+from app.db.session import SessionLocal
+from app.services.drive_tender_import import (
+    ImportValidationError,
+    import_drive_tenders,
+    load_manifest,
+)
+
+DEFAULT_MANIFEST = Path(__file__).resolve().parents[1] / "data" / "drive_tenders_manifest.json"
+DEFAULT_LOCK_FILE = Path("/tmp/iron-house-os-drive-tender-import.lock")
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Dry-run or apply the checked-in Drive tender manifest.")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--operator", required=True, help="Named audit actor running the import.")
+    parser.add_argument("--apply", action="store_true", help="Apply atomically; default is dry-run.")
+    parser.add_argument("--lock-file", type=Path, default=DEFAULT_LOCK_FILE)
+    return parser
+
+
+def require_staging_apply(environment: str, apply: bool) -> None:
+    if apply and environment.casefold() != "staging":
+        raise ImportValidationError("Apply is locked to an IHOS staging environment.")
+
+
+@contextmanager
+def _exclusive_import_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as lock:
+        try:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise ImportValidationError("Another Drive tender import is already running.") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _optional_lock(apply: bool, path: Path) -> Iterator[None]:
+    if apply:
+        with _exclusive_import_lock(path):
+            yield
+    else:
+        yield
+
+
+def _print_blocked(exc: Exception, output: TextIO) -> None:
+    print(json.dumps({"status": "blocked", "issues": [str(exc)]}, indent=2), file=output)
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    settings = get_settings()
+    try:
+        require_staging_apply(settings.environment, args.apply)
+        folders = load_manifest(args.manifest)
+        with _optional_lock(args.apply, args.lock_file), SessionLocal() as db:
+            report = import_drive_tenders(db, folders, actor=args.operator, apply=args.apply)
+            if args.apply:
+                db.commit()
+            else:
+                db.rollback()
+    except (ImportValidationError, OSError, json.JSONDecodeError) as exc:
+        _print_blocked(exc, output=sys.stdout)
+        raise SystemExit(2) from exc
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/operations/drive-tender-import.md
+++ b/docs/operations/drive-tender-import.md
@@ -1,0 +1,52 @@
+# Google Drive tender metadata import
+
+Issue: #129
+
+This controlled admin command imports non-secret metadata and links from the current `Iron House OS/01_Tenders` Drive folder into IHOS project and document records. It never downloads or modifies Drive source files.
+
+## Safety boundaries
+
+- Dry-run is the default.
+- `--apply` is rejected unless `ENVIRONMENT=staging`.
+- The checked-in manifest contains Drive IDs, metadata, and URLs only; it contains no credentials.
+- The command uses an exclusive lock and a single database transaction.
+- The importer is idempotent: stable Drive folder and file IDs update existing records instead of duplicating them.
+- Ambiguous project matches and cross-project file conflicts are reported and skipped.
+- Production apply is intentionally unsupported.
+
+## Dry run
+
+From the backend environment:
+
+```bash
+python -m app.tools.drive_tender_import --operator "Staging Operator"
+```
+
+Review the JSON report before any apply. Confirm create/update counts, consolidated aliases, unresolved folders, and document conflicts.
+
+## Staging apply
+
+A staging mutation requires explicit owner approval and staging credentials:
+
+```bash
+ENVIRONMENT=staging python -m app.tools.drive_tender_import --operator "Staging Operator" --apply
+```
+
+After apply, run the command again in dry-run mode. All previously created projects and linked documents should report as updates, with no duplicate active project or document.
+
+## Manifest refresh
+
+The manifest is a point-in-time metadata snapshot generated from the connected Drive folder. Refresh it before staging apply when the source folder contents change. Preserve source Drive IDs and URLs, keep the original Drive objects immutable, and never commit provider credentials.
+
+## Verification evidence
+
+Record:
+
+- source manifest revision and generation time;
+- dry-run create/update/consolidate/ambiguous counts;
+- staging project IDs and linked document counts;
+- a second idempotency run;
+- project/document UI smoke results;
+- unresolved duplicate decisions.
+
+No production deployment or production data mutation is part of this workflow.

--- a/frontend/src/components/ProjectDocumentBrowser.test.tsx
+++ b/frontend/src/components/ProjectDocumentBrowser.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LibraryDocument } from "../api/documents";
+import { externalDriveUrl, ProjectDocumentBrowser } from "./ProjectDocumentBrowser";
+
+const linkedDocument: LibraryDocument = {
+  id: "12900000-0000-0000-0000-000000000001",
+  title: "ITT-2602 Tender.pdf",
+  category: "other",
+  status: "registered",
+  project_id: "12900000-0000-0000-0000-000000000002",
+  rfq_package_id: null,
+  tender_id: null,
+  supplier_id: null,
+  storage_uri: null,
+  description: "Linked Google Drive source; the original remains immutable.",
+  drawing: null,
+  metadata: {
+    drive_file_id: "drive-file-129",
+    drive_url: "https://drive.google.com/file/d/drive-file-129/view",
+    source_immutable: true,
+  },
+  created_at: "2026-08-02T00:00:00Z",
+  updated_at: "2026-08-02T00:00:00Z",
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ProjectDocumentBrowser", () => {
+  it("shows a safe external Drive link without offering a local download", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ items: [linkedDocument], total: 1 })));
+
+    render(<ProjectDocumentBrowser projectId={linkedDocument.project_id} />);
+
+    const link = await screen.findByRole("link", { name: "Open in Drive" });
+    expect(link).toHaveAttribute("href", linkedDocument.metadata.drive_url);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.queryByRole("button", { name: "Download" })).not.toBeInTheDocument();
+  });
+
+  it("rejects non-Google and non-HTTPS metadata links", () => {
+    expect(
+      externalDriveUrl({ ...linkedDocument, metadata: { drive_url: "https://example.com/file" } }),
+    ).toBeNull();
+    expect(
+      externalDriveUrl({ ...linkedDocument, metadata: { drive_url: "javascript:alert(1)" } }),
+    ).toBeNull();
+  });
+});
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}

--- a/frontend/src/components/ProjectDocumentBrowser.tsx
+++ b/frontend/src/components/ProjectDocumentBrowser.tsx
@@ -54,43 +54,97 @@ export function ProjectDocumentBrowser({ projectId }: Props) {
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 className="text-base font-semibold text-iron-950">Project Document Browser</h2>
-          <p className="mt-1 text-sm text-iron-500">Load uploaded documents, download stored files with short-lived links, and mark records current or superseded.</p>
+          <p className="mt-1 text-sm text-iron-500">
+            Load uploaded documents, open linked Drive sources, and mark records current or superseded.
+          </p>
         </div>
-        <button type="button" onClick={loadDocuments} disabled={isLoading} className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800">
+        <button
+          type="button"
+          onClick={loadDocuments}
+          disabled={isLoading}
+          className="rounded-md border border-iron-100 px-4 py-2 text-sm font-semibold text-iron-800"
+        >
           {isLoading ? "Loading..." : "Load documents"}
         </button>
       </div>
       {error ? <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div> : null}
       {documents ? (
-        <div className="mt-4 overflow-hidden rounded-md border border-iron-100">
+        <div className="mt-4 overflow-x-auto rounded-md border border-iron-100">
           <table className="w-full text-left text-sm">
             <thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500">
-              <tr><th className="px-3 py-2">Title</th><th className="px-3 py-2">Category</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Revision</th><th className="px-3 py-2">Actions</th></tr>
+              <tr>
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Category</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Revision</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
             </thead>
             <tbody>
-              {documents.items.map((document) => (
-                <tr key={document.id} className="border-t border-iron-100">
-                  <td className="px-3 py-2 font-medium text-iron-950">{document.title}</td>
-                  <td className="px-3 py-2 text-iron-700">{document.category}</td>
-                  <td className="px-3 py-2 text-iron-700">{document.status}</td>
-                  <td className="px-3 py-2 text-iron-700">{document.drawing?.revision ?? "-"}</td>
-                  <td className="space-x-2 px-3 py-2 text-iron-700">
-                    {document.storage_uri ? (
-                      <button type="button" className="font-semibold" disabled={downloadingId === document.id} onClick={() => void downloadDocument(document)}>
-                        {downloadingId === document.id ? "Preparing..." : "Download"}
+              {documents.items.map((document) => {
+                const driveUrl = externalDriveUrl(document);
+                return (
+                  <tr key={document.id} className="border-t border-iron-100">
+                    <td className="px-3 py-2 font-medium text-iron-950">{document.title}</td>
+                    <td className="px-3 py-2 text-iron-700">{document.category}</td>
+                    <td className="px-3 py-2 text-iron-700">{document.status}</td>
+                    <td className="px-3 py-2 text-iron-700">{document.drawing?.revision ?? "-"}</td>
+                    <td className="space-x-2 whitespace-nowrap px-3 py-2 text-iron-700">
+                      {driveUrl ? (
+                        <a className="font-semibold" href={driveUrl} target="_blank" rel="noreferrer noopener">
+                          Open in Drive
+                        </a>
+                      ) : null}
+                      {document.storage_uri ? (
+                        <button
+                          type="button"
+                          className="font-semibold"
+                          disabled={downloadingId === document.id}
+                          onClick={() => void downloadDocument(document)}
+                        >
+                          {downloadingId === document.id ? "Preparing..." : "Download"}
+                        </button>
+                      ) : null}
+                      <button type="button" className="font-semibold" onClick={() => void setStatus(document, "current")}>
+                        Current
                       </button>
-                    ) : null}
-                    <button type="button" className="font-semibold" onClick={() => void setStatus(document, "current")}>Current</button>
-                    <button type="button" className="font-semibold" onClick={() => void setStatus(document, "superseded")}>Supersede</button>
-                  </td>
+                      <button type="button" className="font-semibold" onClick={() => void setStatus(document, "superseded")}>
+                        Supersede
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+              {documents.items.length === 0 ? (
+                <tr>
+                  <td className="px-3 py-3 text-iron-500" colSpan={5}>No documents found.</td>
                 </tr>
-              ))}
-              {documents.items.length === 0 ? <tr><td className="px-3 py-3 text-iron-500" colSpan={5}>No documents found.</td></tr> : null}
+              ) : null}
             </tbody>
           </table>
         </div>
       ) : null}
-      {documents?.items.some((item) => item.category === "photo") ? <div className="mt-5"><UniversalPhotoField documentIds={documents.items.filter((item) => item.category === "photo").map((item) => item.id)} label="Project photo gallery" /></div> : null}
+      {documents?.items.some((item) => item.category === "photo") ? (
+        <div className="mt-5">
+          <UniversalPhotoField
+            documentIds={documents.items.filter((item) => item.category === "photo").map((item) => item.id)}
+            label="Project photo gallery"
+          />
+        </div>
+      ) : null}
     </div>
   );
+}
+
+export function externalDriveUrl(document: LibraryDocument): string | null {
+  const candidate = document.metadata.drive_url;
+  if (typeof candidate !== "string") return null;
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "https:") return null;
+    if (!["drive.google.com", "docs.google.com"].includes(url.hostname)) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
 }

--- a/tests/backend/test_drive_tender_import.py
+++ b/tests/backend/test_drive_tender_import.py
@@ -1,0 +1,241 @@
+from datetime import datetime, timezone
+
+import pytest
+from app.models.document import Document
+from app.models.project import Project
+from app.services.drive_tender_import import (
+    DriveFile,
+    ImportValidationError,
+    TenderFolder,
+    extract_reference,
+    import_drive_tenders,
+    parse_manifest,
+    plan_import,
+)
+from app.tools.drive_tender_import import require_staging_apply
+from conftest import TestingSessionLocal
+from sqlalchemy import func, select
+
+IMPORTED_AT = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
+
+
+def drive_file(file_id: str, name: str) -> DriveFile:
+    return DriveFile(
+        drive_file_id=file_id,
+        name=name,
+        mime_type="application/pdf",
+        url=f"https://drive.google.com/file/d/{file_id}/view",
+        created_time="2026-08-01T00:00:00Z",
+        modified_time="2026-08-02T00:00:00Z",
+    )
+
+
+def folder(folder_id: str, name: str, *files: DriveFile) -> TenderFolder:
+    return TenderFolder(
+        drive_folder_id=folder_id,
+        name=name,
+        url=f"https://drive.google.com/drive/folders/{folder_id}",
+        files=tuple(files),
+    )
+
+
+def tender_folders() -> tuple[TenderFolder, ...]:
+    return (
+        folder(
+            "folder-cumberland-full",
+            "Village of Cumberland - 2026 Sewer Separation - ITT-2602",
+            drive_file("file-cumberland-001", "ITT-2602 Tender.pdf"),
+        ),
+        folder("folder-cumberland-old", "Cumberland sewer separation"),
+        folder(
+            "folder-hillcrest-main",
+            "Hillcrest Avenue Storm Rehabilitation - 2311-30196-00",
+            drive_file("file-hillcrest-001", "District of Port Edward Hillcrest Tender.pdf"),
+            drive_file("file-hillcrest-002", "10482-C Series IFT.pdf"),
+        ),
+        folder(
+            "folder-edward-alias",
+            "Edward sewer",
+            drive_file("file-edward-copy-01", "District of Port Edward Hillcrest Tender.pdf"),
+            drive_file("file-edward-copy-02", "10482-C Series IFT.pdf"),
+        ),
+        folder("folder-we-fireball", "We fireball"),
+        folder(
+            "folder-q26-firehall",
+            "Q26 335 - Firehall 3 Concrete Driveway",
+            drive_file("file-firehall-0001", "Q26_335_Firehall_3_Concrete_Driveway.pdf"),
+        ),
+    )
+
+
+def test_extract_reference_handles_approved_source_formats() -> None:
+    assert extract_reference("Village of Cumberland - ITT-2602") == "ITT-2602"
+    assert extract_reference("Q26 335 - Firehall 3 Concrete Driveway") == "Q26-335"
+    assert extract_reference("Hillcrest - 2311-30196-00") == "2311-30196-00"
+    assert extract_reference("RFP_2026-003 Construction Services") == "RFP-2026-003"
+    assert extract_reference("C26-085 Braidwood") == "C26-085"
+
+
+def test_plan_consolidates_verified_aliases_and_flags_unverified_empty_alias() -> None:
+    decisions = plan_import(tender_folders())
+
+    consolidated = [item for item in decisions if item.action == "consolidate"]
+    assert {item.source_folder_ids for item in consolidated} == {
+        ("folder-cumberland-full", "folder-cumberland-old"),
+        ("folder-edward-alias", "folder-hillcrest-main"),
+    }
+    ambiguous = next(item for item in decisions if item.action == "ambiguous")
+    assert ambiguous.source_folder_ids == ("folder-we-fireball",)
+    firehall = next(item for item in decisions if item.reference == "Q26-335")
+    assert firehall.source_folder_ids == ("folder-q26-firehall",)
+
+
+def test_manifest_validation_rejects_duplicate_stable_file_ids() -> None:
+    payload = {
+        "source": "google_drive",
+        "folders": [
+            {
+                "drive_folder_id": "folder-0000000001",
+                "name": "Tender A",
+                "url": "https://drive.google.com/drive/folders/folder-0000000001",
+                "files": [
+                    {
+                        "drive_file_id": "file-00000000001",
+                        "name": "A.pdf",
+                        "mime_type": "application/pdf",
+                        "url": "https://drive.google.com/file/d/file-00000000001/view",
+                    }
+                ],
+            },
+            {
+                "drive_folder_id": "folder-0000000002",
+                "name": "Tender B",
+                "url": "https://drive.google.com/drive/folders/folder-0000000002",
+                "files": [
+                    {
+                        "drive_file_id": "file-00000000001",
+                        "name": "B.pdf",
+                        "mime_type": "application/pdf",
+                        "url": "https://drive.google.com/file/d/file-00000000001/view",
+                    }
+                ],
+            },
+        ],
+    }
+
+    with pytest.raises(ImportValidationError, match="Duplicate Drive file ID"):
+        parse_manifest(payload)
+
+
+def test_dry_run_reports_without_mutating_database() -> None:
+    with TestingSessionLocal() as db:
+        report = import_drive_tenders(
+            db,
+            [tender_folders()[0]],
+            actor="Staging Operator",
+            imported_at=IMPORTED_AT,
+        )
+
+        assert report["status"] == "dry_run"
+        assert report["summary"]["create"] == 1
+        assert db.scalar(select(func.count()).select_from(Project)) == 0
+        assert db.scalar(select(func.count()).select_from(Document)) == 0
+
+
+def test_apply_is_idempotent_and_preserves_external_source_metadata() -> None:
+    source = [tender_folders()[0]]
+    with TestingSessionLocal() as db:
+        first = import_drive_tenders(
+            db,
+            source,
+            actor="Staging Operator",
+            apply=True,
+            imported_at=IMPORTED_AT,
+        )
+        db.commit()
+        second = import_drive_tenders(
+            db,
+            source,
+            actor="Staging Operator",
+            apply=True,
+            imported_at=IMPORTED_AT,
+        )
+        db.commit()
+
+        project = db.scalar(select(Project))
+        document = db.scalar(select(Document))
+        assert first["summary"]["create"] == 1
+        assert second["summary"]["update"] == 1
+        assert db.scalar(select(func.count()).select_from(Project)) == 1
+        assert db.scalar(select(func.count()).select_from(Document)) == 1
+        assert project.status == "tendering"
+        assert project.tender_number == "ITT-2602"
+        assert project.client_owner == "Village of Cumberland"
+        assert document.project_id == project.id
+        assert document.storage_uri is None
+        assert document.metadata_json["drive_file_id"] == "file-cumberland-001"
+        assert document.metadata_json["drive_url"].startswith("https://drive.google.com/")
+        assert document.metadata_json["source_immutable"] is True
+
+
+def test_existing_project_is_updated_instead_of_duplicated() -> None:
+    with TestingSessionLocal() as db:
+        existing = Project(
+            name="Village of Cumberland - 2026 Sewer Separation - ITT-2602",
+            tender_number="ITT-2602",
+            status="tendering",
+            metadata_json={"kept": True},
+        )
+        db.add(existing)
+        db.commit()
+
+        report = import_drive_tenders(
+            db,
+            [tender_folders()[0]],
+            actor="Staging Operator",
+            apply=True,
+            imported_at=IMPORTED_AT,
+        )
+        db.commit()
+
+        assert report["summary"]["update"] == 1
+        assert db.scalar(select(func.count()).select_from(Project)) == 1
+        db.refresh(existing)
+        assert existing.metadata_json["kept"] is True
+        assert existing.metadata_json["drive_tender_import"]["audit_actor"] == "Staging Operator"
+
+
+def test_file_link_is_not_moved_between_projects() -> None:
+    source = tender_folders()[0]
+    with TestingSessionLocal() as db:
+        other_project = Project(name="Other project", status="tendering", metadata_json={})
+        db.add(other_project)
+        db.flush()
+        db.add(
+            Document(
+                title="Existing source",
+                category="other",
+                status="registered",
+                project_id=other_project.id,
+                metadata_json={"drive_file_id": "file-cumberland-001"},
+            )
+        )
+        db.commit()
+
+        report = import_drive_tenders(
+            db,
+            [source],
+            actor="Staging Operator",
+            apply=True,
+            imported_at=IMPORTED_AT,
+        )
+
+        assert report["unresolved"][0]["reason"] == "Drive file ID is already linked outside the matched project"
+        assert db.scalar(select(func.count()).select_from(Document)) == 1
+
+
+def test_apply_is_locked_to_staging() -> None:
+    require_staging_apply("staging", True)
+    require_staging_apply("development", False)
+    with pytest.raises(ImportValidationError, match="locked to an IHOS staging"):
+        require_staging_apply("production", True)


### PR DESCRIPTION
## What changed

- Rebuilt the paused Drive tender importer on current `main`.
- Added a staging-only, dry-run-first, idempotent admin command.
- Added a fresh non-secret manifest from the live `Iron House OS/01_Tenders` folder: 20 top-level tender folders and 98 linked files, including nested contents.
- Consolidates strong duplicate matches, reports ambiguous folders, and refuses cross-project Drive-file conflicts.
- Stores immutable Drive metadata links without downloading or changing source files.
- Exposes validated Google Drive/Docs links in the project document browser.
- Added backend and frontend regression coverage plus operating documentation.

## Why

The previous `feature/129-drive-tender-import` branch contained useful work but was 85 commits behind `main` and had no PR. This branch preserves and audits that implementation against the current application schema and current Drive records.

## Safety

- Dry-run is default.
- `--apply` is rejected outside an IHOS staging environment.
- No credentials are committed.
- No production data, deployment, DNS, secret, certificate, backup, or infrastructure change.
- No staging apply has been run; that remains a separate mutation gate after CI and dry-run evidence.

## Validation requested

- Backend importer and idempotency tests
- Frontend linked-document tests
- Full CI
- Release readiness/disposable staging checks

Closes #129
