### PR TITLE
Make Worker Orientations resilient to status failures

### DIFF
--- a/frontend/src/pages/WorkerOrientationsPage.test.tsx
+++ b/frontend/src/pages/WorkerOrientationsPage.test.tsx
@@ -44,8 +44,17 @@ const worker = {
   updated_at: "2026-08-20T10:00:00Z",
 };
 
+const readyWorker = {
+  ...worker,
+  id: "worker-2",
+  legal_first_name: "Ready",
+  legal_last_name: "Worker",
+  personal_email: "ready.worker@example.com",
+};
+
 describe("WorkerOrientationsPage", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.mocked(employeeOnboardingApi.list).mockResolvedValue({ items: [worker], total: 1 });
     vi.mocked(employeeOnboardingApi.deploymentStatus).mockResolvedValue({
       status: "Blocked",
@@ -116,5 +125,94 @@ describe("WorkerOrientationsPage", () => {
         ),
       }),
     );
+  });
+
+  it("keeps workers visible and fails closed when deployment status cannot be verified", async () => {
+    vi.mocked(employeeOnboardingApi.deploymentStatus).mockRejectedValue(
+      new Error("Onboarding request failed."),
+    );
+
+    render(<WorkerOrientationsPage />);
+
+    expect(await screen.findByRole("option", { name: "Test Worker" })).toBeInTheDocument();
+    expect(await screen.findByText("Status unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Deployment evidence is unverified. This worker is not cleared for deployment.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Required evidence is complete.")).not.toBeInTheDocument();
+    expect(employeeOnboardingApi.deploymentStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a pending status check fail-closed without showing a false failure", async () => {
+    vi.mocked(employeeOnboardingApi.deploymentStatus).mockImplementation(
+      () => new Promise(() => undefined),
+    );
+
+    render(<WorkerOrientationsPage />);
+
+    expect(await screen.findByText("Checking status")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Deployment evidence is being verified. This worker is not cleared for deployment.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Required evidence is complete.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry status" })).not.toBeInTheDocument();
+  });
+
+  it("preserves a verified worker status when another worker status fails", async () => {
+    vi.mocked(employeeOnboardingApi.list).mockResolvedValue({
+      items: [worker, readyWorker],
+      total: 2,
+    });
+    vi.mocked(employeeOnboardingApi.deploymentStatus).mockImplementation(async (workerId) => {
+      if (workerId === readyWorker.id) {
+        return {
+          status: "Ready",
+          blockers: [],
+          latest_company_orientation_id: "orientation-1",
+          latest_site_orientation_id: null,
+        };
+      }
+      throw new Error("Onboarding request failed.");
+    });
+
+    render(<WorkerOrientationsPage />);
+
+    expect(await screen.findByRole("option", { name: "Test Worker" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Ready Worker" })).toBeInTheDocument();
+    expect(await screen.findByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Status unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Required evidence is complete.")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Deployment evidence is unverified. This worker is not cleared for deployment.",
+      ),
+    ).toBeInTheDocument();
+    expect(employeeOnboardingApi.deploymentStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("lets management retry an unavailable deployment status", async () => {
+    const user = userEvent.setup();
+    vi.mocked(employeeOnboardingApi.deploymentStatus)
+      .mockRejectedValueOnce(new Error("Onboarding request failed."))
+      .mockRejectedValueOnce(new Error("Onboarding request failed."))
+      .mockResolvedValue({
+        status: "Blocked",
+        blockers: ["Company orientation is required."],
+        latest_company_orientation_id: null,
+        latest_site_orientation_id: null,
+      });
+
+    render(<WorkerOrientationsPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Retry status" }));
+
+    expect(await screen.findByText("Company orientation is required.")).toBeInTheDocument();
+    expect(screen.getByText("Blocked")).toBeInTheDocument();
+    expect(screen.queryByText("Status unavailable")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry status" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/WorkerOrientationsPage.tsx
+++ b/frontend/src/pages/WorkerOrientationsPage.tsx
@@ -45,6 +45,8 @@ function topicIsRecorded(topic: TopicState[OrientationTopicCode]) {
 export function WorkerOrientationsPage() {
   const [workers, setWorkers] = useState<OnboardingRecord[]>([]);
   const [statuses, setStatuses] = useState<Record<string, DeploymentStatus>>({});
+  const [checkingStatusIds, setCheckingStatusIds] = useState<Set<string>>(new Set());
+  const [unverifiedStatusIds, setUnverifiedStatusIds] = useState<Set<string>>(new Set());
   const [selected, setSelected] = useState("");
   const [scope, setScope] = useState<"company" | "site">("company");
   const [siteName, setSiteName] = useState("");
@@ -61,16 +63,34 @@ export function WorkerOrientationsPage() {
   const [message, setMessage] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
+    setError(null);
     try {
       const records = (await employeeOnboardingApi.list()).items;
       setWorkers(records);
-      const pairs = await Promise.all(
-        records.map(
-          async (worker) =>
-            [worker.id, await employeeOnboardingApi.deploymentStatus(worker.id)] as const,
-        ),
+      setStatuses({});
+      setCheckingStatusIds(new Set(records.map((worker) => worker.id)));
+      setUnverifiedStatusIds(new Set());
+      const results = await Promise.allSettled(
+        records.map(async (worker) => {
+          try {
+            return [worker.id, await employeeOnboardingApi.deploymentStatus(worker.id)] as const;
+          } catch {
+            return [worker.id, await employeeOnboardingApi.deploymentStatus(worker.id)] as const;
+          }
+        }),
       );
-      setStatuses(Object.fromEntries(pairs));
+      const verifiedPairs: Array<readonly [string, DeploymentStatus]> = [];
+      const unverifiedIds = new Set<string>();
+      results.forEach((result, index) => {
+        if (result.status === "fulfilled") {
+          verifiedPairs.push(result.value);
+        } else {
+          unverifiedIds.add(records[index].id);
+        }
+      });
+      setStatuses(Object.fromEntries(verifiedPairs));
+      setCheckingStatusIds(new Set());
+      setUnverifiedStatusIds(unverifiedIds);
       setSelected((current) => current || records[0]?.id || "");
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : "Unable to load orientations.");
@@ -178,8 +198,31 @@ export function WorkerOrientationsPage() {
       </header>
 
       {error ? (
-        <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-          {error}
+        <div role="alert" className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <span>{error}</span>
+          <button type="button" onClick={() => void refresh()} className="min-h-11 rounded-md border border-red-300 bg-white px-4 font-semibold">
+            Retry
+          </button>
+        </div>
+      ) : null}
+      {checkingStatusIds.size ? (
+        <div
+          role="status"
+          className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900"
+        >
+          Checking deployment status for {checkingStatusIds.size} worker
+          {checkingStatusIds.size === 1 ? "" : "s"}. Workers are not cleared until verification
+          finishes.
+        </div>
+      ) : null}
+      {unverifiedStatusIds.size ? (
+        <div role="alert" className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+          <span>
+            Deployment status could not be verified for {unverifiedStatusIds.size} worker{unverifiedStatusIds.size === 1 ? "" : "s"}. Treat affected workers as blocked until verification succeeds.
+          </span>
+          <button type="button" onClick={() => void refresh()} className="min-h-11 rounded-md border border-amber-400 bg-white px-4 font-semibold">
+            Retry status
+          </button>
         </div>
       ) : null}
       {message ? (
@@ -191,27 +234,36 @@ export function WorkerOrientationsPage() {
       <section className="rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
         <h2 className="font-semibold text-iron-950">Deployment board</h2>
         <div className="mt-4 grid gap-3">
-          {workers.map((worker) => (
-            <button
-              type="button"
-              onClick={() => setSelected(worker.id)}
-              key={worker.id}
-              className={`rounded-md border p-4 text-left ${selected === worker.id ? "border-brand-gold" : "border-iron-100"}`}
-            >
-              <div className="flex flex-wrap justify-between gap-2">
-                <strong>
-                  {worker.legal_first_name} {worker.legal_last_name}
-                </strong>
-                <Status value={statuses[worker.id]?.status ?? "Blocked"} />
-              </div>
-              <div className="mt-1 text-sm text-iron-500">
-                {worker.position.replaceAll("_", " ")} · {worker.primary_location ?? "Location pending"}
-              </div>
-              <div className="mt-2 text-xs text-iron-500">
-                {statuses[worker.id]?.blockers.join(" ") || "Required evidence is complete."}
-              </div>
-            </button>
-          ))}
+          {workers.map((worker) => {
+            const status = statuses[worker.id];
+            const checking = checkingStatusIds.has(worker.id);
+            return (
+              <button
+                type="button"
+                onClick={() => setSelected(worker.id)}
+                key={worker.id}
+                className={`rounded-md border p-4 text-left ${selected === worker.id ? "border-brand-gold" : "border-iron-100"}`}
+              >
+                <div className="flex flex-wrap justify-between gap-2">
+                  <strong>
+                    {worker.legal_first_name} {worker.legal_last_name}
+                  </strong>
+                  <Status value={status?.status ?? (checking ? "Checking status" : "Status unavailable")} />
+                </div>
+                <div className="mt-1 text-sm text-iron-500">
+                  {worker.position.replaceAll("_", " ")} · {worker.primary_location ?? "Location pending"}
+                </div>
+                <div className="mt-2 text-xs text-iron-500">
+                  {status?.blockers.join(" ") ||
+                    (status
+                      ? "Required evidence is complete."
+                      : checking
+                        ? "Deployment evidence is being verified. This worker is not cleared for deployment."
+                        : "Deployment evidence is unverified. This worker is not cleared for deployment.")}
+                </div>
+              </button>
+            );
+          })}
         </div>
       </section>
 
@@ -383,11 +435,15 @@ function Field({ label, children }: { label: string; children: ReactNode }) {
   );
 }
 
-function Status({ value }: { value: DeploymentStatus["status"] }) {
+function Status({
+  value,
+}: {
+  value: DeploymentStatus["status"] | "Checking status" | "Status unavailable";
+}) {
   const tone =
     value === "Ready"
       ? "bg-emerald-100 text-emerald-800"
-      : value === "Blocked"
+      : value === "Blocked" || value === "Status unavailable"
         ? "bg-red-100 text-red-800"
         : "bg-amber-100 text-amber-800";
   return <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${tone}`}>{value}</span>;


### PR DESCRIPTION
Closes #233.

## What changed

- preserves the worker list when an individual deployment-status request fails
- retries each failed deployment-status request once before marking it unavailable
- distinguishes checking, verified, and unavailable evidence states
- fails closed so pending or unavailable workers are never shown as deployment-ready
- adds an accessible management retry action without overlapping in-flight checks
- preserves verified statuses for workers whose requests succeed
- removes the contradictory “Required evidence is complete” fallback for unverified workers

## Validation

Local on current `main`:
- Backend Ruff: passed
- Backend: 426 passed, 1 existing Pydantic warning
- Frontend: 30 files / 79 tests passed
- Focused Worker Orientations: 6 passed
- TypeScript and production Vite build: passed
- Visual design lock: passed
- React Router/RSC security boundary: passed
- Diff check: passed

## Release boundary

Draft for CI, Release Readiness, and independent review. No production deployment or production data/safety evidence changes performed.