### PR TITLE
Ops: execute owner-approved staging tender imports (#204)

### DIFF
--- a/.github/workflows/staging-approved-imports.yml
+++ b/.github/workflows/staging-approved-imports.yml
@@ -1,0 +1,52 @@
+name: Approved staging tender imports
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ops/staging-imports/2026-08-19-issues-129-132-134.json
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iron-house-os-approved-staging-imports
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Dry-run, apply, and verify approved staging imports
+    runs-on: [self-hosted, linux, ihos-staging]
+    timeout-minutes: 45
+    steps:
+      - name: Check out exact approved release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Verify main ancestry and approval marker
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
+          test -f ops/staging-imports/2026-08-19-issues-129-132-134.json
+          python3 -m json.tool ops/staging-imports/2026-08-19-issues-129-132-134.json >/dev/null
+
+      - name: Execute owner-approved staging-only imports
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          EVIDENCE_DIR: ${{ runner.temp }}/approved-staging-import-evidence
+          IHOS_IMPORT_OPERATOR: Iron House OS GitHub staging automation (owner-approved 2026-08-19)
+        run: bash ops/staging-imports/run-approved-tender-imports.sh
+
+      - name: Upload immutable staging import evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: approved-staging-imports-${{ github.run_id }}
+          path: ${{ runner.temp }}/approved-staging-import-evidence
+          if-no-files-found: error
+          retention-days: 90

--- a/ops/staging-imports/2026-08-19-issues-129-132-134.json
+++ b/ops/staging-imports/2026-08-19-issues-129-132-134.json
@@ -1,0 +1,20 @@
+{
+  "approval_date": "2026-08-19",
+  "approved_by": "Iron House owner",
+  "purpose": "One-time staging-only tender metadata and estimate imports",
+  "issues": [129, 132, 134, 204],
+  "required_order": [
+    "drive_tender_import",
+    "fernie_staging_import",
+    "fuel_estimate_staging_import"
+  ],
+  "controls": {
+    "environment": "staging",
+    "dry_run_before_apply": true,
+    "idempotency_apply": true,
+    "fernie_submission_status": "unverified",
+    "fuel_estimates_submission_ready": false,
+    "production_changes": false
+  },
+  "source_main_release": "31db24e8a88dc49fe19f289bd7d6b1524ee3350d"
+}

--- a/ops/staging-imports/run-approved-tender-imports.sh
+++ b/ops/staging-imports/run-approved-tender-imports.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+: "${RELEASE_SHA:?RELEASE_SHA is required}"
+: "${EVIDENCE_DIR:?EVIDENCE_DIR is required}"
+: "${IHOS_IMPORT_OPERATOR:?IHOS_IMPORT_OPERATOR is required}"
+
+readonly STACK_FILE="${GITHUB_WORKSPACE}/docker-compose.staging.yml"
+readonly STACK_NAME="iron-house-os-staging"
+readonly STAGING_ENV="/etc/iron-house-os/staging.env"
+readonly READINESS_URL="https://staging.os.ironhousecivil.com/readiness"
+readonly HEALTH_URL="https://staging.os.ironhousecivil.com/health"
+
+mkdir -p "$EVIDENCE_DIR"
+cp ops/staging-imports/2026-08-19-issues-129-132-134.json "$EVIDENCE_DIR/approval-marker.json"
+
+compose=(
+  sudo env "IHOS_STAGING_RELEASE_ID=$RELEASE_SHA"
+  docker compose
+  --env-file "$STAGING_ENV"
+  -f "$STACK_FILE"
+  -p "$STACK_NAME"
+)
+
+read_live_release() {
+  local payload
+  payload="$(curl --fail --silent --show-error "$READINESS_URL")" || return 1
+  READINESS_JSON="$payload" python3 - <<'PY'
+import json
+import os
+
+print(json.loads(os.environ["READINESS_JSON"]).get("checks", {}).get("release_id", ""))
+PY
+}
+
+live_release=""
+for attempt in $(seq 1 120); do
+  live_release="$(read_live_release || true)"
+  if [[ "$live_release" == "$RELEASE_SHA" ]]; then
+    break
+  fi
+  sleep 10
+done
+if [[ "$live_release" != "$RELEASE_SHA" ]]; then
+  printf 'Staging did not reach approved release %s; last observed %s\n' "$RELEASE_SHA" "$live_release" >&2
+  exit 1
+fi
+
+curl --fail --silent --show-error "$READINESS_URL" | tee "$EVIDENCE_DIR/readiness-before.json"
+curl --fail --silent --show-error "$HEALTH_URL" | tee "$EVIDENCE_DIR/health-before.json"
+
+run_import() {
+  local label="$1"
+  local module="$2"
+  local expected_status="$3"
+  shift 3
+  local output="$EVIDENCE_DIR/${label}.json"
+
+  "${compose[@]}" exec -T backend     python -m "$module"       --operator "$IHOS_IMPORT_OPERATOR"       "$@" | tee "$output"
+
+  python3 - "$output" "$expected_status" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+expected = sys.argv[2]
+payload = json.loads(path.read_text(encoding="utf-8"))
+actual = payload.get("status")
+if actual != expected:
+    raise SystemExit(f"{path.name}: expected status {expected!r}, got {actual!r}")
+PY
+}
+
+run_import "01-drive-dry-run" "app.tools.drive_tender_import" "dry_run"
+run_import "02-drive-apply" "app.tools.drive_tender_import" "applied" --apply
+run_import "03-drive-idempotency-apply" "app.tools.drive_tender_import" "applied" --apply
+
+run_import "04-fernie-dry-run" "app.tools.fernie_staging_import" "dry_run"
+run_import "05-fernie-apply" "app.tools.fernie_staging_import" "applied"   --apply   --confirm-expired-intake
+run_import "06-fernie-idempotency-apply" "app.tools.fernie_staging_import" "applied"   --apply   --confirm-expired-intake
+
+run_import "07-fuel-estimates-dry-run" "app.tools.fuel_estimate_staging_import" "dry_run"
+run_import "08-fuel-estimates-apply" "app.tools.fuel_estimate_staging_import" "applied"   --apply   --confirm-provisional-estimates   --confirm-expired-intake
+run_import "09-fuel-estimates-idempotency-apply" "app.tools.fuel_estimate_staging_import" "applied"   --apply   --confirm-provisional-estimates   --confirm-expired-intake
+
+curl --fail --silent --show-error "$HEALTH_URL" | tee "$EVIDENCE_DIR/health-after.json"
+curl --fail --silent --show-error "$READINESS_URL" | tee "$EVIDENCE_DIR/readiness-after.json"
+final_release="$(read_live_release)"
+test "$final_release" = "$RELEASE_SHA"
+
+printf '%s\n' "$RELEASE_SHA" >"$EVIDENCE_DIR/release-sha.txt"


### PR DESCRIPTION
## What changes

- adds a one-time, marker-triggered staging workflow on the existing `ihos-staging` runner;
- waits until public staging reports the exact merged release SHA;
- dry-runs, applies, and idempotency-reruns issues #129, #132, and #134 in dependency order;
- captures all JSON reports plus before/after health and readiness as a 90-day workflow artifact;
- preserves Fernie as historical/unverified and fuel estimates as provisional/not submission-ready.

## Trigger control

The workflow runs only when the dated approval marker is added to `main`. Future application pushes do not repeat the imports. The CLI tools themselves also reject non-staging apply.

## Approval

Owner staging-mutation approval was recorded on 2026-08-19. No production deployment, production data, DNS, secret, certificate, backup, or infrastructure change.

Closes #204