### PR TITLE
Add secure staging invitation handoff

### DIFF
--- a/backend/app/tools/staging_onboarding.py
+++ b/backend/app/tools/staging_onboarding.py
@@ -1,4 +1,4 @@
-"""Interactive, staging-only employee onboarding draft creator."""
+"""Interactive, staging-only employee onboarding operator helper."""
 
 from __future__ import annotations
 
@@ -6,12 +6,15 @@ import argparse
 from dataclasses import dataclass
 from datetime import date
 from getpass import getpass
+from http.cookiejar import CookieJar
 import json
+import os
+from pathlib import Path
+import tempfile
 from typing import Any, Protocol
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit
 from urllib.request import HTTPCookieProcessor, Request, build_opener
-from http.cookiejar import CookieJar
 
 
 STAGING_BASE_URL = "https://staging.os.ironhousecivil.com"
@@ -53,11 +56,37 @@ class DraftResult:
     position: str
 
 
+@dataclass(frozen=True)
+class RosterRecord:
+    onboarding_id: str
+    legal_first_name: str
+    legal_last_name: str
+    position: str
+    label: str
+    status: str
+
+
+@dataclass(frozen=True)
+class InvitationLink:
+    worker_name: str
+    label: str
+    invite_url: str
+    expires_at: str
+
+
 EXECUTIVE_STAGING_ROSTER = (
     ("Mack", "Warren", "ceo", "CEO"),
     ("Jeremie", "Peters", "president", "President"),
     ("Stefani", "Warren", "cfo", "CFO"),
 )
+INVITABLE_STATUSES = {
+    "draft",
+    "invitation_sent",
+    "invitation_opened",
+    "in_progress",
+    "corrections_required",
+    "invitation_expired",
+}
 
 
 def validate_staging_base_url(base_url: str) -> str:
@@ -167,6 +196,63 @@ class StagingOnboardingClient:
             raise StagingOnboardingError("Staging created a draft but did not return its record ID.")
         return DraftResult(outcome="created", onboarding_id=onboarding_id, position=draft.position)
 
+    def executive_roster_records(self) -> list[RosterRecord]:
+        response = self._request("GET", "/employee-onboarding")
+        items = response.get("items", []) if isinstance(response, dict) else []
+        records: list[RosterRecord] = []
+        for first_name, last_name, position, label in EXECUTIVE_STAGING_ROSTER:
+            matches = [
+                item
+                for item in items
+                if isinstance(item, dict)
+                and str(item.get("legal_first_name", "")).strip().casefold() == first_name.casefold()
+                and str(item.get("legal_last_name", "")).strip().casefold() == last_name.casefold()
+                and item.get("position") == position
+            ]
+            if len(matches) != 1:
+                reason = "missing" if not matches else "ambiguous"
+                raise StagingOnboardingError(
+                    f"The {label} staging onboarding record is {reason}; invitation generation stopped."
+                )
+            item = matches[0]
+            onboarding_id = item.get("id")
+            status = item.get("status")
+            if not isinstance(onboarding_id, str) or not isinstance(status, str):
+                raise StagingOnboardingError(f"The {label} staging onboarding record is incomplete.")
+            if status not in INVITABLE_STATUSES:
+                raise StagingOnboardingError(
+                    f"The {label} staging onboarding record cannot receive an invitation while {status}."
+                )
+            records.append(
+                RosterRecord(
+                    onboarding_id=onboarding_id,
+                    legal_first_name=first_name,
+                    legal_last_name=last_name,
+                    position=position,
+                    label=label,
+                    status=status,
+                )
+            )
+        return records
+
+    def issue_invitation(self, record: RosterRecord) -> InvitationLink:
+        response = self._request(
+            "POST",
+            f"/employee-onboarding/{record.onboarding_id}/invite",
+        )
+        invite_url = response.get("invite_url") if isinstance(response, dict) else None
+        expires_at = response.get("expires_at") if isinstance(response, dict) else None
+        if not isinstance(invite_url, str) or not isinstance(expires_at, str):
+            raise StagingOnboardingError(
+                f"Staging issued the {record.label} invitation without a complete handoff response."
+            )
+        return InvitationLink(
+            worker_name=f"{record.legal_first_name} {record.legal_last_name}",
+            label=record.label,
+            invite_url=invite_url,
+            expires_at=expires_at,
+        )
+
     def logout(self) -> None:
         self._request("POST", "/auth/logout")
 
@@ -181,15 +267,44 @@ def _prompt_date(prompt: str, default: date) -> date:
         raise StagingOnboardingError("Start date must use YYYY-MM-DD format.") from exc
 
 
-def run_interactive(client: StagingOnboardingClient) -> int:
-    print("Iron House OS staging onboarding helper")
-    print("Creates drafts only. It does not invite, approve, orient, activate, or generate passwords.")
+def _login_interactively(client: StagingOnboardingClient) -> None:
     admin_email = input("Staging administrator email: ").strip()
     admin_password = getpass("Staging administrator password (hidden): ")
     try:
         client.login(admin_email, admin_password)
     finally:
         del admin_password
