### PR TITLE
Harden Build Agent queue governance

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -37,6 +37,8 @@ jobs:
         run: npm install
 
       - name: Run Build Agent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python automation/iron_house_build_agent.py
 
       - name: Show Build Agent output

--- a/automation/build-queue.json
+++ b/automation/build-queue.json
@@ -1,7 +1,8 @@
 {
-  "version": 3,
-  "strategy": "field-operations-reviewable-builds",
-  "program": "Iron House Field Operations",
+  "version": 4,
+  "strategy": "github-issue-linked-builds",
+  "program": "Iron House OS",
+  "canonical_queue_url": "https://github.com/iron-house-os/iron-house-os/issues/1",
   "constraints": [
     "Preserve the approved production visual baseline",
     "Exclude SIN, banking, medical and payroll data",
@@ -28,7 +29,8 @@
     {
       "id": "build-222-vendor-rental-workflow",
       "priority": 222,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Complete subcontractor and rental workflow",
       "summary": "Add vendor-filtered subcontractor and rental equipment entries with hours, rates, quantities, tickets and cost-code matching.",
       "acceptance_criteria": ["Vendor categories filter selections", "Rental and subcontract costs calculate", "Documents attach to entries", "Tests pass"]
@@ -36,7 +38,8 @@
     {
       "id": "build-223-safety-form-engine",
       "priority": 223,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Complete selectable safety form engine",
       "summary": "Build reusable task-hazard-control templates, crew attendance, individual authenticated signatures and corrective-action tracking.",
       "acceptance_criteria": ["Selectable tasks populate hazards and controls", "Every selected employee can sign", "Unsigned workers remain visible", "Corrective actions alert management"]
@@ -44,7 +47,8 @@
     {
       "id": "build-224-inspections-alerts-service",
       "priority": 224,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Complete inspections and service alerts",
       "summary": "Add equipment-specific inspection checklists, hours, next service calculations, severity routing and Jeremie/Mac notification delivery.",
       "acceptance_criteria": ["Inspection templates vary by equipment", "Flagged items create actionable alerts", "Service due dates and hours update", "Alert delivery is audited"]
@@ -52,7 +56,8 @@
     {
       "id": "build-225-employee-compliance",
       "priority": 225,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Complete employee compliance records",
       "summary": "Add management entry/edit screens for contacts, emergency contacts, positions, course tickets, attachments and expiry notifications.",
       "acceptance_criteria": ["Management can maintain employee records", "Tickets support document photos", "60/30/7-day expiry alerts work", "Sensitive excluded data is not collected"]
@@ -60,7 +65,8 @@
     {
       "id": "build-226-requests-reviews",
       "priority": 226,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Complete time-off and performance workflows",
       "summary": "Add employee requests, manager decisions, status history, private review scheduling and acknowledgement.",
       "acceptance_criteria": ["Employees submit and track requests", "Managers approve or decline with audit history", "Performance reviews are access controlled", "Tests pass"]
@@ -68,7 +74,8 @@
     {
       "id": "build-227-field-reporting-exports",
       "priority": 227,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Build field reporting and exports",
       "summary": "Create daily report, weekly labour, fuel, maintenance, production, safety and expense summaries with spreadsheet/PDF export.",
       "acceptance_criteria": ["Reports filter by job and date", "Cost codes reconcile across records", "Exports preserve photos and signatures by reference", "Tests pass"]
@@ -76,7 +83,8 @@
     {
       "id": "build-228-field-role-security",
       "priority": 228,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Harden field role permissions",
       "summary": "Provision Foreman, Operator and Employee access with own-record boundaries, manager oversight and portal-specific navigation.",
       "acceptance_criteria": ["Employees only access authorized records", "Foremen access assigned crews/jobs", "Operators access assigned equipment/jobs", "Permission-denial tests pass"]
@@ -84,7 +92,8 @@
     {
       "id": "build-229-mobile-offline",
       "priority": 229,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Add mobile offline field capture",
       "summary": "Queue time, inspections, safety forms and photos during poor connectivity, then synchronize safely with conflict handling.",
       "acceptance_criteria": ["Forms save offline", "Uploads resume", "Duplicate submissions are prevented", "iPhone and iPad flows pass"]
@@ -92,10 +101,22 @@
     {
       "id": "build-230-production-validation",
       "priority": 230,
-      "status": "open",
+      "status": "superseded",
+      "superseded_by": "https://github.com/iron-house-os/iron-house-os/issues/1",
       "title": "Validate field operations in production",
       "summary": "Run migration, backup, permission, mobile, upload, alert and rollback checks before the controlled production release.",
       "acceptance_criteria": ["Production backup is verified", "Migration and rollback rehearsal pass", "Field acceptance checklist passes", "Release evidence is recorded"]
+    },
+    {
+      "id": "issue-213-build-agent-queue-governance",
+      "priority": 213,
+      "status": "open",
+      "repository": "iron-house-os/iron-house-os",
+      "github_issue_number": 213,
+      "github_issue_url": "https://github.com/iron-house-os/iron-house-os/issues/213",
+      "title": "Stop Build Agent from reopening superseded legacy builds",
+      "summary": "Require issue-linked current tasks, ignore superseded legacy builds, and fail closed when GitHub issue state cannot be verified.",
+      "acceptance_criteria": ["Legacy Builds 222-230 are not selected", "Open tasks require canonical GitHub issue references", "Closed issues are not selected", "Focused tests pass"]
     }
   ]
 }

--- a/automation/iron_house_build_agent.py
+++ b/automation/iron_house_build_agent.py
@@ -15,7 +15,9 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 ROOT = Path(__file__).resolve().parents[1]
 QUEUE_PATH = ROOT / "automation" / "build-queue.json"
@@ -67,11 +69,80 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
-def _select_next_task(queue: dict[str, Any]) -> dict[str, Any] | None:
+def _select_next_task(
+    queue: dict[str, Any],
+    issue_state_getter: Callable[[dict[str, Any]], str] | None = None,
+) -> dict[str, Any] | None:
     open_tasks = [task for task in queue.get("tasks", []) if task.get("status") == "open"]
     if not open_tasks:
         return None
-    return sorted(open_tasks, key=lambda task: int(task.get("priority", 9999)))[0]
+
+    get_issue_state = issue_state_getter or _github_issue_state
+    current_tasks = []
+    for task in open_tasks:
+        _validate_issue_linked_task(task)
+        if get_issue_state(task) == "open":
+            current_tasks.append(task)
+
+    if not current_tasks:
+        return None
+    return sorted(current_tasks, key=lambda task: int(task.get("priority", 9999)))[0]
+
+
+def _validate_issue_linked_task(task: dict[str, Any]) -> None:
+    required = ("id", "title", "repository", "github_issue_number", "github_issue_url")
+    missing = [field for field in required if not task.get(field)]
+    if missing:
+        task_id = task.get("id", "unknown")
+        fields = ", ".join(missing)
+        raise ValueError(
+            f"Open build task {task_id} is missing canonical GitHub fields: {fields}. "
+            "Refusing to generate a stale prompt."
+        )
+
+    repository = str(task["repository"])
+    issue_number = int(task["github_issue_number"])
+    expected_url = f"https://github.com/{repository}/issues/{issue_number}"
+    if task["github_issue_url"] != expected_url:
+        raise ValueError(
+            f"Open build task {task['id']} has a non-canonical GitHub issue URL. "
+            f"Expected {expected_url}."
+        )
+
+
+def _github_issue_state(task: dict[str, Any]) -> str:
+    repository = str(task["repository"])
+    issue_number = int(task["github_issue_number"])
+    api_url = f"https://api.github.com/repos/{repository}/issues/{issue_number}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "iron-house-os-build-agent",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        with urlopen(Request(api_url, headers=headers), timeout=15) as response:
+            payload = json.load(response)
+    except (HTTPError, URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"Could not verify GitHub Issue #{issue_number} for {repository}; "
+            "refusing to generate a build prompt."
+        ) from exc
+
+    if "pull_request" in payload:
+        raise RuntimeError(
+            f"Configured queue target {repository}#{issue_number} is a pull request, not an issue."
+        )
+
+    state = payload.get("state")
+    if state not in {"open", "closed"}:
+        raise RuntimeError(
+            f"GitHub Issue #{issue_number} for {repository} returned an invalid state."
+        )
+    return str(state)
 
 
 def _write_go_prompt(task: dict[str, Any]) -> None:
@@ -82,6 +153,7 @@ def _write_go_prompt(task: dict[str, Any]) -> None:
         f"```text\n{_chatgpt_prompt(task)}\n```\n\n"
         f"## Task\n\n"
         f"Task ID: `{task['id']}`\n\n"
+        f"GitHub Issue: [#{task['github_issue_number']}]({task['github_issue_url']})\n\n"
         f"Priority: {task.get('priority')}\n\n"
         f"{task.get('summary', '')}\n\n"
         f"## Acceptance Criteria\n\n{criteria}\n",
@@ -96,9 +168,13 @@ def _go_line(task: dict[str, Any]) -> str:
 
 def _chatgpt_prompt(task: dict[str, Any]) -> str:
     return (
-        "GO. Use Jeremie GPT mode. Continue Iron House OS MVP-first build. "
-        f"Next task: {task['title']}. Task ID: {task['id']}. "
-        f"Build it in GitHub and keep it practical. Summary: {task.get('summary', '')}"
+        f"GO. Continue only {task['repository']} GitHub Issue "
+        f"#{task['github_issue_number']}: {task['title']}. "
+        f"Canonical issue: {task['github_issue_url']}. Task ID: {task['id']}. "
+        f"Summary: {task.get('summary', '')} "
+        "Use an issue-linked branch and draft pull request. Preserve the locked Iron House "
+        "visual design. Do not merge, deploy, or change production data, DNS, secrets, "
+        "certificates, backups, or infrastructure without the applicable owner approval."
     )
 
 

--- a/tests/backend/test_build_agent_queue.py
+++ b/tests/backend/test_build_agent_queue.py
@@ -1,0 +1,104 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "automation" / "iron_house_build_agent.py"
+SPEC = importlib.util.spec_from_file_location("iron_house_build_agent", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+BUILD_AGENT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(BUILD_AGENT)
+
+
+def _task(issue_number: int, *, priority: int = 100, status: str = "open") -> dict:
+    return {
+        "id": f"issue-{issue_number}",
+        "priority": priority,
+        "status": status,
+        "repository": "iron-house-os/iron-house-os",
+        "github_issue_number": issue_number,
+        "github_issue_url": (
+            f"https://github.com/iron-house-os/iron-house-os/issues/{issue_number}"
+        ),
+        "title": f"Issue {issue_number}",
+        "summary": "A bounded issue-linked task.",
+    }
+
+
+def test_open_task_without_github_issue_reference_is_rejected() -> None:
+    queue = {
+        "tasks": [
+            {
+                "id": "legacy-open-task",
+                "priority": 1,
+                "status": "open",
+                "title": "Legacy task",
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="canonical GitHub fields"):
+        BUILD_AGENT._select_next_task(queue, lambda task: "open")
+
+
+def test_superseded_tasks_are_not_selected() -> None:
+    queue = {
+        "tasks": [
+            {
+                "id": "legacy-task",
+                "priority": 1,
+                "status": "superseded",
+                "title": "Legacy task",
+            },
+            _task(213, priority=2),
+        ]
+    }
+
+    selected = BUILD_AGENT._select_next_task(queue, lambda task: "open")
+
+    assert selected is not None
+    assert selected["github_issue_number"] == 213
+
+
+def test_closed_issue_linked_task_returns_idle() -> None:
+    queue = {"tasks": [_task(213)]}
+
+    assert BUILD_AGENT._select_next_task(queue, lambda task: "closed") is None
+
+
+def test_lowest_priority_open_issue_is_selected() -> None:
+    queue = {"tasks": [_task(214, priority=214), _task(213, priority=213)]}
+
+    selected = BUILD_AGENT._select_next_task(queue, lambda task: "open")
+
+    assert selected is not None
+    assert selected["github_issue_number"] == 213
+
+
+def test_prompt_includes_canonical_issue_and_production_controls() -> None:
+    prompt = BUILD_AGENT._chatgpt_prompt(_task(213))
+
+    assert "iron-house-os/iron-house-os GitHub Issue #213" in prompt
+    assert "https://github.com/iron-house-os/iron-house-os/issues/213" in prompt
+    assert "draft pull request" in prompt
+    assert "Do not merge, deploy" in prompt
+
+
+def test_checked_in_queue_supersedes_legacy_open_builds() -> None:
+    queue = json.loads((ROOT / "automation" / "build-queue.json").read_text())
+    tasks = {task["id"]: task for task in queue["tasks"]}
+
+    for build_number in range(222, 231):
+        task = next(
+            task
+            for task_id, task in tasks.items()
+            if task_id.startswith(f"build-{build_number}-")
+        )
+        assert task["status"] == "superseded"
+
+    current = tasks["issue-213-build-agent-queue-governance"]
+    assert current["status"] == "open"
+    assert current["github_issue_number"] == 213


### PR DESCRIPTION
Closes #213

## Summary

- require every open Build Agent queue item to carry a canonical GitHub issue reference
- verify the live issue state before generating a prompt and fail closed when verification is unavailable
- mark legacy Builds 222–230 as superseded instead of treating them as current work
- constrain generated prompts to the issue-linked branch/draft-PR workflow and protected production boundaries
- add regression coverage for missing references, superseded tasks, closed issues, ordering, and prompt controls

## Validation

- `python -m ruff check .`
- `python -m pytest` — 353 passed
- `python scripts/check_visual_design_lock.py` — passed (13 protected files)
- checked-in workflow YAML parsed successfully
- live read-only selection resolved Issue #213 while it is open

## Risk and rollback

This changes only Build Agent queue governance and its scheduled workflow token exposure. It does not alter the application UI, production data, DNS, secrets, certificates, backups, or infrastructure. Roll back by reverting commit `7e64d2f547bcdff41ba939195412b6ea96de81ce`.

## Review gate

Draft only. Do not merge or deploy until required CI/readiness checks pass and owner review is recorded.