### PR TITLE
Generate awarded project job numbers

### DIFF
--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 from io import StringIO
 import secrets
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
@@ -60,6 +61,7 @@ SAFETY_AUDIT_EXPORT_TYPES = {
     "small_equipment_inspection",
     "toolbox_talk",
 }
+IRON_HOUSE_TIME_ZONE = ZoneInfo("America/Vancouver")
 FIRST_AID_DETAIL_FIELDS = {
     "occurred_at",
     "location",
@@ -412,13 +414,18 @@ def build_paperwork_recognitions(db: Session, employees: list[Employee]) -> list
     entries = db.scalars(select(TimeEntry).order_by(TimeEntry.work_date))
     days: dict[UUID, set[date]] = {}
     for item in entries:
-        if item.created_at.date() <= item.work_date:
+        if _iron_house_date(item.created_at) <= item.work_date:
             days.setdefault(item.employee_id, set()).add(item.work_date)
     records = db.scalars(select(FieldRecord).where(FieldRecord.employee_id.is_not(None)).order_by(FieldRecord.work_date))
     for item in records:
-        if item.employee_id and item.created_at.date() <= item.work_date:
+        if item.employee_id and _iron_house_date(item.created_at) <= item.work_date:
             days.setdefault(item.employee_id, set()).add(item.work_date)
     return [{"employee_id": str(employee_id), "employee_name": names.get(employee_id, "Employee"), "on_time_days": len(work_days)} for employee_id, work_days in days.items() if work_days]
+
+
+def _iron_house_date(value: datetime) -> date:
+    timestamp = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return timestamp.astimezone(IRON_HOUSE_TIME_ZONE).date()
 
 
 def build_material_movement_summary(db: Session) -> list[dict]:

--- a/backend/app/services/projects.py
+++ b/backend/app/services/projects.py
@@ -1,6 +1,10 @@
+import re
+from datetime import datetime
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
 from app.core.errors import AppError
@@ -18,9 +22,18 @@ from app.schemas.project import (
     ProjectUpdate,
 )
 
+JOB_NUMBER_PREFIX = "IH"
+JOB_NUMBER_WIDTH = 3
+JOB_NUMBER_RETRY_LIMIT = 20
+IRON_HOUSE_TIME_ZONE = ZoneInfo("America/Vancouver")
+
 
 def create_project(db: Session, payload: ProjectCreate) -> ProjectRead:
-    project = Project(**_project_values(payload))
+    values = _project_values(payload)
+    if values.get("status") == ProjectStatus.awarded.value and not _has_job_number(values.get("project_number")):
+        return _create_awarded_project(db, values, payload.supplier_ids)
+
+    project = Project(**values)
     db.add(project)
     db.flush()
     _replace_suppliers(db, project.id, payload.supplier_ids)
@@ -43,13 +56,73 @@ def get_project(db: Session, project_id: UUID) -> ProjectRead:
 def update_project(db: Session, project_id: UUID, payload: ProjectUpdate) -> ProjectRead:
     project = _load_project(db, project_id)
     update_data = _project_values(payload)
+    if project.project_number:
+        update_data.pop("project_number", None)
     supplier_ids = payload.supplier_ids if "supplier_ids" in payload.model_fields_set else None
+    resulting_status = update_data.get("status", project.status)
+    resulting_number = update_data.get("project_number", project.project_number)
+    if resulting_status == ProjectStatus.awarded.value and not _has_job_number(resulting_number):
+        return _update_awarded_project(db, project_id, update_data, supplier_ids)
+
     for key, value in update_data.items():
         setattr(project, key, value)
     if supplier_ids is not None:
         _replace_suppliers(db, project.id, supplier_ids)
     db.commit()
     return _to_schema(_load_project(db, project_id))
+
+
+def _create_awarded_project(db: Session, values: dict, supplier_ids: list[UUID]) -> ProjectRead:
+    for _ in range(JOB_NUMBER_RETRY_LIMIT):
+        project = Project(**{**values, "project_number": _next_job_number(db)})
+        db.add(project)
+        try:
+            db.flush()
+        except IntegrityError:
+            db.rollback()
+            continue
+        _replace_suppliers(db, project.id, supplier_ids)
+        db.commit()
+        return _to_schema(_load_project(db, project.id))
+    raise AppError("Unable to allocate a unique job number. Try again.", status_code=409)
+
+
+def _update_awarded_project(
+    db: Session,
+    project_id: UUID,
+    update_data: dict,
+    supplier_ids: list[UUID] | None,
+) -> ProjectRead:
+    for _ in range(JOB_NUMBER_RETRY_LIMIT):
+        project = _load_project(db, project_id)
+        for key, value in update_data.items():
+            if key != "project_number" or not project.project_number:
+                setattr(project, key, value)
+        if not _has_job_number(project.project_number):
+            project.project_number = _next_job_number(db)
+        try:
+            db.flush()
+        except IntegrityError:
+            db.rollback()
+            continue
+        if supplier_ids is not None:
+            _replace_suppliers(db, project.id, supplier_ids)
+        db.commit()
+        return _to_schema(_load_project(db, project_id))
+    raise AppError("Unable to allocate a unique job number. Try again.", status_code=409)
+
+
+def _next_job_number(db: Session, award_year: int | None = None) -> str:
+    year = award_year or datetime.now(IRON_HOUSE_TIME_ZONE).year
+    prefix = f"{JOB_NUMBER_PREFIX}-{year}-"
+    existing = db.scalars(select(Project.project_number).where(Project.project_number.like(f"{prefix}%"))).all()
+    pattern = re.compile(rf"^{re.escape(prefix)}(\d+)$")
+    sequences = [int(match.group(1)) for number in existing if number and (match := pattern.match(number))]
+    return f"{prefix}{max(sequences, default=0) + 1:0{JOB_NUMBER_WIDTH}d}"
+
+
+def _has_job_number(value: object) -> bool:
+    return bool(str(value or "").strip())
 
 
 def archive_project(db: Session, project_id: UUID) -> ProjectRead:

--- a/docs/project-job-numbering.md
+++ b/docs/project-job-numbering.md
@@ -1,0 +1,20 @@
+# Project job numbering
+
+IHOS assigns a permanent job number when a project first becomes `awarded`.
+
+## Number format
+
+- Default: `IH-YYYY-NNN`
+- Example: `IH-2026-001`
+- The three-digit sequence restarts for each award year using the Iron House BC business date and expands beyond three digits when required.
+
+## Allocation rules
+
+1. An opportunity or tender may remain unnumbered.
+2. Creating an awarded project without a number assigns the next number for the current year.
+3. Changing an existing project to awarded assigns the next number if the project is still unnumbered.
+4. An existing or explicitly supplied project number is preserved.
+5. Later status changes do not remove or replace the assigned number.
+6. The database uniqueness constraint and allocation retry prevent two awarded projects from retaining the same number.
+
+Existing legacy projects are not renumbered automatically. Any controlled legacy cleanup must be reviewed separately before changing company records.

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -52,8 +53,33 @@ describe("ProjectWorkspacePage", () => {
     expect(await screen.findByText(project.name)).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Ready" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Docs" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Job #" })).toBeInTheDocument();
+    expect(screen.getByText("IHO-1001")).toBeInTheDocument();
     expect(await screen.findByText("80%")).toBeInTheDocument();
     expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("creates an awarded project and delegates job-number generation to IHOS", async () => {
+    const fetchMock = mockProjectApi();
+    const user = userEvent.setup();
+    renderWorkspace("/projects");
+    await screen.findByText(project.name);
+
+    await user.type(screen.getByLabelText("Project name"), "Awarded Culvert Replacement");
+    await user.selectOptions(screen.getByLabelText("Project stage"), "awarded");
+
+    expect(screen.getByRole("status")).toHaveTextContent("generate the next unique job number");
+    await user.click(screen.getByRole("button", { name: "Create awarded job" }));
+
+    await waitFor(() => {
+      const createCall = fetchMock.mock.calls.find(([, options]) => options?.method === "POST");
+      expect(createCall).toBeDefined();
+      expect(JSON.parse(String(createCall?.[1]?.body))).toMatchObject({
+        name: "Awarded Culvert Replacement",
+        status: "awarded",
+      });
+      expect(JSON.parse(String(createCall?.[1]?.body))).not.toHaveProperty("project_number");
+    });
   });
 
   it("loads project detail from the route", async () => {
@@ -130,8 +156,18 @@ function renderWorkspace(path: string) {
 }
 
 function mockProjectApi() {
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
     const url = input.toString();
+
+    if (url.endsWith("/projects") && options?.method === "POST") {
+      const payload = JSON.parse(String(options.body));
+      return jsonResponse({
+        ...project,
+        ...payload,
+        id: "22222222-2222-4222-8222-222222222222",
+        project_number: "IH-2026-001",
+      }, 201);
+    }
 
     if (url.endsWith("/projects")) {
       return jsonResponse({ items: [project], total: 1 });
@@ -149,6 +185,7 @@ function mockProjectApi() {
   });
 
   vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
 }
 
 function jsonResponse(body: unknown, status = 200) {

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -100,7 +100,7 @@ export function ProjectWorkspacePage() {
         <div>
           <h1 className="text-3xl font-semibold text-iron-950">Project Workspace</h1>
           <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-500">
-            Command center for a live bid: tender intake, documents, RFQs, suppliers, quotes, estimate, risk, and bid package.
+            Command center for live bids and awarded jobs: tender intake, documents, RFQs, suppliers, quotes, estimate, risk, and delivery records.
           </p>
         </div>
         <button
@@ -169,6 +169,7 @@ function CreateProjectForm({ onSubmit }: { onSubmit: (payload: ProjectCreatePayl
   const [name, setName] = useState("");
   const [municipality, setMunicipality] = useState("");
   const [bidDueDate, setBidDueDate] = useState("");
+  const [status, setStatus] = useState<ProjectStatus>("opportunity");
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -177,7 +178,7 @@ function CreateProjectForm({ onSubmit }: { onSubmit: (payload: ProjectCreatePayl
       name: name.trim(),
       municipality: municipality.trim() || undefined,
       bid_due_date: bidDueDate || undefined,
-      status: "opportunity",
+      status,
     });
     setName("");
     setMunicipality("");
@@ -215,13 +216,30 @@ function CreateProjectForm({ onSubmit }: { onSubmit: (payload: ProjectCreatePayl
             className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
           />
         </Field>
+        <Field label="Project stage">
+          <select
+            aria-label="Project stage"
+            value={status}
+            onChange={(event) => setStatus(event.target.value as ProjectStatus)}
+            className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+          >
+            <option value="opportunity">Opportunity</option>
+            <option value="tendering">Tendering</option>
+            <option value="awarded">Awarded</option>
+          </select>
+        </Field>
+        {status === "awarded" ? (
+          <div role="status" className="rounded-md border border-brand-gold/40 bg-brand-gold/5 p-3 text-sm text-iron-700">
+            IHOS will generate the next unique job number when this awarded project is created.
+          </div>
+        ) : null}
       </div>
       <button
         type="submit"
         className="mt-5 inline-flex items-center gap-2 rounded-md bg-iron-950 px-3 py-2 text-sm font-semibold text-white"
       >
         <FolderKanban className="h-4 w-4" />
-        Create
+        {status === "awarded" ? "Create awarded job" : "Create"}
       </button>
     </form>
   );
@@ -243,6 +261,7 @@ function ProjectList({
         <table className="w-full border-collapse text-left text-sm">
           <thead>
             <tr className="border-b border-iron-100 text-xs uppercase tracking-wide text-iron-500">
+              <th className="py-2 pr-4">Job #</th>
               <th className="py-2 pr-4">Name</th>
               <th className="py-2 pr-4">Municipality</th>
               <th className="py-2 pr-4">Status</th>
@@ -261,6 +280,7 @@ function ProjectList({
                     " ",
                   )}
                 >
+                  <td className="py-3 pr-4 font-semibold text-iron-800">{project.project_number ?? "Pending award"}</td>
                   <td className="py-3 pr-4 font-medium text-iron-950">
                     <Link to={`/projects/${project.id}`}>{project.name}</Link>
                   </td>
@@ -274,7 +294,7 @@ function ProjectList({
             })}
             {projects.length === 0 ? (
               <tr>
-                <td className="py-3 text-iron-500" colSpan={6}>
+                <td className="py-3 text-iron-500" colSpan={7}>
                   No projects found.
                 </td>
               </tr>

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -1,9 +1,14 @@
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
 from fastapi.testclient import TestClient
 
 from app.main import app
 
 
 client = TestClient(app)
+IRON_HOUSE_TIME_ZONE = ZoneInfo("America/Vancouver")
 
 
 def create_project(name: str = "King George Utility Upgrade") -> dict:
@@ -44,6 +49,75 @@ def test_create_project() -> None:
     assert project["name"] == "King George Utility Upgrade"
     assert project["municipality"] == "Surrey"
     assert project["status"] == "opportunity"
+
+
+def test_awarded_project_creation_generates_sequential_job_numbers() -> None:
+    year = datetime.now(IRON_HOUSE_TIME_ZONE).year
+
+    first = client.post("/api/v1/projects", json={"name": "First Award", "status": "awarded"})
+    second = client.post("/api/v1/projects", json={"name": "Second Award", "status": "awarded"})
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert first.json()["project_number"] == f"IH-{year}-001"
+    assert second.json()["project_number"] == f"IH-{year}-002"
+
+
+def test_transition_to_awarded_generates_job_number() -> None:
+    year = datetime.now(IRON_HOUSE_TIME_ZONE).year
+    project = client.post("/api/v1/projects", json={"name": "Tender Without Number"}).json()
+
+    response = client.patch(f"/api/v1/projects/{project['id']}", json={"status": "awarded"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "awarded"
+    assert response.json()["project_number"] == f"IH-{year}-001"
+
+
+def test_award_generation_skips_existing_numbers_and_preserves_explicit_number() -> None:
+    year = datetime.now(IRON_HOUSE_TIME_ZONE).year
+    explicit = client.post(
+        "/api/v1/projects",
+        json={"name": "Existing Award", "status": "awarded", "project_number": f"IH-{year}-009"},
+    )
+    generated = client.post("/api/v1/projects", json={"name": "Next Award", "status": "awarded"})
+
+    assert explicit.status_code == 201
+    assert explicit.json()["project_number"] == f"IH-{year}-009"
+    assert generated.status_code == 201
+    assert generated.json()["project_number"] == f"IH-{year}-010"
+
+
+def test_award_generation_retries_a_unique_collision() -> None:
+    year = datetime.now(IRON_HOUSE_TIME_ZONE).year
+    duplicate = f"IH-{year}-001"
+    available = f"IH-{year}-002"
+    client.post(
+        "/api/v1/projects",
+        json={"name": "Existing Number", "status": "awarded", "project_number": duplicate},
+    )
+
+    with patch("app.services.projects._next_job_number", side_effect=[duplicate, available]):
+        response = client.post("/api/v1/projects", json={"name": "Concurrent Award", "status": "awarded"})
+
+    assert response.status_code == 201
+    assert response.json()["project_number"] == available
+
+
+def test_assigned_job_number_is_not_removed_or_replaced_by_project_update() -> None:
+    project = client.post(
+        "/api/v1/projects",
+        json={"name": "Award With Custom Number", "status": "awarded", "project_number": "CLIENT-JOB-77"},
+    ).json()
+
+    response = client.patch(
+        f"/api/v1/projects/{project['id']}",
+        json={"project_number": None, "status": "construction"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["project_number"] == "CLIENT-JOB-77"
+    assert response.json()["status"] == "construction"
 
 
 def test_list_project_and_detail() -> None:


### PR DESCRIPTION
Closes #234.

## What changed

- generates a collision-safe `IH-YYYY-NNN` job number when an awarded project is created without one
- assigns the number when an existing opportunity or tender first transitions to awarded
- preserves existing and manually supplied project numbers through later status changes
- retries database uniqueness collisions instead of retaining or returning a duplicate number
- adds an awarded-project option and generated-number explanation to Project Workspace
- shows job numbers in the project list
- uses the Iron House BC business date for award-year numbering
- corrects the same BC/UTC midnight boundary in on-time paperwork recognition
- documents the allocation and legacy-project rules

## Validation

Local:
- Backend Ruff: passed
- Backend: 388 passed, 1 existing Pydantic warning
- Frontend: 29 files / 70 tests passed
- TypeScript and production Vite build: passed
- Locked visual design: passed
- React Router/RSC security boundary: passed
- Diff check: passed

GitHub head `9ac2024cc59f9a9b98a819558b625bee76650c97`:
- CI run 871: passed
- Release Readiness run 369: passed
- Desktop Chromium, mobile Chromium, and iPad WebKit browser/accessibility gates: passed
- Staging isolation gate: passed
- Disposable staging smoke, backup/restore, rollback, and immutable evidence: passed
- Disposable production-stack smoke and recovery path: passed

## Release boundary

Ready for independent approval and merge. No production deployment, production data backfill, or infrastructure change performed. Existing legacy projects are not renumbered automatically.