+
+
+def write_invitation_handoff(
+    invitations: list[InvitationLink],
+    *,
+    directory: Path | None = None,
+) -> Path:
+    if not invitations:
+        raise StagingOnboardingError("No invitation links were generated.")
+    file_descriptor, raw_path = tempfile.mkstemp(
+        prefix="ihos-staging-invitations-",
+        suffix=".txt",
+        dir=str(directory) if directory else None,
+        text=True,
+    )
+    path = Path(raw_path)
+    with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+        handle.write("Iron House OS staging invitation handoff\n")
+        handle.write("These links are confidential, expire, and are replaced by a later handoff.\n\n")
+        for invitation in invitations:
+            handle.write(f"{invitation.worker_name} — {invitation.label}\n")
+            handle.write(f"Expires: {invitation.expires_at}\n")
+            handle.write(f"{invitation.invite_url}\n\n")
+    path.chmod(0o600)
+    return path
+
+
+def run_interactive(client: StagingOnboardingClient) -> int:
+    print("Iron House OS staging onboarding helper")
+    print("Creates drafts only. It does not invite, approve, orient, activate, or generate passwords.")
+    _login_interactively(client)
 
     client.verify_positions({"ceo", "president", "cfo"})
     start_date = _prompt_date("Start date for these staging records", date.today())
@@ -228,12 +343,49 @@ def run_interactive(client: StagingOnboardingClient) -> int:
     return 0
 
 
+def run_invitation_handoff(client: StagingOnboardingClient) -> int:
+    print("Iron House OS staging invitation handoff")
+    print("Issues fresh links only. It does not complete, acknowledge, approve, orient, or activate records.")
+    _login_interactively(client)
+    invitations: list[InvitationLink] = []
+    handoff_path: Path | None = None
+    try:
+        records = client.executive_roster_records()
+        for record in records:
+            invitations.append(client.issue_invitation(record))
+            print(f"Fresh {record.label} invitation issued.")
+        handoff_path = write_invitation_handoff(invitations)
+    except StagingOnboardingError as exc:
+        if invitations:
+            handoff_path = write_invitation_handoff(invitations)
+            raise StagingOnboardingError(
+                f"{exc} {len(invitations)} current link(s) were saved to {handoff_path}."
+            ) from exc
+        raise
+    finally:
+        client.logout()
+
+    print(f"Invitation handoff saved to: {handoff_path}")
+    print("Open the file, share each link only with its named employee, then delete the file.")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "action",
+        nargs="?",
+        choices=("create", "invite"),
+        default="create",
+        help="create staging drafts or issue secure invitation links",
+    )
     parser.add_argument("--base-url", default=STAGING_BASE_URL, help=argparse.SUPPRESS)
     args = parser.parse_args(argv)
     try:
-        return run_interactive(StagingOnboardingClient(base_url=args.base_url))
+        client = StagingOnboardingClient(base_url=args.base_url)
+        if args.action == "invite":
+            return run_invitation_handoff(client)
+        return run_interactive(client)
     except (KeyboardInterrupt, EOFError):
         print("\nCancelled. No further records were created.")
         return 130

--- a/docs/operations/staging-onboarding-cli.md
+++ b/docs/operations/staging-onboarding-cli.md
@@ -12,4 +12,14 @@ The helper prompts for the staging administrator email and a hidden password. It
 
 The helper creates onboarding drafts only. It does not issue invitations, complete checklist items, approve records, record orientations, activate portal accounts, or generate temporary passwords. Existing email matches are skipped to prevent duplicate drafts.
 
+After the approved CEO, President, and CFO drafts exist, generate fresh invitation links without re-entering employee emails:
+
+```bash
+python3 scripts/staging_onboarding.py invite
+```
+
+The invitation action authenticates the staging administrator, finds exactly one matching executive record for each controlled title, and issues a fresh link for each person. A fresh handoff invalidates older links. Current links are written to a mode-`0600` temporary file outside the repository; the terminal prints only that file path. Open the file locally, share each link only with its named employee, and delete the file after handoff.
+
+Invitation generation does not complete or acknowledge employee checklist items. It also does not record orientation evidence, approve onboarding, activate portal access, or create passwords. Each employee must personally complete their checklist, and management must verify the real orientation controls before activation.
+
 Stop with `Ctrl+C` at any prompt. Successfully created drafts remain in staging; no production records are read or changed.

--- a/tests/backend/test_staging_onboarding_cli.py
+++ b/tests/backend/test_staging_onboarding_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from io import BytesIO
 import json
+import stat
 from urllib.error import HTTPError
 from urllib.request import Request
 
