### PR TITLE
Add awarded-job launch dashboard

### DIFF
--- a/backend/app/api/v1/routes/projects.py
+++ b/backend/app/api/v1/routes/projects.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import CurrentUser
@@ -14,9 +14,10 @@ from app.schemas.project import (
     ProjectUpdate,
 )
 from app.schemas.project_folder import AwardedProjectWorkspace, ProjectFolderManifest, ProjectFolderRequest
+from app.schemas.project_launch import ProjectLaunchDashboard
 from app.schemas.project_readiness import ProjectReadinessResponse
 from app.schemas.project_start import ProjectStartChecklistRead, ProjectStartChecklistUpdate
-from app.services import project_folders, project_readiness, projects
+from app.services import project_folders, project_launch, project_readiness, projects
 
 router = APIRouter()
 DBSession = Annotated[Session, Depends(get_db)]
@@ -71,6 +72,20 @@ def read_awarded_project_workspace(project_id: UUID, db: DBSession) -> AwardedPr
 @router.get("/{project_id}/start-checklist", response_model=ProjectStartChecklistRead)
 def read_project_start_checklist(project_id: UUID, db: DBSession) -> ProjectStartChecklistRead:
     return projects.get_project_start_checklist(db, project_id)
+
+
+@router.get("/{project_id}/launch-dashboard", response_model=ProjectLaunchDashboard)
+def read_project_launch_dashboard(
+    project_id: UUID,
+    user: CurrentUser,
+    db: DBSession,
+) -> ProjectLaunchDashboard:
+    if user.role not in {"admin", "operations_manager", "estimator"}:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Management or estimating access is required for the job launch dashboard.",
+        )
+    return project_launch.get_project_launch_dashboard(db, project_id)
 
 
 @router.patch("/{project_id}/start-checklist/{code}", response_model=ProjectStartChecklistRead)

--- a/backend/app/schemas/project_launch.py
+++ b/backend/app/schemas/project_launch.py
@@ -1,0 +1,27 @@
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class ProjectLaunchNextControl(BaseModel):
+    code: str
+    category: str
+    label: str
+
+
+class ProjectLaunchDashboard(BaseModel):
+    project_id: UUID
+    job_number: str
+    mobilization_status: Literal["ready", "not_ready"]
+    checklist_completed_count: int
+    checklist_total_count: int
+    next_incomplete_control: ProjectLaunchNextControl | None
+    estimate_workspace_count: int
+    priced_estimate_available: bool
+    baseline_budget_total: float
+    budget_entry_count: int
+    po_request_count: int
+    pending_po_request_count: int
+    safety_record_counts: dict[str, int]
+    document_count: int

