### PR TITLE
Follow up on awarded checklist review findings

### DIFF
--- a/backend/app/services/projects.py
+++ b/backend/app/services/projects.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
@@ -33,30 +35,60 @@ JOB_NUMBER_WIDTH = 3
 JOB_NUMBER_RETRY_LIMIT = 20
 IRON_HOUSE_TIME_ZONE = ZoneInfo("America/Vancouver")
 PROJECT_START_CHECKLIST: tuple[tuple[str, str, str], ...] = (
-    ("award_contract", "Contract", "Award notice or executed contract and the client scope record are saved."),
+    (
+        "award_contract",
+        "Contract",
+        "Award notice or executed contract and the client scope record are saved.",
+    ),
     ("scope_review", "Contract", "Scope, exclusions, allowances, and alternates are reviewed."),
-    ("current_documents", "Documents", "Current drawings, specifications, and addenda are confirmed."),
+    (
+        "current_documents",
+        "Documents",
+        "Current drawings, specifications, and addenda are confirmed.",
+    ),
     (
         "contacts_authority",
         "Administration",
         "Project contacts, authority limits, and communication path are confirmed.",
     ),
-    ("budget_cost_codes", "Cost control", "Baseline budget and project cost codes are established."),
-    ("schedule_milestones", "Schedule", "Baseline schedule, milestones, and notice periods are established."),
-    ("procurement_plan", "Procurement", "Subcontractor, material, equipment, and procurement plans are established."),
-    ("permits_insurance_bonding", "Administration", "Permit, insurance, and bonding requirements are assigned."),
+    (
+        "budget_cost_codes",
+        "Cost control",
+        "Baseline budget and project cost codes are established.",
+    ),
+    (
+        "schedule_milestones",
+        "Schedule",
+        "Baseline schedule, milestones, and notice periods are established.",
+    ),
+    (
+        "procurement_plan",
+        "Procurement",
+        "Subcontractor, material, equipment, and procurement plans are established.",
+    ),
+    (
+        "permits_insurance_bonding",
+        "Administration",
+        "Permit, insurance, and bonding requirements are assigned.",
+    ),
     (
         "safety_mobilization",
         "Safety",
         "Project-specific safety and mobilization requirements are assigned for verification.",
     ),
-    ("quality_testing_asbuilts", "Quality", "Quality, inspection, testing, and as-built requirements are assigned."),
+    (
+        "quality_testing_asbuilts",
+        "Quality",
+        "Quality, inspection, testing, and as-built requirements are assigned.",
+    ),
 )
 
 
 def create_project(db: Session, payload: ProjectCreate) -> ProjectRead:
     values = _project_values(payload)
-    if values.get("status") == ProjectStatus.awarded.value and not _has_job_number(values.get("project_number")):
+    if values.get("status") == ProjectStatus.awarded.value and not _has_job_number(
+        values.get("project_number")
+    ):
         return _create_awarded_project(db, values, payload.supplier_ids)
 
     project = Project(**values)
@@ -70,7 +102,11 @@ def create_project(db: Session, payload: ProjectCreate) -> ProjectRead:
 
 
 def list_projects(db: Session, status: str | None = None) -> ProjectList:
-    statement = select(Project).options(selectinload(Project.supplier_links)).order_by(Project.created_at.desc())
+    statement = (
+        select(Project)
+        .options(selectinload(Project.supplier_links))
+        .order_by(Project.created_at.desc())
+    )
     if status:
         statement = statement.where(Project.status == status)
     items = [_to_schema(project) for project in db.scalars(statement).all()]