@@ -10,9 +11,12 @@ import pytest
 
 from app.tools.staging_onboarding import (
     OnboardingDraft,
+    InvitationLink,
+    RosterRecord,
     StagingOnboardingClient,
     StagingOnboardingError,
     validate_staging_base_url,
+    write_invitation_handoff,
 )
 
 
@@ -132,3 +136,88 @@ def test_position_verification_requires_all_executive_titles() -> None:
 
     with pytest.raises(StagingOnboardingError, match="cfo"):
         client.verify_positions({"ceo", "president", "cfo"})
+
+
+def _record(first_name: str, last_name: str, position: str, identifier: str) -> dict[str, str]:
+    return {
+        "id": identifier,
+        "legal_first_name": first_name,
+        "legal_last_name": last_name,
+        "position": position,
+        "status": "draft",
+    }
+
+
+def test_exact_executive_roster_records_are_resolved() -> None:
+    opener = FakeOpener(
+        [
+            {
+                "items": [
+                    _record("Mack", "Warren", "ceo", "mack-id"),
+                    _record("Jeremie", "Peters", "president", "jeremie-id"),
+                    _record("Stefani", "Warren", "cfo", "stefani-id"),
+                ]
+            }
+        ]
+    )
+    client = StagingOnboardingClient(opener=opener)
+
+    records = client.executive_roster_records()
+
+    assert [record.onboarding_id for record in records] == ["mack-id", "jeremie-id", "stefani-id"]
+
+
+@pytest.mark.parametrize("duplicate", [False, True])
+def test_missing_or_ambiguous_roster_record_is_refused(duplicate: bool) -> None:
+    mack = _record("Mack", "Warren", "ceo", "mack-id")
+    items = [mack, _record("Jeremie", "Peters", "president", "jeremie-id")]
+    if duplicate:
+        items.append({**mack, "id": "second-mack-id"})
+    opener = FakeOpener([{"items": items}])
+    client = StagingOnboardingClient(opener=opener)
+
+    with pytest.raises(StagingOnboardingError, match="missing|ambiguous"):
+        client.executive_roster_records()
+
+
+def test_fresh_invitation_is_issued_for_selected_record() -> None:
+    opener = FakeOpener(
+        [
+            {
+                "invite_url": "https://staging.os.ironhousecivil.com/employee-onboarding/secure-token",
+                "expires_at": "2026-08-23T10:00:00Z",
+            }
+        ]
+    )
+    client = StagingOnboardingClient(opener=opener)
+    record = RosterRecord(
+        onboarding_id="mack-id",
+        legal_first_name="Mack",
+        legal_last_name="Warren",
+        position="ceo",
+        label="CEO",
+        status="draft",
+    )
+
+    invitation = client.issue_invitation(record)
+
+    assert invitation.worker_name == "Mack Warren"
+    assert invitation.label == "CEO"
+    assert opener.requests[0].get_method() == "POST"
+    assert opener.requests[0].full_url.endswith("/employee-onboarding/mack-id/invite")
+
+
+def test_invitation_handoff_file_is_private_and_contains_current_link(tmp_path) -> None:
+    invitation = InvitationLink(
+        worker_name="Test Worker",
+        label="CEO",
+        invite_url="https://staging.os.ironhousecivil.com/employee-onboarding/secure-token",
+        expires_at="2026-08-23T10:00:00Z",
+    )
+
+    path = write_invitation_handoff([invitation], directory=tmp_path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    content = path.read_text()
+    assert "Test Worker — CEO" in content
+    assert "secure-token" in content


### PR DESCRIPTION
Closes #227.

## Outcome
- extends the staging-only onboarding helper with `invite` mode
- resolves exactly one Mack Warren / CEO, Jeremie Peters / President, and Stefani Warren / CFO staging record
- refuses missing, ambiguous, non-invitable, production, or arbitrary targets
- issues fresh invitation links and invalidates older links
- stores current links in a mode-`0600` temporary file outside the repository
- prints only safe status and the temporary file path
- does not require employee emails again
- never completes checklist items, records acknowledgement or safety evidence, approves onboarding, activates accounts, or creates passwords

## Human gates preserved
- each named employee must personally complete and acknowledge their onboarding checklist
- management must verify real company-orientation evidence, PPE, qualifications, and competency before approval and activation
- existing IHOS orientation topics are already pre-populated as controlled checkboxes

## Verification
- canonical backend suite: 380 passed
- Ruff passed
- 14 focused staging-helper tests passed
- CI run 32361046411: success
- Release Readiness run 32361046400: success
- browser/mobile/accessibility, disposable staging, rollback, and production-stack smoke gates passed
- exact validated head: `8c5859101d75af28174e10c739c6212d3d34cdac`
- no production data, infrastructure, secrets, credentials, safety attestations, DNS, certificates, or backups changed

## Operator command after merge
```bash
python3 scripts/staging_onboarding.py invite
```