### PR TITLE
Add President and CFO as controlled onboarding positions

### DIFF
--- a/backend/app/schemas/employee_onboarding.py
+++ b/backend/app/schemas/employee_onboarding.py
@@ -26,6 +26,7 @@ class EmploymentPosition(StrEnum):
     ADMIN = "admin"
     CONTROLLER = "controller"
     PROJECT_MANAGER = "project_manager"
+    CFO = "cfo"
     COO = "coo"
     CEO = "ceo"
     PRESIDENT = "president"
@@ -46,6 +47,7 @@ OFFICE_POSITIONS = {
     EmploymentPosition.ADMIN,
     EmploymentPosition.CONTROLLER,
     EmploymentPosition.PROJECT_MANAGER,
+    EmploymentPosition.CFO,
     EmploymentPosition.COO,
     EmploymentPosition.CEO,
     EmploymentPosition.PRESIDENT,
@@ -288,7 +290,8 @@ POSITION_OPTIONS = [
     PositionOption(value=EmploymentPosition.ADMIN, label="Admin", category=EmploymentCategory.OFFICE_STAFF, level=1),
     PositionOption(value=EmploymentPosition.CONTROLLER, label="Controller", category=EmploymentCategory.OFFICE_STAFF, level=2),
     PositionOption(value=EmploymentPosition.PROJECT_MANAGER, label="Project Manager", category=EmploymentCategory.OFFICE_STAFF, level=3),
-    PositionOption(value=EmploymentPosition.COO, label="COO", category=EmploymentCategory.OFFICE_STAFF, level=4),
-    PositionOption(value=EmploymentPosition.CEO, label="CEO", category=EmploymentCategory.OFFICE_STAFF, level=5),
-    PositionOption(value=EmploymentPosition.PRESIDENT, label="President", category=EmploymentCategory.OFFICE_STAFF, level=6),
+    PositionOption(value=EmploymentPosition.CFO, label="CFO", category=EmploymentCategory.OFFICE_STAFF, level=4),
+    PositionOption(value=EmploymentPosition.COO, label="COO", category=EmploymentCategory.OFFICE_STAFF, level=5),
+    PositionOption(value=EmploymentPosition.CEO, label="CEO", category=EmploymentCategory.OFFICE_STAFF, level=6),
+    PositionOption(value=EmploymentPosition.PRESIDENT, label="President", category=EmploymentCategory.OFFICE_STAFF, level=7),
 ]

--- a/backend/app/schemas/employee_onboarding.py
+++ b/backend/app/schemas/employee_onboarding.py
@@ -28,6 +28,7 @@ class EmploymentPosition(StrEnum):
     PROJECT_MANAGER = "project_manager"
     COO = "coo"
     CEO = "ceo"
+    PRESIDENT = "president"
 
 
 FIELD_POSITIONS = {
@@ -47,6 +48,7 @@ OFFICE_POSITIONS = {
     EmploymentPosition.PROJECT_MANAGER,
     EmploymentPosition.COO,
     EmploymentPosition.CEO,
+    EmploymentPosition.PRESIDENT,
 }
 
 
@@ -288,4 +290,5 @@ POSITION_OPTIONS = [
     PositionOption(value=EmploymentPosition.PROJECT_MANAGER, label="Project Manager", category=EmploymentCategory.OFFICE_STAFF, level=3),
     PositionOption(value=EmploymentPosition.COO, label="COO", category=EmploymentCategory.OFFICE_STAFF, level=4),
     PositionOption(value=EmploymentPosition.CEO, label="CEO", category=EmploymentCategory.OFFICE_STAFF, level=5),
+    PositionOption(value=EmploymentPosition.PRESIDENT, label="President", category=EmploymentCategory.OFFICE_STAFF, level=6),
 ]

--- a/backend/tests/test_employee_onboarding_schema.py
+++ b/backend/tests/test_employee_onboarding_schema.py
@@ -24,8 +24,8 @@ def payload(**overrides):
 
 
 def test_all_approved_positions_are_exposed_once():
-    assert len(POSITION_OPTIONS) == 15
-    assert len({item.value for item in POSITION_OPTIONS}) == 15
+    assert len(POSITION_OPTIONS) == 16
+    assert len({item.value for item in POSITION_OPTIONS}) == 16
 
 
 def test_field_position_accepts_field_category():
@@ -50,3 +50,10 @@ def test_office_position_accepts_office_category():
         payload(category=EmploymentCategory.OFFICE_STAFF, position=EmploymentPosition.PRESIDENT)
     )
     assert model.position == EmploymentPosition.PRESIDENT
+
+
+def test_cfo_is_a_controlled_office_position():
+    model = EmployeeOnboardingCreate.model_validate(
+        payload(category=EmploymentCategory.OFFICE_STAFF, position=EmploymentPosition.CFO)
+    )
+    assert model.position == EmploymentPosition.CFO

--- a/backend/tests/test_employee_onboarding_schema.py
+++ b/backend/tests/test_employee_onboarding_schema.py
@@ -24,8 +24,8 @@ def payload(**overrides):
 
 
 def test_all_approved_positions_are_exposed_once():
-    assert len(POSITION_OPTIONS) == 14
-    assert len({item.value for item in POSITION_OPTIONS}) == 14
+    assert len(POSITION_OPTIONS) == 15
+    assert len({item.value for item in POSITION_OPTIONS}) == 15
 
 
 def test_field_position_accepts_field_category():
@@ -47,6 +47,6 @@ def test_office_position_rejects_field_category():
 
 def test_office_position_accepts_office_category():
     model = EmployeeOnboardingCreate.model_validate(
-        payload(category=EmploymentCategory.OFFICE_STAFF, position=EmploymentPosition.PROJECT_MANAGER)
+        payload(category=EmploymentCategory.OFFICE_STAFF, position=EmploymentPosition.PRESIDENT)
     )
-    assert model.position == EmploymentPosition.PROJECT_MANAGER
+    assert model.position == EmploymentPosition.PRESIDENT

--- a/tests/backend/test_employee_onboarding.py
+++ b/tests/backend/test_employee_onboarding.py
@@ -58,6 +58,19 @@ def test_office_position_is_controlled() -> None:
     assert payload.position == EmploymentPosition.PROJECT_MANAGER
 
 
+def test_president_is_a_controlled_office_position() -> None:
+    payload = EmployeeOnboardingCreate(
+        legal_first_name="Test",
+        legal_last_name="President",
+        personal_email="president@example.com",
+        category=EmploymentCategory.OFFICE_STAFF,
+        position=EmploymentPosition.PRESIDENT,
+        employment_type="salary",
+        start_date=date(2026, 8, 20),
+    )
+    assert payload.position == EmploymentPosition.PRESIDENT
+
+
 def test_orientation_requires_every_regulatory_topic_once() -> None:
     payload = WorkerOrientationCreate(
         scope="company",

--- a/tests/backend/test_employee_onboarding.py
+++ b/tests/backend/test_employee_onboarding.py
@@ -71,6 +71,19 @@ def test_president_is_a_controlled_office_position() -> None:
     assert payload.position == EmploymentPosition.PRESIDENT
 
 
+def test_cfo_is_a_controlled_office_position() -> None:
+    payload = EmployeeOnboardingCreate(
+        legal_first_name="Test",
+        legal_last_name="CFO",
+        personal_email="cfo@example.com",
+        category=EmploymentCategory.OFFICE_STAFF,
+        position=EmploymentPosition.CFO,
+        employment_type="salary",
+        start_date=date(2026, 8, 20),
+    )
+    assert payload.position == EmploymentPosition.CFO
+
+
 def test_orientation_requires_every_regulatory_topic_once() -> None:
     payload = WorkerOrientationCreate(
         scope="company",

--- a/tests/backend/test_employee_onboarding_activation.py
+++ b/tests/backend/test_employee_onboarding_activation.py
@@ -13,6 +13,7 @@ from app.models.employee_onboarding import EmployeeOnboarding, EmployeeOnboardin
 from app.models.user import Employee, UserAccount
 from app.schemas.employee_onboarding import REQUIRED_ORIENTATION_TOPIC_CODES
 from app.services.auth import hash_password, verify_password
+from app.services.employee_onboarding import portal_role_for_position
 
 
 def _client() -> tuple[TestClient, sessionmaker[Session], str]:
@@ -180,3 +181,8 @@ def test_activation_rejects_an_existing_portal_identity_without_overwriting() ->
         account = db.query(UserAccount).filter_by(email="alex.operator@example.com").one()
         assert account.display_name == "Existing Account"
         assert account.session_version == 4
+
+
+def test_executive_titles_do_not_auto_escalate_portal_access() -> None:
+    assert portal_role_for_position("ceo") == "employee"
+    assert portal_role_for_position("president") == "employee"

--- a/tests/backend/test_employee_onboarding_activation.py
+++ b/tests/backend/test_employee_onboarding_activation.py
@@ -186,3 +186,4 @@ def test_activation_rejects_an_existing_portal_identity_without_overwriting() ->
 def test_executive_titles_do_not_auto_escalate_portal_access() -> None:
     assert portal_role_for_position("ceo") == "employee"
     assert portal_role_for_position("president") == "employee"
+    assert portal_role_for_position("cfo") == "employee"


### PR DESCRIPTION
Closes #221.

## Outcome
- adds President and CFO as controlled office-staff employee-onboarding positions
- exposes both titles in the existing position-options endpoint and admin form
- preserves least-privilege routing: CEO, President, and CFO receive Employee Portal / viewer access unless management privileges are separately approved

## Staging validation identities
- Mack Warren — CEO
- Jeremie Peters — President
- Stefani Warren — CFO
- exact company emails are not added to source code or test fixtures
- Mack and Jeremie emails are verified from company records
- Stefani's exact company email remains an open item and will not be guessed
- live records will be created separately in staging, one at a time, after merge

## Verification
- canonical backend suite: 366 passed
- Ruff passed
- TypeScript type-check passed
- visual-design lock and diff checks passed
- CI run 32355331877: success
- Release Readiness run 32355331735: success
- browser/mobile/accessibility, isolated staging smoke, backup/rollback, and production-stack disposable smoke passed
- exact validated head: `9e06f79928038ae958ecd26a3b6c8acd9627b369`
- no production data, credentials, secrets, infrastructure, DNS, certificates, or backups changed