### PR TITLE
Fix estimate document category and retry staging imports (#210)

### DIFF
--- a/.github/workflows/staging-approved-imports.yml
+++ b/.github/workflows/staging-approved-imports.yml
@@ -32,7 +32,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.display_title == 'Fix RFQ document status and retry approved staging imports (#208)'
+      github.event.workflow_run.display_title == 'Fix estimate document category and retry staging imports (#210)'
     runs-on: [self-hosted, linux, ihos-staging]
     timeout-minutes: 45
     env:

--- a/backend/app/services/fuel_estimate_staging_import.py
+++ b/backend/app/services/fuel_estimate_staging_import.py
@@ -418,10 +418,10 @@ def _upsert_document(
     title = revision.source_title if baseline else revision.replacement_title
     drive_url = revision.source_url if baseline else revision.replacement_url
     if document is None:
-        document = Document(title=title, category="estimate")
+        document = Document(title=title, category="other")
         db.add(document)
     document.title = title
-    document.category = "estimate"
+    document.category = "other"
     document.status = "archived" if baseline else "registered"
     document.project_id = project.id
     document.tender_id = tender.id
@@ -442,6 +442,7 @@ def _upsert_document(
             "original_filename": title,
             "source_folder_ids": [revision.source_folder_id],
             "source": SOURCE_KEY,
+            "document_role": "estimate",
             "revision_key": revision.key,
             "record_status": "superseded_archived" if baseline else "provisional_active",
             "source_immutable": True,

--- a/tests/backend/test_fuel_estimate_staging_import.py
+++ b/tests/backend/test_fuel_estimate_staging_import.py
@@ -72,6 +72,8 @@ def test_apply_is_idempotent_and_archives_only_the_ihos_baseline_link() -> None:
         replacements = [item for item in documents if item.status == "registered"]
         assert len(baseline) == 2
         assert len(replacements) == 2
+        assert all(item.category == "other" for item in documents)
+        assert all(item.metadata_json["document_role"] == "estimate" for item in documents)
         assert all(
             item.metadata_json["record_status"] == "superseded_archived" for item in baseline
         )


### PR DESCRIPTION
## Root cause

The issue #134 importer used document category `estimate`, but the controlled live categories do not include that value.

## Fix

- use schema-valid category `other` for immutable baseline and replacement estimate links;
- preserve `document_role: estimate` in audit metadata;
- add regression assertions for both category and role;
- activate the existing owner-approved staging retry only after this uniquely named deployment succeeds.

## Staging state

- issues #129 and #132 applied successfully and passed idempotency;
- issue #134 transaction rolled back at the invalid document-category update;
- retry remains fully idempotent.

No production deployment or production data/infrastructure change.

Closes #210 and #204