--- a/backend/app/services/project_launch.py
+++ b/backend/app/services/project_launch.py
@@ -1,0 +1,107 @@
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.errors import AppError
+from app.models.bid import Bid
+from app.models.document import Document
+from app.models.field_operations import FieldRecord
+from app.models.finance import FinancialEntry
+from app.models.project import Project, ProjectStartChecklistItem
+from app.schemas.project import ProjectStatus
+from app.schemas.project_launch import ProjectLaunchDashboard, ProjectLaunchNextControl
+
+SAFETY_RECORD_TYPES = (
+    "safety_permit",
+    "emergency_action_card",
+    "daily_hazard_assessment",
+    "toolbox_talk",
+    "corrective_action",
+)
+
+
+def get_project_launch_dashboard(db: Session, project_id: UUID) -> ProjectLaunchDashboard:
+    project = db.get(Project, project_id)
+    if project is None:
+        raise AppError("Project not found.", status_code=404)
+    if project.status != ProjectStatus.awarded.value or not project.project_number:
+        raise AppError("The launch dashboard is available only for awarded jobs.", status_code=409)
+
+    checklist = list(
+        db.scalars(
+            select(ProjectStartChecklistItem)
+            .where(ProjectStartChecklistItem.project_id == project_id)
+            .order_by(ProjectStartChecklistItem.sort_order)
+        ).all()
+    )
+    completed_count = sum(item.completed for item in checklist)
+    next_item = next((item for item in checklist if not item.completed), None)
+
+    bids = list(db.scalars(select(Bid).where(Bid.project_id == project_id)).all())
+    priced_estimate_available = any(
+        bid.total_amount is not None or bool((bid.bid_json or {}).get("summary"))
+        for bid in bids
+    )
+
+    budget_rows = list(
+        db.scalars(
+            select(FinancialEntry).where(
+                FinancialEntry.project_id == project_id,
+                FinancialEntry.entry_type == "budget",
+                FinancialEntry.status != "void",
+            )
+        ).all()
+    )
+    baseline_budget_total = round(sum(float(row.amount) for row in budget_rows), 2)
+
+    po_rows = list(
+        db.scalars(
+            select(FieldRecord).where(
+                FieldRecord.project_id == project_id,
+                FieldRecord.record_type == "purchase_order_request",
+            )
+        ).all()
+    )
+    safety_counts = {record_type: 0 for record_type in SAFETY_RECORD_TYPES}
+    safety_rows = db.execute(
+        select(FieldRecord.record_type, func.count(FieldRecord.id))
+        .where(
+            FieldRecord.project_id == project_id,
+            FieldRecord.record_type.in_(SAFETY_RECORD_TYPES),
+        )
+        .group_by(FieldRecord.record_type)
+    ).all()
+    for record_type, count in safety_rows:
+        safety_counts[str(record_type)] = int(count)
+
+    document_count = int(
+        db.scalar(select(func.count(Document.id)).where(Document.project_id == project_id)) or 0
+    )
+    total_count = len(checklist)
+    return ProjectLaunchDashboard(
+        project_id=project.id,
+        job_number=project.project_number,
+        mobilization_status=(
+            "ready" if total_count > 0 and completed_count == total_count else "not_ready"
+        ),
+        checklist_completed_count=completed_count,
+        checklist_total_count=total_count,
+        next_incomplete_control=(
+            ProjectLaunchNextControl(
+                code=next_item.code,
+                category=next_item.category,
+                label=next_item.label,
+            )
+            if next_item
+            else None
+        ),
+        estimate_workspace_count=len(bids),
+        priced_estimate_available=priced_estimate_available,
+        baseline_budget_total=baseline_budget_total,
+        budget_entry_count=len(budget_rows),
+        po_request_count=len(po_rows),
+        pending_po_request_count=sum(row.status == "pending_approval" for row in po_rows),
+        safety_record_counts=safety_counts,
+        document_count=document_count,
+    )

--- a/docs/awarded-job-launch-dashboard.md
+++ b/docs/awarded-job-launch-dashboard.md
@@ -1,0 +1,37 @@
+# Awarded-job launch dashboard
+
+## Purpose
+
+The project workspace gives management and estimators one read-only launch view after a project is awarded. The dashboard connects the generated job number and project-start checklist to the estimate, baseline budget, purchase-order requests, safety records, and project documents.
+
+The dashboard does not copy or own those source records. It derives the current summary from each operational register so the figures cannot drift from the records they represent.
+
+## Access and scope
+
+- The dashboard is available only for awarded projects with a job number.
+- Administrators, operations managers, and estimators can read it.
+- Employee/viewer accounts cannot read the management launch summary.
+- Every count and total is filtered to the selected project.
+
+## Readiness rule
+
+Mobilization readiness is determined only by the ten-item awarded-job start checklist. Estimate, budget, PO, safety, and document values are indicators and never create or imply an approval.
+
+The next incomplete checklist control is shown so management has one clear next action. When all ten controls are checked, the dashboard reports the job as ready. Source documents, permits, engineering approvals, and project-specific evidence remain required where applicable.
+
+## Derived indicators
+
+- estimate workspace count and whether a priced estimate exists;
+- active baseline-budget total and entry count (void entries excluded);
+- project PO-request count and pending-approval count;
+- counts for project safety permits, emergency cards, hazard assessments, toolbox talks, and corrective actions; and
+- project document count.
+
+Direct links preserve the project ID and name when opening Estimating, Finance, PO Requests, Safety Operations, or Documents.
+Confidential incident and first-aid occurrence counts are deliberately excluded from the estimator-visible launch summary.
+
+## API
+
+`GET /api/v1/projects/{project_id}/launch-dashboard`
+
+The endpoint returns `409` when the project has not been awarded, `403` for a role without management/estimating access, and `404` when the project does not exist.

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -103,6 +103,29 @@ export type ProjectStartChecklist = {
   items: ProjectStartChecklistItem[];
 };
 
