### PR TITLE
Fix management access to Worker Orientations

### DIFF
--- a/backend/app/services/access_control.py
+++ b/backend/app/services/access_control.py
@@ -33,6 +33,7 @@ BUSINESS_MODULES = (
     "equipment",
     "field-operations",
     "daily-timesheets",
+    "employee-onboarding",
     "finance",
     "media",
 )
@@ -70,6 +71,7 @@ def module_permissions_for_role(role: str | None, module: str) -> frozenset[Modu
         "iron-house-chat",
         "meeting-minutes",
         "google-calendar",
+        "employee-onboarding",
     } and normalized_role not in {
         "admin",
         "operations_manager",

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -55,6 +55,36 @@ def test_role_matrix_separates_administration_and_mutation() -> None:
     assert can_access_module("viewer", "daily-timesheets", ModulePermission.WRITE)
 
 
+def test_employee_onboarding_permissions_are_management_only() -> None:
+    for role in ("admin", "operations_manager"):
+        assert can_access_module(role, "employee-onboarding", ModulePermission.READ)
+        assert can_access_module(role, "employee-onboarding", ModulePermission.WRITE)
+
+    for role in ("estimator", "viewer", "unknown"):
+        assert not can_access_module(role, "employee-onboarding", ModulePermission.READ)
+        assert not can_access_module(role, "employee-onboarding", ModulePermission.WRITE)
+
+
+@pytest.mark.parametrize("role", ["admin", "operations_manager"])
+def test_management_roles_can_load_worker_orientations(role: str) -> None:
+    _authenticate_as(role)
+
+    response = client.get("/api/v1/employee-onboarding")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0}
+
+
+@pytest.mark.parametrize("role", ["estimator", "viewer"])
+def test_non_management_roles_cannot_load_worker_orientations(role: str) -> None:
+    _authenticate_as(role)
+
+    response = client.get("/api/v1/employee-onboarding")
+
+    assert response.status_code == 403
+    assert "read" in response.json()["detail"]
+
+
 def test_viewer_is_read_only_and_denial_is_audited() -> None:
     clear_recent_document_audit_events()
     _authenticate_as("viewer")


### PR DESCRIPTION
Closes #215

## Summary

- register `employee-onboarding` in the central protected-module authorization matrix
- restrict Worker Orientations access to Administrator and Operations Manager roles
- keep Estimator, Viewer, and unknown roles denied
- add live protected-route and permission-matrix regression coverage

## Root cause

The Worker Orientations page called `GET /api/v1/employee-onboarding`, but `employee-onboarding` was absent from `ALL_MODULES`. The global module-access dependency therefore rejected the request before the route's management-role guard could run.

## Validation

- focused Ruff — passed
- focused authorization suite — 29 passed
- full backend Ruff — passed
- full backend suite — 358 passed, 1 existing warning
- locked visual-design check — passed (13 protected files)

## Risk and rollback

This is a narrow backend authorization correction. It adds no database migration and changes no visual files, production data, DNS, secrets, certificates, backups, or infrastructure. Revert commit `41278bf44c7d2b21209acda8b81a8aec3c6108ad` to roll back.

## Staging acceptance

After merge and the automatic exact-SHA staging deployment, retest Worker Orientations as the staging Administrator. Production remains unchanged until a separate owner-approved release.