### PR TITLE
Fix RFQ document status and retry approved staging imports (#208)

### DIFF
--- a/.github/workflows/staging-approved-imports.yml
+++ b/.github/workflows/staging-approved-imports.yml
@@ -32,7 +32,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.display_title == 'Ops: activate one-time approved staging imports (#204)'
+      github.event.workflow_run.display_title == 'Fix RFQ document status and retry approved staging imports (#208)'
     runs-on: [self-hosted, linux, ihos-staging]
     timeout-minutes: 45
     env:

--- a/backend/app/models/rfq.py
+++ b/backend/app/models/rfq.py
@@ -104,7 +104,7 @@ class RFQPackageDocument(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     document_type: Mapped[str] = mapped_column(String(120), nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     required: Mapped[bool] = mapped_column(default=True)
-    status: Mapped[str] = mapped_column(String(80), default="registered")
+    status: Mapped[str] = mapped_column(String(80), default="pending")
     storage_uri: Mapped[str | None] = mapped_column(String(500))
     metadata_json: Mapped[dict] = mapped_column(JSONType, default=dict)
 

--- a/backend/app/services/fernie_staging_import.py
+++ b/backend/app/services/fernie_staging_import.py
@@ -364,7 +364,7 @@ def _link_documents(
                 document_type=document.category,
                 title=document.title,
                 required=True,
-                status="registered",
+                status="attached",
                 storage_uri=None,
                 metadata_json={},
             )

--- a/tests/backend/test_fernie_staging_import.py
+++ b/tests/backend/test_fernie_staging_import.py
@@ -136,6 +136,10 @@ def test_apply_is_idempotent_and_links_all_controlled_objects() -> None:
         assert all(document.status == "attached" for document in rfq_documents)
 
 
+def test_rfq_document_default_matches_database_constraint() -> None:
+    assert RFQPackageDocument.__table__.c.status.default.arg == "pending"
+
+
 def test_apply_requires_expired_intake_confirmation() -> None:
     require_expired_intake_confirmation(False, False)
     require_expired_intake_confirmation(True, True)

--- a/tests/backend/test_fernie_staging_import.py
+++ b/tests/backend/test_fernie_staging_import.py
@@ -123,6 +123,7 @@ def test_apply_is_idempotent_and_links_all_controlled_objects() -> None:
         tender = db.scalar(select(Tender))
         bid = db.scalar(select(Bid))
         documents = list(db.scalars(select(Document)).all())
+        rfq_documents = list(db.scalars(select(RFQPackageDocument)).all())
         assert project.status == "opportunity"
         assert project.contract_value == 169500
         assert tender.status == "reviewing"
@@ -132,6 +133,7 @@ def test_apply_is_idempotent_and_links_all_controlled_objects() -> None:
         assert bid.total_amount == 169500
         assert all(document.tender_id == tender.id for document in documents)
         assert all(document.rfq_package_id is not None for document in documents)
+        assert all(document.status == "attached" for document in rfq_documents)
 
 
 def test_apply_requires_expired_intake_confirmation() -> None:


### PR DESCRIPTION
## Root cause

The live workflow-value constraint permits RFQ package document statuses `pending`, `attached`, and `not_applicable`. The Fernie importer used `registered`, and the SQLAlchemy model default was also stale.

## Fix

- change the model default to `pending`;
- mark immutable Drive-linked Fernie RFQ documents `attached`;
- assert both the imported status and model default in regression tests;
- activate the existing owner-approved staging retry only after this uniquely named deployment succeeds.

## Validation

- CI run 826 backend tests and frontend checks: SUCCESS.
- Release-readiness run 330 backend, frontend, and staging-isolation gates: SUCCESS.
- Both redundant browser jobs remain in the external Playwright download; no code step failed.
- CI run 820 and full Release-readiness run 328 passed on the same frontend/application stack before this backend-only status correction.

## Staging state

- issue #129 applied successfully and passed idempotency;
- issue #132 transaction rolled back at the rejected RFQ document insert;
- issue #134 did not start;
- retry begins with idempotent #129 and continues through #132/#134.

No production deployment or production data/infrastructure change.

Closes #208 and #204