+export type ProjectLaunchNextControl = {
+  code: string;
+  category: string;
+  label: string;
+};
+
+export type ProjectLaunchDashboard = {
+  project_id: string;
+  job_number: string;
+  mobilization_status: "ready" | "not_ready";
+  checklist_completed_count: number;
+  checklist_total_count: number;
+  next_incomplete_control: ProjectLaunchNextControl | null;
+  estimate_workspace_count: number;
+  priced_estimate_available: boolean;
+  baseline_budget_total: number;
+  budget_entry_count: number;
+  po_request_count: number;
+  pending_po_request_count: number;
+  safety_record_counts: Record<string, number>;
+  document_count: number;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -161,6 +184,7 @@ export const projectsApi = {
     }),
   dashboard: (id: string) => request<ProjectDashboard>(`/projects/${id}/dashboard`),
   workspace: (id: string) => request<AwardedProjectWorkspace>(`/projects/${id}/workspace`),
+  launchDashboard: (id: string) => request<ProjectLaunchDashboard>(`/projects/${id}/launch-dashboard`),
   startChecklist: (id: string) => requestOptional<ProjectStartChecklist>(`/projects/${id}/start-checklist`),
   updateStartChecklistItem: (id: string, code: string, completed: boolean) =>
     request<ProjectStartChecklist>(`/projects/${id}/start-checklist/${encodeURIComponent(code)}`, {

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -3,7 +3,13 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { AwardedProjectWorkspace, Project, ProjectDashboard, ProjectStartChecklist } from "../api/projects";
+import {
+  AwardedProjectWorkspace,
+  Project,
+  ProjectDashboard,
+  ProjectLaunchDashboard,
+  ProjectStartChecklist,
+} from "../api/projects";
 import { ProjectWorkspacePage } from "./ProjectWorkspacePage";
 
 const project: Project = {
@@ -91,6 +97,33 @@ const awardedStartChecklist: ProjectStartChecklist = {
   })),
 };
 
