### PR TITLE
Ops: activate one-time approved staging imports (#204)

### DIFF
--- a/.github/workflows/staging-approved-imports.yml
+++ b/.github/workflows/staging-approved-imports.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Superseded import run cancelled; waiting for staging deployment completion."
+      - run: echo "Superseded import run cancelled; waiting for the uniquely named staging deployment."
 
   apply:
     name: Dry-run, apply, and verify approved staging imports
@@ -32,7 +32,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_sha == 'b8d055e2bfe8593f55004d96e2029baacd025960'
+      github.event.workflow_run.display_title == 'Ops: activate one-time approved staging imports (#204)'
     runs-on: [self-hosted, linux, ihos-staging]
     timeout-minutes: 45
     env:


### PR DESCRIPTION
## Final runner sequencing

- cancels the superseded queued/polling import run via the existing concurrency group;
- allows the staging deployment for this uniquely named merge to finish first;
- starts the import from that successful deployment's actual `head_sha`;
- matches the unique deployment title, so later staging deploys cannot repeat the imports;
- retains exact-SHA, staging-only, dry-run, idempotency, and artifact controls.

The earlier orchestration attempts performed no import apply. No production deployment or production data/infrastructure change.

Closes #204