@@ -148,9 +184,13 @@ def _update_awarded_project(
 def _next_job_number(db: Session, award_year: int | None = None) -> str:
     year = award_year or datetime.now(IRON_HOUSE_TIME_ZONE).year
     prefix = f"{JOB_NUMBER_PREFIX}-{year}-"
-    existing = db.scalars(select(Project.project_number).where(Project.project_number.like(f"{prefix}%"))).all()
+    existing = db.scalars(
+        select(Project.project_number).where(Project.project_number.like(f"{prefix}%"))
+    ).all()
     pattern = re.compile(rf"^{re.escape(prefix)}(\d+)$")
-    sequences = [int(match.group(1)) for number in existing if number and (match := pattern.match(number))]
+    sequences = [
+        int(match.group(1)) for number in existing if number and (match := pattern.match(number))
+    ]
     return f"{prefix}{max(sequences, default=0) + 1:0{JOB_NUMBER_WIDTH}d}"
 
 
@@ -160,7 +200,9 @@ def _has_job_number(value: object) -> bool:
 
 def _provision_awarded_workspace(db: Session, project: Project) -> None:
     if not _has_job_number(project.project_number):
-        raise AppError("A permanent job number is required before workspace provisioning", status_code=409)
+        raise AppError(
+            "A permanent job number is required before workspace provisioning", status_code=409
+        )
     if not project.workspace_root:
         manifest = project_folders.build_awarded_project_folder_manifest(
             job_number=str(project.project_number),
@@ -177,23 +219,34 @@ def _provision_awarded_workspace(db: Session, project: Project) -> None:
 
 
 def _provision_project_start_checklist(db: Session, project_id: UUID) -> None:
-    existing_codes = set(
-        db.scalars(
-            select(ProjectStartChecklistItem.code).where(ProjectStartChecklistItem.project_id == project_id)
-        ).all()
-    )
-    db.add_all(
-        ProjectStartChecklistItem(
-            project_id=project_id,
-            code=code,
-            category=category,
-            label=label,
-            sort_order=sort_order,
-            completed=False,
-        )
+    values = [
+        {
+            "project_id": project_id,
+            "code": code,
+            "category": category,
+            "label": label,
+            "sort_order": sort_order,
+            "completed": False,
+        }
         for sort_order, (code, category, label) in enumerate(PROJECT_START_CHECKLIST, start=1)
-        if code not in existing_codes
-    )
+    ]
+    dialect_name = db.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        statement = postgresql_insert(ProjectStartChecklistItem).values(values)
+        db.execute(statement.on_conflict_do_nothing(index_elements=["project_id", "code"]))
+        return
+    if dialect_name == "sqlite":
+        statement = sqlite_insert(ProjectStartChecklistItem).values(values)
+        db.execute(statement.on_conflict_do_nothing(index_elements=["project_id", "code"]))
+        return
+
+    for value in values:
+        try:
+            with db.begin_nested():
+                db.add(ProjectStartChecklistItem(**value))
+                db.flush()
+        except IntegrityError:
+            continue
 
 
 def archive_project(db: Session, project_id: UUID) -> ProjectRead:
@@ -283,12 +336,26 @@ def _project_start_checklist_schema(
 
 def get_project_dashboard(db: Session, project_id: UUID) -> ProjectDashboard:
     project = _load_project(db, project_id)
-    rfq_count = db.scalar(select(func.count()).select_from(RFQPackage).where(RFQPackage.project_id == project_id)) or 0
-    supplier_count = (
-        db.scalar(select(func.count()).select_from(ProjectSupplier).where(ProjectSupplier.project_id == project_id))
+    rfq_count = (
+        db.scalar(
+            select(func.count()).select_from(RFQPackage).where(RFQPackage.project_id == project_id)
+        )
         or 0
     )
-    document_count = db.scalar(select(func.count()).select_from(Document).where(Document.project_id == project_id)) or 0
+    supplier_count = (
+        db.scalar(
+            select(func.count())
+            .select_from(ProjectSupplier)
+            .where(ProjectSupplier.project_id == project_id)
+        )
+        or 0
+    )
+    document_count = (
+        db.scalar(
+            select(func.count()).select_from(Document).where(Document.project_id == project_id)
+        )
+        or 0
+    )
     drawing_count = (
         db.scalar(
             select(func.count())
@@ -300,7 +367,10 @@ def get_project_dashboard(db: Session, project_id: UUID) -> ProjectDashboard:
         )
         or 0
     )
-    drawing_count += db.scalar(select(func.count()).select_from(Drawing).where(Drawing.project_id == project_id)) or 0
+    drawing_count += (
+        db.scalar(select(func.count()).select_from(Drawing).where(Drawing.project_id == project_id))
+        or 0
+    )
     bid_status = _bid_status(db, project_id)
     readiness_percentage = _readiness_percentage(
         rfq_count=rfq_count,
@@ -321,7 +391,11 @@ def get_project_dashboard(db: Session, project_id: UUID) -> ProjectDashboard:
 
 
 def _load_project(db: Session, project_id: UUID) -> Project:
-    project = db.scalar(select(Project).where(Project.id == project_id).options(selectinload(Project.supplier_links)))
+    project = db.scalar(
+        select(Project)
+        .where(Project.id == project_id)
+        .options(selectinload(Project.supplier_links))
+    )
     if project is None:
         raise AppError("Project not found", status_code=404)
     return project
@@ -343,7 +417,10 @@ def _project_values(payload: ProjectCreate | ProjectUpdate) -> dict:
 
 def _replace_suppliers(db: Session, project_id: UUID, supplier_ids: list[UUID]) -> None:
     db.execute(delete(ProjectSupplier).where(ProjectSupplier.project_id == project_id))
-    db.add_all(ProjectSupplier(project_id=project_id, supplier_id=supplier_id) for supplier_id in supplier_ids)
+    db.add_all(
+        ProjectSupplier(project_id=project_id, supplier_id=supplier_id)
+        for supplier_id in supplier_ids
+    )
 
 
 def _bid_status(db: Session, project_id: UUID) -> str:
@@ -384,7 +461,9 @@ def _to_schema(project: Project) -> ProjectRead:
         project_address=project.project_address,
         latitude=project.latitude,
         longitude=project.longitude,
-        contract_value=(float(project.contract_value) if project.contract_value is not None else None),
+        contract_value=(
+            float(project.contract_value) if project.contract_value is not None else None
+        ),
         status=workflow_enum(
             ProjectStatus,
             project.status,

--- a/docs/awarded-project-start-checklist.md
+++ b/docs/awarded-project-start-checklist.md
@@ -27,4 +27,4 @@ Project Workspace loads the checklist from `GET /api/v1/projects/{project_id}/st
 
 ## Control boundary
 
-A checked item records management confirmation only. It does not create or replace source documents, permits, contract approval, engineering approval, or project-specific safety evidence. Checklist provisioning does not create external folders, send notices, change contracts, or alter production data outside the normal deployment process.
+A checked item records management confirmation only. Checklist provisioning and selections persist checklist rows, actor, and timestamp state in the active IHOS database during normal application use. They do not create or replace source documents, permits, contract approval, engineering approval, or project-specific safety evidence, and they do not create external folders, send notices, change contracts, or backfill legacy projects.

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -62,25 +62,39 @@ const awardedWorkspace: AwardedProjectWorkspace = {
   provisioned_at: "2026-08-21T08:30:00Z",
 };
 
+const startChecklistDefinitions = [
+  ["award_contract", "Contract", "Award notice or executed contract and the client scope record are saved."],
+  ["scope_review", "Contract", "Scope, exclusions, allowances, and alternates are reviewed."],
+  ["current_documents", "Documents", "Current drawings, specifications, and addenda are confirmed."],
+  ["contacts_authority", "Administration", "Project contacts, authority limits, and communication path are confirmed."],
+  ["budget_cost_codes", "Cost control", "Baseline budget and project cost codes are established."],
+  ["schedule_milestones", "Schedule", "Baseline schedule, milestones, and notice periods are established."],
+  ["procurement_plan", "Procurement", "Subcontractor, material, equipment, and procurement plans are established."],
+  ["permits_insurance_bonding", "Administration", "Permit, insurance, and bonding requirements are assigned."],
+  ["safety_mobilization", "Safety", "Project-specific safety and mobilization requirements are assigned for verification."],
+  ["quality_testing_asbuilts", "Quality", "Quality, inspection, testing, and as-built requirements are assigned."],
+] as const;
+
 const awardedStartChecklist: ProjectStartChecklist = {
   project_id: awardedProject.id,
   status: "not_ready",
   completed_count: 0,
-  total_count: 1,
-  items: [
-    {
-      code: "award_contract",
-      category: "Contract",
-      label: "Award notice or executed contract and the client scope record are saved.",
-      sort_order: 1,
-      completed: false,
-      changed_by: null,
-      changed_at: null,
-    },
-  ],
+  total_count: startChecklistDefinitions.length,
+  items: startChecklistDefinitions.map(([code, category, label], index) => ({
+    code,
+    category,
+    label,
+    sort_order: index + 1,
+    completed: false,
+    changed_by: null,
+    changed_at: null,
+  })),
 };
 
+let releaseChecklistUpdate: (() => void) | null = null;
+
 afterEach(() => {
+  releaseChecklistUpdate = null;
   vi.restoreAllMocks();
 });
 
@@ -123,7 +137,7 @@ describe("ProjectWorkspacePage", () => {
   });
 
   it("loads project detail from the route", async () => {
-    mockProjectApi();
+    const fetchMock = mockProjectApi();
 
     renderWorkspace(`/projects/${project.id}`);
 
@@ -131,6 +145,8 @@ describe("ProjectWorkspacePage", () => {
     expect(screen.getByText("City of Surrey - Surrey")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Archive" })).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Awarded project workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Awarded job start checklist" })).not.toBeInTheDocument();
+    expect(fetchMock.mock.calls.some(([url]) => url.toString().includes("/start-checklist"))).toBe(false);
   });
 
   it("shows the stable prepared workspace for an awarded job", async () => {
@@ -152,7 +168,8 @@ describe("ProjectWorkspacePage", () => {
 
     const checklist = await screen.findByRole("region", { name: "Awarded job start checklist" });
     expect(checklist).toHaveTextContent("Not ready");
-    expect(checklist).toHaveTextContent("0 of 1");
+    expect(checklist).toHaveTextContent("0 of 10");
+    expect(within(checklist).getAllByRole("checkbox")).toHaveLength(10);
 
     await user.click(within(checklist).getByRole("checkbox", { name: /Award notice or executed contract/ }));
 
@@ -162,9 +179,48 @@ describe("ProjectWorkspacePage", () => {
       );
       expect(updateCall).toBeDefined();
       expect(JSON.parse(String(updateCall?.[1]?.body))).toEqual({ completed: true });
-      expect(checklist).toHaveTextContent("Ready");
-      expect(checklist).toHaveTextContent("1 of 1");
+      expect(checklist).toHaveTextContent("Not ready");
+      expect(checklist).toHaveTextContent("1 of 10");
       expect(checklist).toHaveTextContent("Recorded by test-admin@ironhousecontracting.com");
+    });
+
+    for (const item of awardedStartChecklist.items.slice(1)) {
+      await user.click(within(checklist).getAllByRole("checkbox")[item.sort_order - 1]);
+      await waitFor(() => {
+        expect(checklist).toHaveTextContent(`${item.sort_order} of 10`);
+      });
+    }
+
+    expect(checklist).toHaveTextContent("Ready");
+    expect(
+      within(checklist)
+        .getAllByRole("checkbox")
+        .every((checkbox) => (checkbox as HTMLInputElement).checked),
+    ).toBe(true);
+  });
+
+  it("serializes checklist updates so an older response cannot replace newer state", async () => {
+    mockProjectApi(awardedProject, awardedWorkspace, awardedStartChecklist, true);
+    const user = userEvent.setup();
+    renderWorkspace(`/projects/${awardedProject.id}`);
+
+    const checklist = await screen.findByRole("region", { name: "Awarded job start checklist" });
+    const checkboxes = within(checklist).getAllByRole("checkbox");
+    await user.click(checkboxes[0]);
+
+    await waitFor(() => {
+      expect(checkboxes.every((checkbox) => (checkbox as HTMLInputElement).disabled)).toBe(true);
+      expect(releaseChecklistUpdate).not.toBeNull();
+    });
+    releaseChecklistUpdate?.();
+
+    await waitFor(() => {
+      expect(
+        within(checklist)
+          .getAllByRole("checkbox")
+          .every((checkbox) => !(checkbox as HTMLInputElement).disabled),
+      ).toBe(true);
+      expect(checklist).toHaveTextContent("1 of 10");
     });
   });
 
@@ -235,6 +291,7 @@ function mockProjectApi(
   currentProject: Project = project,
   workspace?: AwardedProjectWorkspace,
   startChecklist?: ProjectStartChecklist,
+  delayChecklistUpdates = false,
 ) {
   let currentStartChecklist = startChecklist;
   const fetchMock = vi.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
@@ -266,18 +323,31 @@ function mockProjectApi(
       return jsonResponse(currentStartChecklist);
     }
 
-    if (url.endsWith(`/projects/${currentProject.id}/start-checklist/award_contract`) && currentStartChecklist) {
+    const checklistItemPath = `/projects/${currentProject.id}/start-checklist/`;
+    if (url.includes(checklistItemPath) && options?.method === "PATCH" && currentStartChecklist) {
+      if (delayChecklistUpdates) {
+        await new Promise<void>((resolve) => {
+          releaseChecklistUpdate = resolve;
+        });
+      }
       const payload = JSON.parse(String(options?.body));
+      const code = decodeURIComponent(url.slice(url.indexOf(checklistItemPath) + checklistItemPath.length));
+      const items = currentStartChecklist.items.map((item) =>
+        item.code === code
+          ? {
+              ...item,
+              completed: payload.completed,
+              changed_by: "test-admin@ironhousecontracting.com",
+              changed_at: "2026-08-21T10:00:00Z",
+            }
+          : item,
+      );
+      const completedCount = items.filter((item) => item.completed).length;
       currentStartChecklist = {
         ...currentStartChecklist,
-        status: payload.completed ? "ready" : "not_ready",
-        completed_count: payload.completed ? 1 : 0,
-        items: currentStartChecklist.items.map((item) => ({
-          ...item,
-          completed: payload.completed,
-          changed_by: "test-admin@ironhousecontracting.com",
-          changed_at: "2026-08-21T10:00:00Z",
-        })),
+        status: completedCount === currentStartChecklist.total_count ? "ready" : "not_ready",
+        completed_count: completedCount,
+        items,
       };
       return jsonResponse(currentStartChecklist);
     }

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -106,7 +106,7 @@ export function ProjectWorkspacePage() {
   }
 
   async function updateStartChecklistItem(code: string, completed: boolean) {
-    if (!selectedProject) return;
+    if (!selectedProject || savingChecklistCode) return;
     setSavingChecklistCode(code);
     setError(null);
     try {
@@ -506,7 +506,7 @@ function ProjectStartChecklistCard({
             <input
               type="checkbox"
               checked={item.completed}
-              disabled={savingCode === item.code}
+              disabled={savingCode !== null}
               onChange={(event) => onChange(item.code, event.target.checked)}
               className="mt-0.5 h-5 w-5 shrink-0 accent-signal-green"
             />

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -1,10 +1,14 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 from fastapi.testclient import TestClient
+from sqlalchemy import func, select
 
 from app.main import app
+from app.models.project import Project, ProjectStartChecklistItem
+from app.services.projects import _provision_project_start_checklist
+from conftest import TestingSessionLocal
 
 
 client = TestClient(app)
@@ -160,12 +164,62 @@ def test_awarded_job_start_readiness_is_derived_and_provisioning_is_idempotent()
     assert reprovisioned["completed_count"] == 10
 
 
+def test_checklist_provisioning_is_conflict_safe_before_commit() -> None:
+    with TestingSessionLocal() as db:
+        project = Project(
+            name="Concurrent Checklist Award",
+            status="awarded",
+            project_number="IH-2026-099",
+        )
+        db.add(project)
+        db.flush()
+
+        _provision_project_start_checklist(db, project.id)
+        _provision_project_start_checklist(db, project.id)
+        db.flush()
+
+        count = db.scalar(
+            select(func.count())
+            .select_from(ProjectStartChecklistItem)
+            .where(ProjectStartChecklistItem.project_id == project.id)
+        )
+
+    assert count == 10
+
+
 def test_non_awarded_project_has_no_start_checklist() -> None:
     project = client.post("/api/v1/projects", json={"name": "Open Tender"}).json()
 
     response = client.get(f"/api/v1/projects/{project['id']}/start-checklist")
 
     assert response.status_code == 404
+
+
+def test_legacy_awarded_project_is_not_backfilled_by_an_ordinary_update() -> None:
+    with TestingSessionLocal() as db:
+        project = Project(
+            name="Legacy Award Without Checklist",
+            status="awarded",
+            project_number="LEGACY-2025-001",
+            workspace_root="LEGACY-2025-001_LegacyAwardWithoutChecklist",
+            workspace_manifest_json={"legacy": True},
+            workspace_provisioned_at=datetime.now(UTC),
+        )
+        db.add(project)
+        db.commit()
+        project_id = project.id
+
+    before_update = client.get(f"/api/v1/projects/{project_id}/start-checklist")
+    updated = client.patch(
+        f"/api/v1/projects/{project_id}",
+        json={"name": "Legacy Award Renamed"},
+    )
+    after_update = client.get(f"/api/v1/projects/{project_id}/start-checklist")
+
+    assert before_update.status_code == 404
+    assert updated.status_code == 200
+    assert updated.json()["name"] == "Legacy Award Renamed"
+    assert after_update.status_code == 404
 
 
 def test_award_generation_skips_existing_numbers_and_preserves_explicit_number() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #245 / #244. The original PR merged before the review-fix commit reached its branch.

- make checklist provisioning conflict-safe under concurrent award requests
- serialize checklist checkbox writes so older responses cannot replace newer UI state
- expand the frontend fixture to all ten controls and prove 10/10 readiness
- prove non-awarded projects neither fetch nor render the checklist
- prove legacy awarded projects are not backfilled by ordinary updates
- clarify database persistence versus prohibited external side effects

## Validation

- focused project backend: 18 passed
- full backend with this fix and the stacked autosave slice: 438 passed
- full frontend with this fix and the stacked autosave slice: 86 passed
- TypeScript production build: passed
- Ruff: passed
- visual design lock: passed
- React Router RSC security boundary: passed
- `git diff --check`: passed

## Boundary

This is a corrective application change only. It does not deploy, mutate production data, create external folders, send notices, or change contracts.

Relates #244