+const awardedLaunchDashboard: ProjectLaunchDashboard = {
+  project_id: awardedProject.id,
+  job_number: "IH-2026-014",
+  mobilization_status: "not_ready",
+  checklist_completed_count: 0,
+  checklist_total_count: 10,
+  next_incomplete_control: {
+    code: "award_contract",
+    category: "Contract",
+    label: "Award notice or executed contract and the client scope record are saved.",
+  },
+  estimate_workspace_count: 1,
+  priced_estimate_available: true,
+  baseline_budget_total: 125000,
+  budget_entry_count: 4,
+  po_request_count: 3,
+  pending_po_request_count: 2,
+  safety_record_counts: {
+    safety_permit: 1,
+    emergency_action_card: 1,
+    daily_hazard_assessment: 2,
+    toolbox_talk: 1,
+    corrective_action: 0,
+  },
+  document_count: 7,
+};
+
 let releaseChecklistUpdate: (() => void) | null = null;
 
 afterEach(() => {
@@ -145,8 +178,10 @@ describe("ProjectWorkspacePage", () => {
     expect(screen.getByText("City of Surrey - Surrey")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Archive" })).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Awarded project workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Job launch dashboard" })).not.toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Awarded job start checklist" })).not.toBeInTheDocument();
     expect(fetchMock.mock.calls.some(([url]) => url.toString().includes("/start-checklist"))).toBe(false);
+    expect(fetchMock.mock.calls.some(([url]) => url.toString().includes("/launch-dashboard"))).toBe(false);
   });
 
   it("shows the stable prepared workspace for an awarded job", async () => {
@@ -159,6 +194,27 @@ describe("ProjectWorkspacePage", () => {
     expect(workspace).toHaveTextContent("IH-2026-014_AwardedCulvertReplacement");
     expect(within(workspace).getByText("00_Admin")).toBeInTheDocument();
     expect(within(workspace).getByText("13_Award_Handoff")).toBeInTheDocument();
+  });
+
+  it("shows awarded-job launch indicators with project-scoped handoff links", async () => {
+    mockProjectApi(awardedProject, awardedWorkspace, awardedStartChecklist, false, awardedLaunchDashboard);
+
+    renderWorkspace(`/projects/${awardedProject.id}`);
+
+    const launch = await screen.findByRole("region", { name: "Job launch dashboard" });
+    expect(launch).toHaveTextContent("Mobilization controls not ready");
+    expect(launch).toHaveTextContent("0 of 10");
+    expect(launch).toHaveTextContent("Available");
+    expect(launch).toHaveTextContent("$125,000");
+    expect(launch).toHaveTextContent("3");
+    expect(launch).toHaveTextContent("5");
+    expect(launch).toHaveTextContent("Only the project-start checklist determines");
+
+    for (const name of ["Estimate", "Budget", "Purchase orders", "Safety", "Documents"]) {
+      const link = within(launch).getByRole("link", { name: new RegExp(name) });
+      expect(link).toHaveAttribute("href", expect.stringContaining(`projectId=${awardedProject.id}`));
+      expect(link).toHaveAttribute("href", expect.stringContaining("projectName=Awarded+Culvert+Replacement"));
+    }
   });
 
   it("updates awarded-job readiness by selecting a pre-populated checklist item", async () => {
@@ -292,6 +348,7 @@ function mockProjectApi(
   workspace?: AwardedProjectWorkspace,
   startChecklist?: ProjectStartChecklist,
   delayChecklistUpdates = false,
+  launchDashboard: ProjectLaunchDashboard = awardedLaunchDashboard,
 ) {
   let currentStartChecklist = startChecklist;
   const fetchMock = vi.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
@@ -321,6 +378,20 @@ function mockProjectApi(
 
     if (url.endsWith(`/projects/${currentProject.id}/start-checklist`) && currentStartChecklist) {
       return jsonResponse(currentStartChecklist);
+    }
+
+    if (url.endsWith(`/projects/${currentProject.id}/launch-dashboard`) && workspace) {
+      return jsonResponse({
+        ...launchDashboard,
+        project_id: currentProject.id,
+        job_number: currentProject.project_number,
+        mobilization_status: currentStartChecklist?.status ?? launchDashboard.mobilization_status,
+        checklist_completed_count: currentStartChecklist?.completed_count ?? launchDashboard.checklist_completed_count,
+        checklist_total_count: currentStartChecklist?.total_count ?? launchDashboard.checklist_total_count,
+        next_incomplete_control: currentStartChecklist
+          ? currentStartChecklist.items.find((item) => !item.completed) ?? null
+          : launchDashboard.next_incomplete_control,
+      });
     }
 
     const checklistItemPath = `/projects/${currentProject.id}/start-checklist/`;

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -7,6 +7,7 @@ import {
   Project,
   ProjectCreatePayload,
   ProjectDashboard,
+  ProjectLaunchDashboard,
   ProjectStartChecklist,
   ProjectStatus,
   projectStatuses,
@@ -36,6 +37,7 @@ export function ProjectWorkspacePage() {
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [dashboard, setDashboard] = useState<ProjectDashboard | null>(null);
   const [workspace, setWorkspace] = useState<AwardedProjectWorkspace | null>(null);
+  const [launchDashboard, setLaunchDashboard] = useState<ProjectLaunchDashboard | null>(null);
   const [startChecklist, setStartChecklist] = useState<ProjectStartChecklist | null>(null);
   const [savingChecklistCode, setSavingChecklistCode] = useState<string | null>(null);
   const [dashboardByProjectId, setDashboardByProjectId] = useState<Record<string, ProjectDashboard>>({});
@@ -56,19 +58,22 @@ export function ProjectWorkspacePage() {
       setDashboardByProjectId(Object.fromEntries(summaries));
       if (projectId) {
         const detail = await projectsApi.detail(projectId);
-        const [summary, provisionedWorkspace, provisionedStartChecklist] = await Promise.all([
+        const [summary, provisionedWorkspace, provisionedStartChecklist, launchSummary] = await Promise.all([
           projectsApi.dashboard(projectId),
           detail.workspace_root ? projectsApi.workspace(projectId) : Promise.resolve(null),
           detail.workspace_root ? projectsApi.startChecklist(projectId) : Promise.resolve(null),
+          detail.workspace_root ? projectsApi.launchDashboard(projectId) : Promise.resolve(null),
         ]);
         setSelectedProject(detail);
         setDashboard(summary);
         setWorkspace(provisionedWorkspace);
+        setLaunchDashboard(launchSummary);
         setStartChecklist(provisionedStartChecklist);
       } else {
         setSelectedProject(null);
         setDashboard(null);
         setWorkspace(null);
+        setLaunchDashboard(null);
         setStartChecklist(null);
       }
     } catch (currentError) {
@@ -112,6 +117,17 @@ export function ProjectWorkspacePage() {
     try {
       const updated = await projectsApi.updateStartChecklistItem(selectedProject.id, code, completed);
       setStartChecklist(updated);
+      setLaunchDashboard((current) =>
+        current
+          ? {
+              ...current,
+              mobilization_status: updated.status,
+              checklist_completed_count: updated.completed_count,
+              checklist_total_count: updated.total_count,
+              next_incomplete_control: updated.items.find((item) => !item.completed) ?? null,
+            }
+          : current,
+      );
     } catch (currentError) {
       setError(currentError instanceof Error ? currentError.message : "Unable to update the job start checklist");
     } finally {
@@ -152,6 +168,7 @@ export function ProjectWorkspacePage() {
             project={selectedProject}
             dashboard={dashboard}
             workspace={workspace}
+            launchDashboard={launchDashboard}
             startChecklist={startChecklist}
             savingChecklistCode={savingChecklistCode}
             activeTab={activeTab}
@@ -339,6 +356,7 @@ function ProjectDetail({
   project,
   dashboard,
   workspace,
+  launchDashboard,
   startChecklist,
   savingChecklistCode,
   activeTab,
@@ -350,6 +368,7 @@ function ProjectDetail({
   project: Project;
   dashboard: ProjectDashboard;
   workspace: AwardedProjectWorkspace | null;
+  launchDashboard: ProjectLaunchDashboard | null;
   startChecklist: ProjectStartChecklist | null;
   savingChecklistCode: string | null;
   activeTab: string;
@@ -393,6 +412,7 @@ function ProjectDetail({
       </div>
 
       {workspace ? <AwardedWorkspaceCard workspace={workspace} /> : null}
+      {launchDashboard ? <ProjectLaunchDashboardCard dashboard={launchDashboard} project={project} /> : null}
       {startChecklist ? (
         <ProjectStartChecklistCard
           checklist={startChecklist}
@@ -422,6 +442,103 @@ function ProjectDetail({
           <TabBody tab={activeTab} project={project} dashboard={dashboard} />
         </div>
       </div>
+    </div>
+  );
+}
+
+function ProjectLaunchDashboardCard({
+  dashboard,
+  project,
+}: {
+  dashboard: ProjectLaunchDashboard;
+  project: Project;
+}) {
+  const safetyRecordCount = Object.values(dashboard.safety_record_counts).reduce((total, count) => total + count, 0);
+  const ready = dashboard.mobilization_status === "ready";
+  const actions = [
+    { label: "Estimate", href: "/estimating", description: "Confirm the priced estimate and handoff." },
+    { label: "Budget", href: "/finance", description: "Establish the baseline budget and cost codes." },
+    { label: "Purchase orders", href: "/request-po", description: "Prepare and route project PO requests." },
+    { label: "Safety", href: "/safety-operations", description: "Create project-specific safety records." },
+    { label: "Documents", href: "/documents", description: "Register current award and construction files." },
+  ];
+  return (
+    <section aria-label="Job launch dashboard" className="rounded-md border border-brand-gold/40 bg-white p-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <Activity className="h-5 w-5 text-brand-gold" aria-hidden="true" />
+            <h2 className="text-base font-semibold text-iron-950">Job launch dashboard</h2>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-iron-500">
+            One view of the records needed to move {dashboard.job_number} from award into controlled mobilization.
+          </p>
+        </div>
+        <span
+          className={[
+            "w-fit rounded-md px-3 py-2 text-xs font-semibold",
+            ready ? "bg-signal-green/10 text-signal-green" : "bg-brand-gold/10 text-iron-800",
+          ].join(" ")}
+        >
+          {ready ? "Mobilization controls ready" : "Mobilization controls not ready"}
+        </span>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        <LaunchMetric
+          label="Start checklist"
+          value={`${dashboard.checklist_completed_count} of ${dashboard.checklist_total_count}`}
+          detail={dashboard.next_incomplete_control ? `Next: ${dashboard.next_incomplete_control.label}` : "All controls confirmed."}
+        />
+        <LaunchMetric
+          label="Priced estimate"
+          value={dashboard.priced_estimate_available ? "Available" : "Missing"}
+          detail={`${dashboard.estimate_workspace_count} estimate workspace${dashboard.estimate_workspace_count === 1 ? "" : "s"}`}
+        />
+        <LaunchMetric
+          label="Baseline budget"
+          value={formatCurrency(dashboard.baseline_budget_total)}
+          detail={`${dashboard.budget_entry_count} active budget entr${dashboard.budget_entry_count === 1 ? "y" : "ies"}`}
+        />
+        <LaunchMetric
+          label="PO requests"
+          value={String(dashboard.po_request_count)}
+          detail={`${dashboard.pending_po_request_count} awaiting approval`}
+        />
+        <LaunchMetric
+          label="Safety records"
+          value={String(safetyRecordCount)}
+          detail="Project-linked records only"
+        />
+        <LaunchMetric label="Documents" value={String(dashboard.document_count)} detail="Project-linked records only" />
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        {actions.map((action) => (
+          <Link
+            key={action.label}
+            to={withProjectContext(action.href, project)}
+            className="rounded-md border border-iron-100 p-3 hover:bg-iron-50"
+          >
+            <span className="block text-sm font-semibold text-iron-950">{action.label}</span>
+            <span className="mt-1 block text-xs leading-5 text-iron-500">{action.description}</span>
+          </Link>
+        ))}
+      </div>
+      <p className="mt-4 text-xs leading-5 text-iron-500">
+        Estimate, budget, PO, safety, and document totals are launch indicators. Only the project-start checklist determines the
+        mobilization-ready status; no approval is inferred from a record count.
+      </p>
+    </section>
+  );
+}
+
+function LaunchMetric({ label: itemLabel, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="rounded-md border border-iron-100 bg-iron-50 p-4">
+      <div className="text-xs font-semibold uppercase tracking-wide text-iron-500">{itemLabel}</div>
+      <div className="mt-2 text-xl font-semibold text-iron-950">{value}</div>
+      <p className="mt-1 text-xs leading-5 text-iron-500">{detail}</p>
     </div>
   );
 }
@@ -675,6 +792,14 @@ function getNextStep(project: Project, dashboard: ProjectDashboard) {
   if (dashboard.rfq_count === 0) return "create RFQ packages for pipe, aggregates, asphalt, concrete, testing, and specialty scopes.";
   if (dashboard.readiness_percentage < 80) return "finish RFQ readiness items before final pricing.";
   return "build the estimate, compare quotes, and assemble the bid package.";
+}
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
 function Field({ label: itemLabel, children }: { label: string; children: React.ReactNode }) {

--- a/tests/backend/test_project_launch.py
+++ b/tests/backend/test_project_launch.py
@@ -1,0 +1,239 @@
+from datetime import date
+from uuid import UUID
+
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from app.api.dependencies.auth import require_authenticated_user
+from app.main import app
+from app.models.bid import Bid
+from app.models.document import Document
+from app.models.field_operations import FieldRecord
+from app.models.finance import FinancialEntry
+from app.services.auth import AuthenticatedUser
+from conftest import TestingSessionLocal, override_authenticated_user
+
+
+client = TestClient(app)
+
+
+def create_awarded_project(name: str = "Launch Dashboard Job") -> dict:
+    response = client.post(
+        "/api/v1/projects",
+        json={"name": name, "status": "awarded"},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+def test_awarded_project_launch_dashboard_starts_with_derived_controls() -> None:
+    project = create_awarded_project()
+
+    response = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "project_id": project["id"],
+        "job_number": project["project_number"],
+        "mobilization_status": "not_ready",
+        "checklist_completed_count": 0,
+        "checklist_total_count": 10,
+        "next_incomplete_control": {
+            "code": "award_contract",
+            "category": "Contract",
+            "label": "Award notice or executed contract and the client scope record are saved.",
+        },
+        "estimate_workspace_count": 0,
+        "priced_estimate_available": False,
+        "baseline_budget_total": 0.0,
+        "budget_entry_count": 0,
+        "po_request_count": 0,
+        "pending_po_request_count": 0,
+        "safety_record_counts": {
+            "safety_permit": 0,
+            "emergency_action_card": 0,
+            "daily_hazard_assessment": 0,
+            "toolbox_talk": 0,
+            "corrective_action": 0,
+        },
+        "document_count": 0,
+    }
+
+
+def test_launch_dashboard_summarizes_existing_source_records_without_inferred_approval() -> None:
+    project = create_awarded_project("Populated Launch Job")
+    project_id = UUID(project["id"])
+
+    with TestingSessionLocal() as db:
+        db.add_all(
+            [
+                Bid(
+                    project_id=project_id,
+                    status="draft",
+                    total_amount=125000,
+                    summary="Priced estimate",
+                    bid_json={"summary": {"total": 125000}},
+                ),
+                FinancialEntry(
+                    project_id=project_id,
+                    cost_code="01-100",
+                    entry_type="budget",
+                    category="labour",
+                    amount=75000,
+                    entry_date=date(2026, 8, 21),
+                    source_type="estimate",
+                    status="posted",
+                    metadata_json={},
+                    created_by="test-admin@ironhousecontracting.com",
+                ),
+                FinancialEntry(
+                    project_id=project_id,
+                    cost_code="02-100",
+                    entry_type="budget",
+                    category="materials",
+                    amount=25000,
+                    entry_date=date(2026, 8, 21),
+                    source_type="estimate",
+                    status="void",
+                    metadata_json={},
+                    created_by="test-admin@ironhousecontracting.com",
+                ),
+                FieldRecord(
+                    record_type="purchase_order_request",
+                    project_id=project_id,
+                    work_date=date(2026, 8, 21),
+                    title="Pipe and fittings",
+                    status="pending_approval",
+                    severity="none",
+                    details={},
+                    document_ids=[],
+                    signatures=[],
+                    alert_recipients=[],
+                ),
+                FieldRecord(
+                    record_type="purchase_order_request",
+                    project_id=project_id,
+                    work_date=date(2026, 8, 21),
+                    title="Aggregate",
+                    status="approved",
+                    severity="none",
+                    details={},
+                    document_ids=[],
+                    signatures=[],
+                    alert_recipients=[],
+                ),
+                FieldRecord(
+                    record_type="safety_permit",
+                    project_id=project_id,
+                    work_date=date(2026, 8, 21),
+                    title="Ground disturbance permit",
+                    status="ready",
+                    severity="high",
+                    details={},
+                    document_ids=[],
+                    signatures=[],
+                    alert_recipients=[],
+                ),
+                FieldRecord(
+                    record_type="toolbox_talk",
+                    project_id=project_id,
+                    work_date=date(2026, 8, 21),
+                    title="Mobilization talk",
+                    status="submitted",
+                    severity="none",
+                    details={},
+                    document_ids=[],
+                    signatures=[],
+                    alert_recipients=[],
+                ),
+                FieldRecord(
+                    record_type="incident",
+                    project_id=project_id,
+                    work_date=date(2026, 8, 21),
+                    title="Confidential occurrence",
+                    status="reported",
+                    severity="high",
+                    details={"occurrence_kind": "incident"},
+                    document_ids=[],
+                    signatures=[],
+                    alert_recipients=[],
+                ),
+                Document(
+                    project_id=project_id,
+                    title="Issued for construction drawing",
+                    category="drawing",
+                    status="registered",
+                    metadata_json={},
+                ),
+            ]
+        )
+        db.commit()
+
+    response = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["priced_estimate_available"] is True
+    assert body["estimate_workspace_count"] == 1
+    assert body["baseline_budget_total"] == 75000.0
+    assert body["budget_entry_count"] == 1
+    assert body["po_request_count"] == 2
+    assert body["pending_po_request_count"] == 1
+    assert body["safety_record_counts"]["safety_permit"] == 1
+    assert body["safety_record_counts"]["toolbox_talk"] == 1
+    assert "incident" not in body["safety_record_counts"]
+    assert body["document_count"] == 1
+    assert body["mobilization_status"] == "not_ready"
+
+
+def test_launch_dashboard_readiness_follows_only_the_project_start_checklist() -> None:
+    project = create_awarded_project("Ready Launch Job")
+    checklist = client.get(f"/api/v1/projects/{project['id']}/start-checklist").json()
+
+    for item in checklist["items"]:
+        response = client.patch(
+            f"/api/v1/projects/{project['id']}/start-checklist/{item['code']}",
+            json={"completed": True},
+        )
+        assert response.status_code == 200
+
+    response = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard")
+
+    assert response.status_code == 200
+    assert response.json()["mobilization_status"] == "ready"
+    assert response.json()["checklist_completed_count"] == 10
+    assert response.json()["next_incomplete_control"] is None
+
+
+def test_launch_dashboard_rejects_non_awarded_projects() -> None:
+    project = client.post(
+        "/api/v1/projects",
+        json={"name": "Still Tendering", "status": "tendering"},
+    ).json()
+
+    response = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard")
+
+    assert response.status_code == 409
+
+
+def test_launch_dashboard_blocks_viewer_role() -> None:
+    project = create_awarded_project("Management Only Launch Job")
+
+    def viewer_user(request: Request) -> AuthenticatedUser:
+        user = AuthenticatedUser(
+            id=UUID("00000000-0000-0000-0000-000000000099"),
+            email="viewer@ironhousecontracting.com",
+            display_name="Viewer",
+            role="viewer",
+            session_version=1,
+        )
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = viewer_user
+    try:
+        response = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard")
+    finally:
+        app.dependency_overrides[require_authenticated_user] = override_authenticated_user
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary

- add a read-only launch dashboard for awarded jobs with permanent job numbers
- derive project-start readiness from the existing ten-item checklist
- summarize priced estimate workspaces, active baseline budget, PO requests, non-confidential safety controls, and project documents
- show the next incomplete mobilization control
- preserve project context in direct links to Estimating, Finance, PO Requests, Safety Operations, and Documents
- exclude confidential incident and first-aid occurrence counts from the estimator-visible summary

## Stack

This draft is stacked on direct-to-main PR #253. Retarget this PR to `main` after #253 lands.

Closes #252

## Validation

- Backend full suite: 413 passed (1 existing warning)
- Frontend full suite: 88 passed
- Launch dashboard backend: 5 passed
- Project workspace frontend: 10 passed
- TypeScript production build: passed
- Ruff: passed
- Visual design lock: passed
- React Router RSC boundary: passed
- `git diff --check`: passed

## Controls

Only administrators, operations managers, and estimators can read the launch summary. Record totals are indicators only; the project-start checklist remains the sole mobilization-ready gate. No approval, purchase, deployment, or production data mutation is performed.