### PR TITLE
Guide quote-to-job work from one queue

### DIFF
--- a/docs/guided-mvp-workflow.md
+++ b/docs/guided-mvp-workflow.md
@@ -1,0 +1,40 @@
+# Guided MVP workflow
+
+## Purpose
+
+The MVP Workflow page is the operational starting point for customer work. It replaces the former static module list with a live, read-only work queue derived from Customer Quotes, Projects, awarded-job launch summaries, and owner-scoped unfinished forms.
+
+## Quote-to-job stages
+
+1. Capture the verbal request as a durable Customer Quote and linked opportunity.
+2. Finish the quote, record that it was sent, and record the customer's decision.
+3. Management acceptance records the evidence, awards the linked project, and creates the permanent job number.
+4. Complete the awarded-job start controls and handoffs for estimate, budget, purchase orders, safety, and documents.
+5. Continue the ready job through Project Operations and field delivery.
+
+The work queue derives one next action for each active item:
+
+- draft quote: finish and send the quote;
+- sent quote: record acceptance, decline, expiry, or a revised scope;
+- awarded job with incomplete controls: open the Project Workspace and complete the launch checklist;
+- launch-ready job: begin Project Operations;
+- construction job: continue Project Operations; and
+- tender or unquoted opportunity: open the Project Workspace and choose the correct workflow.
+
+An active quote and its automatically created opportunity appear as one queue item, not duplicates.
+
+## Project context
+
+Queue links carry both the project ID and name. Project Operations, Finance, PO Requests, Safety Operations, and Documents open in that project context. New project-linked safety controls persist the project ID, and the PO and Finance modules preselect the routed job.
+
+A requested durable draft remains authoritative when a `draftId` is present. Otherwise, an explicit project link takes priority over a device recovery buffer when the PO form opens.
+
+## Partial availability
+
+Customer Quotes, Projects, workflow drafts, and each awarded-job launch summary load independently. If one source is temporarily unavailable, IHOS identifies the missing status and keeps the successfully loaded work usable. A single failed request must not blank the workflow page.
+
+## Controls
+
+The queue does not send a quote, record customer acceptance, award work, approve a budget or PO, create safety evidence, or deploy software. It routes the user to the existing controlled action. Quote decline and expiry require explicit confirmation, and reopening either state requires a new quote revision.
+
+The formal tender tools remain available separately for document, takeoff, estimating, RFQ, and bid-package work.

--- a/frontend/src/pages/CustomerQuotesPage.test.tsx
+++ b/frontend/src/pages/CustomerQuotesPage.test.tsx
@@ -21,7 +21,7 @@ function json(payload: unknown, status = 200) {
   });
 }
 
-function quote(status: "draft" | "accepted", revision: number) {
+function quote(status: "draft" | "sent" | "accepted" | "declined" | "expired", revision: number) {
   return {
     id: "quote-1",
     project_id: "project-1",
@@ -74,6 +74,12 @@ describe("CustomerQuotesPage", () => {
       if (url.endsWith("/accept") && init?.method === "POST") {
         quoteBodies.push(JSON.parse(String(init.body)));
         savedQuote = quote("accepted", 2);
+        return json(savedQuote);
+      }
+      if (url.endsWith("/status") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body));
+        quoteBodies.push(body);
+        savedQuote = quote(body.status, 2);
         return json(savedQuote);
       }
       if (url.endsWith("/workflow-drafts") && init?.method === "POST") {
@@ -146,5 +152,32 @@ describe("CustomerQuotesPage", () => {
     expect(screen.getByText("IH-2026-001")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open Project Workspace/ })).toHaveAttribute("href", "/projects/project-1");
     await waitFor(() => expect(quoteBodies.at(-1)).toEqual(expect.objectContaining({ acceptance_reference: "Customer email" })));
+  });
+
+  it("opens a queued draft directly and records a sent quote decision", async () => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    savedQuote = quote("draft", 1);
+    const { unmount } = render(
+      <MemoryRouter initialEntries={["/customer-quotes?quoteId=quote-1&action=edit"]}>
+        <CustomerQuotesPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Edit Q-2026-001" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Project / work name")).toHaveValue("Smith drainage repair");
+    unmount();
+
+    savedQuote = quote("sent", 1);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/customer-quotes?quoteId=quote-1&action=decision"]}>
+        <CustomerQuotesPage />
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Mark declined" }));
+    await waitFor(() => expect(screen.getByText("declined")).toBeInTheDocument());
+    expect(quoteBodies.at(-1)).toEqual({ expected_revision: 1, status: "declined", note: null });
   });
 });

--- a/frontend/src/pages/CustomerQuotesPage.tsx
+++ b/frontend/src/pages/CustomerQuotesPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight, CheckCircle2, Plus, Trash2 } from "lucide-react";
-import { FormEvent, useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 
 import {
   CustomerQuote,
@@ -18,6 +18,8 @@ const blankLine = (): CustomerQuoteLineItem => ({ description: "", quantity: "1"
 
 export function CustomerQuotesPage() {
   const { user } = useAuth();
+  const location = useLocation();
+  const openedTarget = useRef<string | null>(null);
   const [quotes, setQuotes] = useState<CustomerQuote[]>([]);
   const [registerReady, setRegisterReady] = useState(false);
   const [editing, setEditing] = useState<CustomerQuote | null>(null);
@@ -53,6 +55,18 @@ export function CustomerQuotesPage() {
   }
 
   useEffect(() => { void refresh(); }, []);
+
+  useEffect(() => {
+    if (!registerReady) return;
+    const params = new URLSearchParams(location.search);
+    const quoteId = params.get("quoteId");
+    if (!quoteId || openedTarget.current === `${quoteId}:${params.get("action")}`) return;
+    const quote = quotes.find((item) => item.id === quoteId);
+    if (!quote) return;
+    openedTarget.current = `${quoteId}:${params.get("action")}`;
+    if (params.get("action") === "edit" && quote.status !== "accepted") edit(quote);
+    else document.getElementById(`quote-${quoteId}`)?.scrollIntoView?.({ behavior: "smooth", block: "center" });
+  }, [location.search, quotes, registerReady]);
 
   const draftPayload = useMemo(() => ({
     projectName,
@@ -193,6 +207,22 @@ export function CustomerQuotesPage() {
     }
   }
 
+  async function closeQuote(quote: CustomerQuote, status: "declined" | "expired") {
+    const confirmed = window.confirm(
+      status === "declined"
+        ? `Record ${quote.quote_number} as declined? A new revision is required to reopen it.`
+        : `Record ${quote.quote_number} as expired? A new revision is required to reopen it.`,
+    );
+    if (!confirmed) return;
+    setError(null);
+    try {
+      const result = await customerQuotesApi.status(quote.id, quote.record_revision, status);
+      setQuotes((current) => current.map((item) => item.id === result.id ? result : item));
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Unable to close the quote.");
+    }
+  }
+
   async function accept() {
     if (!accepting || !acceptanceReference.trim()) return;
     setSaving(true);
@@ -286,7 +316,10 @@ export function CustomerQuotesPage() {
         <h2 className="text-xl font-semibold text-iron-950">Customer quote register</h2>
         <p className="mt-1 text-sm text-iron-500">Draft and sent quotes have no job number. Only management acceptance creates an awarded job.</p>
         <div className="mt-4 overflow-x-auto"><table className="w-full text-left text-sm"><thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500"><tr><th className="px-3 py-2">Quote</th><th className="px-3 py-2">Customer / project</th><th className="px-3 py-2">Total</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Job</th><th className="px-3 py-2">Actions</th></tr></thead><tbody>
-          {quotes.map((quote) => <tr key={quote.id} className="border-t border-iron-100"><td className="px-3 py-3 font-semibold text-iron-950">{quote.quote_number}</td><td className="px-3 py-3"><div>{quote.customer_name}</div><div className="text-xs text-iron-500">{quote.project_name}</div></td><td className="px-3 py-3">{money.format(Number(quote.total))}</td><td className="px-3 py-3 capitalize">{quote.status}</td><td className="px-3 py-3">{quote.job_number ?? "Not awarded"}</td><td className="px-3 py-3"><div className="flex flex-wrap gap-2">{quote.status !== "accepted" && quote.status !== "declined" && quote.status !== "expired" ? <><button type="button" onClick={() => edit(quote)} className="font-semibold text-iron-700">Edit</button>{quote.status === "draft" ? <button type="button" onClick={() => void markSent(quote)} className="font-semibold text-iron-700">Mark sent</button> : null}{user?.role === "admin" || user?.role === "operations_manager" ? <button type="button" onClick={() => { setAccepting(quote); setAcceptanceReference(""); setAcceptanceNote(""); }} className="font-semibold text-emerald-700">Accept / award</button> : null}</> : null}<a href={customerQuotesApi.pdfUrl(quote.id)} target="_blank" rel="noopener noreferrer" className="font-semibold text-iron-700">Open PDF</a><Link to={`/projects/${quote.project_id}`} className="font-semibold text-iron-700">Project</Link></div></td></tr>)}
+          {quotes.map((quote) => {
+            const targeted = new URLSearchParams(location.search).get("quoteId") === quote.id;
+            return <tr id={`quote-${quote.id}`} key={quote.id} className={["border-t border-iron-100", targeted ? "bg-brand-gold/10" : ""].join(" ")}><td className="px-3 py-3 font-semibold text-iron-950">{quote.quote_number}</td><td className="px-3 py-3"><div>{quote.customer_name}</div><div className="text-xs text-iron-500">{quote.project_name}</div></td><td className="px-3 py-3">{money.format(Number(quote.total))}</td><td className="px-3 py-3 capitalize">{quote.status}</td><td className="px-3 py-3">{quote.job_number ?? "Not awarded"}</td><td className="px-3 py-3"><div className="flex flex-wrap gap-2">{quote.status !== "accepted" && quote.status !== "declined" && quote.status !== "expired" ? <><button type="button" onClick={() => edit(quote)} className="font-semibold text-iron-700">Edit</button>{quote.status === "draft" ? <button type="button" onClick={() => void markSent(quote)} className="font-semibold text-iron-700">Mark sent</button> : null}{user?.role === "admin" || user?.role === "operations_manager" ? <button type="button" onClick={() => { setAccepting(quote); setAcceptanceReference(""); setAcceptanceNote(""); }} className="font-semibold text-emerald-700">Accept / award</button> : null}<button type="button" onClick={() => void closeQuote(quote, "declined")} className="font-semibold text-red-700">Mark declined</button><button type="button" onClick={() => void closeQuote(quote, "expired")} className="font-semibold text-iron-500">Mark expired</button></> : null}<a href={customerQuotesApi.pdfUrl(quote.id)} target="_blank" rel="noopener noreferrer" className="font-semibold text-iron-700">Open PDF</a><Link to={`/projects/${quote.project_id}`} className="font-semibold text-iron-700">Project</Link></div></td></tr>;
+          })}
           {!quotes.length ? <tr><td colSpan={6} className="px-3 py-8 text-center text-iron-500">No customer quotes yet.</td></tr> : null}
         </tbody></table></div>
       </section>

--- a/frontend/src/pages/FinancialControlPage.test.tsx
+++ b/frontend/src/pages/FinancialControlPage.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BackupsIntake } from "../api/backups";
 import { financeApi } from "../api/finance";
+import { projectsApi } from "../api/projects";
 import { FinancialControlPage } from "./FinancialControlPage";
 
 vi.mock("../api/finance", () => ({ financeApi: { getBackupsReview: vi.fn(), getStartupExpenses: vi.fn(), getCustomerInvoices: vi.fn(() => Promise.resolve({ items: [], total: 0 })), getProject: vi.fn(), importEstimate: vi.fn(), createEntry: vi.fn(), createStartupExpense: vi.fn(), updateStartupExpense: vi.fn(), startupQuickBooksUrl: vi.fn(() => "#"), quickBooksUrl: vi.fn(() => "#"), customerInvoicePdfUrl: vi.fn(() => "#") } }));
@@ -18,6 +19,7 @@ const item: BackupsIntake = {
 describe("FinancialControlPage Backups queues", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.replaceState({}, "", "/finance");
     vi.mocked(financeApi.getStartupExpenses).mockResolvedValue({ total_startup_costs: 0, owner_loan_payable: 0, reimbursed_to_owner: 0, pending_review: 0, approved_unreimbursed: 0, entries: [] });
     vi.mocked(financeApi.getBackupsReview).mockImplementation(async (destination) => ({ items: destination === "finance_packing_slips" ? [item] : [], total: destination === "finance_packing_slips" ? 1 : 0 }));
   });
@@ -29,5 +31,32 @@ describe("FinancialControlPage Backups queues", () => {
     expect(screen.getByText(/quantity, quality, delivery acceptance, and project cost are not confirmed/i)).toBeInTheDocument();
     await waitFor(() => expect(financeApi.getBackupsReview).toHaveBeenCalledTimes(4));
     expect(screen.getByRole("img", { name: "Private Backups Packing Slips original" })).toHaveAttribute("src", "/private-media/media-1");
+  });
+
+  it("opens the linked project financial summary from workflow context", async () => {
+    window.history.replaceState({}, "", "/finance?projectId=project-7&projectName=Linked+Job");
+    vi.mocked(projectsApi.list).mockResolvedValue({
+      items: [{ id: "project-7", name: "Linked Job" }],
+      total: 1,
+    } as never);
+    vi.mocked(financeApi.getProject).mockResolvedValue({
+      project_id: "project-7",
+      project_name: "Linked Job",
+      contract_value: 0,
+      budget: 0,
+      committed: 0,
+      actual: 0,
+      forecast_cost: 0,
+      cost_variance: 0,
+      forecast_profit: 0,
+      forecast_margin_percent: 0,
+      entries: [],
+      cost_codes: [],
+    });
+
+    render(<FinancialControlPage />);
+
+    expect(await screen.findByRole("combobox", { name: "Project" })).toHaveValue("project-7");
+    await waitFor(() => expect(financeApi.getProject).toHaveBeenCalledWith("project-7"));
   });
 });

--- a/frontend/src/pages/FinancialControlPage.tsx
+++ b/frontend/src/pages/FinancialControlPage.tsx
@@ -8,13 +8,15 @@ import { ReceiptCapturePanel } from "../components/ReceiptCapturePanel";
 import { CustomerInvoicePanel } from "../components/CustomerInvoicePanel";
 import { financeApi, FinancialSummary, StartupExpenseSummary } from "../api/finance";
 import { projectsApi, Project } from "../api/projects";
+import { readEffectiveProjectContext } from "../utils/projectContext";
 
 const money = new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" });
 const today = () => new Date().toISOString().slice(0, 10);
 
 export function FinancialControlPage() {
+  const routedProjectId = readEffectiveProjectContext(window.location.search).projectId ?? "";
   const [projects, setProjects] = useState<Project[]>([]);
-  const [projectId, setProjectId] = useState("");
+  const [projectId, setProjectId] = useState(routedProjectId);
   const [summary, setSummary] = useState<FinancialSummary | null>(null);
   const [startup, setStartup] = useState<StartupExpenseSummary | null>(null);
   const [backupsReview, setBackupsReview] = useState<Record<string, BackupsIntake[]>>({});
@@ -22,7 +24,7 @@ export function FinancialControlPage() {
   const [startupDate, setStartupDate] = useState(today()); const [startupVendor, setStartupVendor] = useState(""); const [startupDescription, setStartupDescription] = useState(""); const [startupAmount, setStartupAmount] = useState(""); const [startupCategory, setStartupCategory] = useState("other"); const [startupReference, setStartupReference] = useState(""); const [startupOwner, setStartupOwner] = useState("");
   const [startupFiles, setStartupFiles] = useState<File[]>([]);
   const [error, setError] = useState<string | null>(null); const [loading, setLoading] = useState(false);
-  useEffect(() => { projectsApi.list().then((data) => setProjects(data.items)).catch(() => setError("Unable to load projects.")); void refreshStartup(); void refreshBackupsReview(); }, []);
+  useEffect(() => { projectsApi.list().then((data) => { setProjects(data.items); if (routedProjectId && data.items.some((project) => project.id === routedProjectId)) void refresh(routedProjectId); }).catch(() => setError("Unable to load projects.")); void refreshStartup(); void refreshBackupsReview(); }, []);
   async function refresh(id = projectId) { if (!id) return; setLoading(true); setError(null); try { setSummary(await financeApi.getProject(id)); } catch (current) { setError(current instanceof Error ? current.message : "Unable to load financials."); } finally { setLoading(false); } }
   async function refreshStartup() { try { setStartup(await financeApi.getStartupExpenses()); } catch (current) { setError(current instanceof Error ? current.message : "Unable to load startup costs."); } }
   async function refreshBackupsReview() { const destinations: BackupsReviewDestination[] = ["finance_intake", "finance_receipts", "finance_invoices", "finance_packing_slips"]; try { const queues = await Promise.all(destinations.map(async (destination) => [destination, (await financeApi.getBackupsReview(destination)).items] as const)); setBackupsReview(Object.fromEntries(queues)); } catch (current) { setError(current instanceof Error ? current.message : "Unable to load Backups review queues."); } }

--- a/frontend/src/pages/MVPWorkflowPage.test.tsx
+++ b/frontend/src/pages/MVPWorkflowPage.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { CustomerQuote } from "../api/customerQuotes";
+import { Project, ProjectLaunchDashboard } from "../api/projects";
 import { MVPWorkflowPage } from "./MVPWorkflowPage";
 
 const draft = {
@@ -20,26 +22,54 @@ const draft = {
   updated_at: "2026-08-21T06:30:00Z",
 };
 
-function response(payload: unknown) {
-  return new Response(JSON.stringify(payload), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
-}
+const draftQuote = customerQuote({
+  id: "quote-draft",
+  project_id: "quote-project-draft",
+  project_name: "Driveway culvert",
+  customer_name: "Morgan Lee",
+  quote_number: "Q-2026-001",
+  status: "draft",
+});
+const sentQuote = customerQuote({
+  id: "quote-sent",
+  project_id: "quote-project-sent",
+  project_name: "Storm repair",
+  customer_name: "Avery Chen",
+  quote_number: "Q-2026-002",
+  status: "sent",
+});
+const launchJob = project({
+  id: "project-launch",
+  name: "Awarded launch job",
+  status: "awarded",
+  project_number: "IH-2026-021",
+  workspace_root: "IH-2026-021_AwardedLaunchJob",
+});
+const readyJob = project({
+  id: "project-ready",
+  name: "Ready job",
+  status: "awarded",
+  project_number: "IH-2026-022",
+  workspace_root: "IH-2026-022_ReadyJob",
+});
+const constructionJob = project({
+  id: "project-construction",
+  name: "Active construction job",
+  status: "construction",
+  project_number: "IH-2026-020",
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe("MVPWorkflowPage", () => {
-  beforeEach(() => {
-    vi.stubGlobal("fetch", vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      if (init?.method === "POST") return response({ ...draft, status: "cancelled", revision: 4 });
-      return response({ items: [draft], total: 1 });
-    }));
-  });
-
-  afterEach(() => vi.unstubAllGlobals());
-
-  it("lists unfinished work with a direct resume link and audited discard action", async () => {
+  it("keeps durable unfinished work with direct resume and audited discard controls", async () => {
+    const fetchMock = mockApi({ drafts: [draft] });
     const user = userEvent.setup();
-    render(<MemoryRouter><MVPWorkflowPage /></MemoryRouter>);
+
+    renderWorkflow();
 
     expect(await screen.findByText("PO request — Pipe and fittings")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Continue" })).toHaveAttribute(
@@ -49,9 +79,217 @@ describe("MVPWorkflowPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Discard" }));
     await waitFor(() => expect(screen.queryByText("PO request — Pipe and fittings")).not.toBeInTheDocument());
-    expect(fetch).toHaveBeenLastCalledWith(
+    expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/workflow-drafts/draft-246/cancel"),
       expect.objectContaining({ method: "POST" }),
     );
   });
+
+  it("derives one next action from quote through award, launch, and delivery", async () => {
+    mockApi({
+      quotes: [draftQuote, sentQuote],
+      projects: [
+        project({ id: draftQuote.project_id, name: draftQuote.project_name }),
+        project({ id: sentQuote.project_id, name: sentQuote.project_name }),
+        launchJob,
+        readyJob,
+        constructionJob,
+      ],
+      launches: {
+        [launchJob.id]: launchDashboard(launchJob, "not_ready"),
+        [readyJob.id]: launchDashboard(readyJob, "ready"),
+      },
+    });
+
+    renderWorkflow();
+
+    const queue = await screen.findByLabelText("Active quote-to-job work queue");
+    const stages = screen.getByLabelText("Quote-to-job stages");
+    for (const label of ["Capture quote", "Record decision", "Award + job number", "Launch controls", "Deliver"]) {
+      expect(stages).toHaveTextContent(label);
+    }
+
+    const draftCard = within(queue).getByText("Morgan Lee — Driveway culvert").closest("article");
+    expect(draftCard).not.toBeNull();
+    expect(within(draftCard as HTMLElement).getByRole("link", { name: "Finish and send quote" })).toHaveAttribute(
+      "href",
+      "/customer-quotes?quoteId=quote-draft&action=edit",
+    );
+
+    const sentCard = within(queue).getByText("Avery Chen — Storm repair").closest("article");
+    expect(within(sentCard as HTMLElement).getByRole("link", { name: "Record customer decision" })).toHaveAttribute(
+      "href",
+      "/customer-quotes?quoteId=quote-sent&action=decision",
+    );
+
+    const launchCard = within(queue).getByText("Awarded launch job").closest("article");
+    expect(launchCard).toHaveTextContent("3 of 10 start controls");
+    expect(within(launchCard as HTMLElement).getByRole("link", { name: "Complete launch controls" })).toHaveAttribute(
+      "href",
+      `/projects/${launchJob.id}`,
+    );
+
+    const readyCard = within(queue).getByText("Ready job").closest("article");
+    expect(readyCard).toHaveTextContent("All 10 start controls are confirmed");
+    expect(within(readyCard as HTMLElement).getByRole("link", { name: "Begin project operations" })).toHaveAttribute(
+      "href",
+      expect.stringContaining(`/project-operations?projectId=${readyJob.id}`),
+    );
+    expect(within(readyCard as HTMLElement).getByRole("link", { name: "PO requests" })).toHaveAttribute(
+      "href",
+      expect.stringContaining(`/request-po?projectId=${readyJob.id}`),
+    );
+
+    const constructionCard = within(queue).getByText("Active construction job").closest("article");
+    expect(within(constructionCard as HTMLElement).getByRole("link", { name: "Continue project operations" })).toHaveAttribute(
+      "href",
+      expect.stringContaining(`projectId=${constructionJob.id}`),
+    );
+    expect(within(queue).getAllByRole("article")).toHaveLength(5);
+  });
+
+  it("keeps available work usable when one source fails", async () => {
+    mockApi({ projects: [constructionJob], failQuotes: true });
+
+    renderWorkflow();
+
+    expect(await screen.findByText("Customer quotes could not be loaded.")).toBeInTheDocument();
+    expect(screen.getByText("Available work remains usable below.")).toBeInTheDocument();
+    expect(screen.getByText("Active construction job")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Continue project operations" })).toBeInTheDocument();
+  });
 });
+
+function renderWorkflow() {
+  render(<MemoryRouter><MVPWorkflowPage /></MemoryRouter>);
+}
+
+function mockApi({
+  drafts = [],
+  quotes = [],
+  projects = [],
+  launches = {},
+  failQuotes = false,
+}: {
+  drafts?: (typeof draft)[];
+  quotes?: CustomerQuote[];
+  projects?: Project[];
+  launches?: Record<string, ProjectLaunchDashboard>;
+  failQuotes?: boolean;
+} = {}) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input.toString();
+    if (url.includes("/workflow-drafts/") && url.endsWith("/cancel") && init?.method === "POST") {
+      return response({ ...draft, status: "cancelled", revision: 4 });
+    }
+    if (url.endsWith("/workflow-drafts")) return response({ items: drafts, total: drafts.length });
+    if (url.endsWith("/customer-quotes")) {
+      return failQuotes ? response({ detail: "Unavailable" }, 503) : response({ items: quotes, total: quotes.length });
+    }
+    const launchMatch = url.match(/\/projects\/([^/]+)\/launch-dashboard$/);
+    if (launchMatch) {
+      const launch = launches[launchMatch[1]];
+      return launch ? response(launch) : response({ detail: "Unavailable" }, 503);
+    }
+    if (url.endsWith("/projects")) return response({ items: projects, total: projects.length });
+    return response({ detail: "Not found" }, 404);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function response(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function customerQuote(overrides: Partial<CustomerQuote>): CustomerQuote {
+  return {
+    id: "quote-1",
+    project_id: "project-1",
+    project_name: "Customer project",
+    quote_number: "Q-2026-001",
+    customer_name: "Customer",
+    customer_email: "customer@example.com",
+    customer_phone: null,
+    site_address: "100 Main Street",
+    scope_summary: "Quoted work",
+    line_items: [{ description: "Work", quantity: "1", unit: "LS", unit_price: "12000", amount: "12000" }],
+    assumptions: [],
+    exclusions: [],
+    subtotal: "12000.00",
+    gst_rate: "5.00",
+    gst: "600.00",
+    total: "12600.00",
+    quote_date: "2026-08-21",
+    valid_until: "2026-09-20",
+    status: "draft",
+    record_revision: 1,
+    notes: null,
+    created_by: "admin@ironhousecontracting.com",
+    sent_at: null,
+    accepted_at: null,
+    accepted_by: null,
+    acceptance_reference: null,
+    acceptance_note: null,
+    closed_at: null,
+    job_number: null,
+    created_at: "2026-08-21T00:00:00Z",
+    updated_at: "2026-08-21T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<Project>): Project {
+  return {
+    id: "project-1",
+    name: "Project",
+    client_owner: null,
+    municipality: null,
+    project_number: null,
+    tender_number: null,
+    tender_source: null,
+    tender_closing_date: null,
+    bid_due_date: null,
+    estimated_construction_start: null,
+    estimated_construction_finish: null,
+    project_address: null,
+    latitude: null,
+    longitude: null,
+    contract_value: null,
+    status: "opportunity",
+    notes: null,
+    metadata: {},
+    workspace_root: null,
+    workspace_provisioned_at: null,
+    supplier_ids: [],
+    created_at: "2026-08-21T00:00:00Z",
+    updated_at: "2026-08-21T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function launchDashboard(job: Project, status: "ready" | "not_ready"): ProjectLaunchDashboard {
+  return {
+    project_id: job.id,
+    job_number: job.project_number ?? "IH-2026-000",
+    mobilization_status: status,
+    checklist_completed_count: status === "ready" ? 10 : 3,
+    checklist_total_count: 10,
+    next_incomplete_control: status === "ready" ? null : {
+      code: "contacts_authority",
+      category: "Administration",
+      label: "Confirm project contacts and authority limits.",
+    },
+    estimate_workspace_count: 1,
+    priced_estimate_available: true,
+    baseline_budget_total: 100000,
+    budget_entry_count: 5,
+    po_request_count: 2,
+    pending_po_request_count: 1,
+    safety_record_counts: { safety_permit: 1 },
+    document_count: 4,
+  };
+}

--- a/frontend/src/pages/MVPWorkflowPage.tsx
+++ b/frontend/src/pages/MVPWorkflowPage.tsx
@@ -1,63 +1,181 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 
+import { CustomerQuote, customerQuotesApi } from "../api/customerQuotes";
+import { Project, ProjectLaunchDashboard, projectsApi } from "../api/projects";
 import { WorkflowDraft, workflowDraftsApi } from "../api/workflowDrafts";
-import { modulePathWithProjectContext, readEffectiveProjectContext } from "../utils/projectContext";
+import { modulePathWithProjectContext, readEffectiveProjectContext, withProjectContext } from "../utils/projectContext";
 
-const steps = [
-  { label: "1. Capture customer quote", path: "/customer-quotes", detail: "Turn verbal customer information into a durable IHOS opportunity and quote." },
-  { label: "2. Create or select project", path: "/projects", detail: "Open the project workspace for tender, estimate, or awarded-job work." },
-  { label: "3. Register documents", path: "/documents", detail: "Add drawings, specs, addenda, and source documents." },
-  { label: "4. Run takeoff", path: "/quantity-takeoff", detail: "Generate BOQ items, readiness checks, and estimating handoff items." },
-  { label: "5. Build estimate", path: "/estimating", detail: "Convert scope into estimate lines, calculate pricing, and export workbooks." },
-  { label: "6. Build RFQs", path: "/rfq-automation", detail: "Create supplier package drafts from takeoff and estimate categories." },
-  { label: "7. Final bid package", path: "/bid-package", detail: "Review assumptions, exclusions, risks, and final bid readiness." },
+const flowStages = ["Capture quote", "Record decision", "Award + job number", "Launch controls", "Deliver"];
+
+const tenderTools = [
+  { label: "Project workspace", path: "/projects", detail: "Open a formal tender or an existing project." },
+  { label: "Documents", path: "/documents", detail: "Register drawings, specifications, addenda, and source files." },
+  { label: "Quantity takeoff", path: "/quantity-takeoff", detail: "Prepare quantities and estimating handoff items." },
+  { label: "Estimating", path: "/estimating", detail: "Build costs, pricing, risk, and the estimate workbook." },
+  { label: "Supplier RFQs", path: "/rfq-automation", detail: "Prepare supplier package drafts and quote coverage." },
+  { label: "Bid package", path: "/bid-package", detail: "Review scope, assumptions, exclusions, and bid readiness." },
 ];
+
+type WorkQueueItem = {
+  id: string;
+  title: string;
+  reference: string;
+  stage: string;
+  detail: string;
+  nextLabel: string;
+  nextPath: string;
+  secondaryActions: { label: string; path: string }[];
+};
 
 export function MVPWorkflowPage() {
   const location = useLocation();
   const activeProject = readEffectiveProjectContext(location.search);
   const [drafts, setDrafts] = useState<WorkflowDraft[]>([]);
-  const [draftError, setDraftError] = useState<string | null>(null);
+  const [quotes, setQuotes] = useState<CustomerQuote[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [launchByProjectId, setLaunchByProjectId] = useState<Record<string, ProjectLaunchDashboard>>({});
+  const [loadErrors, setLoadErrors] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let active = true;
-    void workflowDraftsApi.list()
-      .then((result) => {
-        if (active) setDrafts(result.items);
-      })
-      .catch((reason) => {
-        if (active) setDraftError(reason instanceof Error ? reason.message : "Unable to load unfinished work.");
-      });
+    void (async () => {
+      const errors: string[] = [];
+      const [draftResult, quoteResult, projectResult] = await Promise.allSettled([
+        workflowDraftsApi.list(),
+        customerQuotesApi.list(),
+        projectsApi.list(),
+      ]);
+      if (!active) return;
+
+      if (draftResult.status === "fulfilled") setDrafts(draftResult.value.items);
+      else errors.push("Unfinished forms could not be loaded.");
+      if (quoteResult.status === "fulfilled") setQuotes(quoteResult.value.items);
+      else errors.push("Customer quotes could not be loaded.");
+
+      if (projectResult.status === "fulfilled") {
+        setProjects(projectResult.value.items);
+        const awarded = projectResult.value.items.filter(
+          (project) => project.status === "awarded" && project.workspace_root,
+        );
+        const launches = await Promise.allSettled(
+          awarded.map((project) => projectsApi.launchDashboard(project.id)),
+        );
+        if (!active) return;
+        const available: Record<string, ProjectLaunchDashboard> = {};
+        launches.forEach((result, index) => {
+          if (result.status === "fulfilled") available[awarded[index].id] = result.value;
+          else errors.push(`Launch status could not be loaded for ${awarded[index].name}.`);
+        });
+        setLaunchByProjectId(available);
+      } else {
+        errors.push("Projects could not be loaded.");
+      }
+
+      setLoadErrors(errors);
+      setIsLoading(false);
+    })();
     return () => { active = false; };
   }, []);
+
+  const workQueue = useMemo(
+    () => buildMvpWorkQueue(quotes, projects, launchByProjectId),
+    [launchByProjectId, projects, quotes],
+  );
 
   async function discardDraft(draft: WorkflowDraft) {
     try {
       await workflowDraftsApi.cancel(draft.id, draft.revision);
       setDrafts((current) => current.filter((item) => item.id !== draft.id));
-    } catch (reason) {
-      setDraftError(reason instanceof Error ? reason.message : "Unable to discard the draft.");
+    } catch {
+      setLoadErrors((current) => [...current, `Unable to discard ${draft.title}. Reload and try again.`]);
     }
   }
 
   return (
     <section className="space-y-6">
-      <div className="border-b border-iron-100 pb-6">
-        <h1 className="text-3xl font-semibold text-iron-950">IHOS MVP Workflow</h1>
-        <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-500">
-          Build 51 operating page for the first usable internal web app flow: project, documents, takeoff, estimate, RFQs, and bid package.
+      <div className="rounded-xl border border-brand-gold/30 bg-iron-950 p-6 text-white shadow-brand">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-gold">Quote to completed job</div>
+        <h1 className="mt-2 text-3xl font-semibold">IHOS Guided Workflow</h1>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-200">
+          Start with what the customer told you, then follow one next action through quote, acceptance, job number, launch, and delivery.
         </p>
+        <Link to="/customer-quotes" className="mt-5 inline-flex min-h-12 items-center rounded-md bg-brand-gold px-4 py-3 text-sm font-semibold text-brand-black">
+          Start a verbal customer quote
+        </Link>
       </div>
+
+      <ol aria-label="Quote-to-job stages" className="grid gap-2 sm:grid-cols-5">
+        {flowStages.map((stage, index) => (
+          <li key={stage} className="rounded-md border border-iron-100 bg-white p-3 text-sm font-semibold text-iron-800">
+            <span className="mr-2 text-brand-gold-dark">{index + 1}</span>{stage}
+          </li>
+        ))}
+      </ol>
+
+      {loadErrors.length ? (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900" role="status">
+          <div className="font-semibold">Some live status is temporarily unavailable.</div>
+          <ul className="mt-2 list-disc space-y-1 pl-5">{loadErrors.map((error) => <li key={error}>{error}</li>)}</ul>
+          <p className="mt-2">Available work remains usable below.</p>
+        </div>
+      ) : null}
+
+      <section className="rounded-xl border border-brand-gold/30 bg-white p-5 shadow-sm" aria-labelledby="active-work-title">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 id="active-work-title" className="text-xl font-semibold text-iron-950">What needs attention</h2>
+            <p className="mt-1 text-sm text-iron-500">Each card gives the next safe action from IHOS records. Approval gates still apply.</p>
+          </div>
+          <span className="rounded-full bg-iron-100 px-3 py-1 text-xs font-semibold text-iron-700">
+            {isLoading ? "Loading" : `${workQueue.length} active`}
+          </span>
+        </div>
+        {workQueue.length ? (
+          <div className="mt-4 grid gap-4 lg:grid-cols-2" aria-label="Active quote-to-job work queue">
+            {workQueue.map((item) => (
+              <article key={item.id} className="flex flex-col rounded-lg border border-iron-100 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <div className="text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">{item.stage}</div>
+                    <h3 className="mt-1 text-lg font-semibold text-iron-950">{item.title}</h3>
+                  </div>
+                  <span className="rounded-md bg-iron-50 px-2 py-1 text-xs font-semibold text-iron-700">{item.reference}</span>
+                </div>
+                <p className="mt-3 flex-1 text-sm leading-6 text-iron-600">{item.detail}</p>
+                <Link to={item.nextPath} className="mt-4 inline-flex min-h-12 items-center justify-center rounded-md bg-iron-950 px-4 py-3 text-sm font-semibold text-white">
+                  {item.nextLabel}
+                </Link>
+                {item.secondaryActions.length ? (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {item.secondaryActions.map((action) => (
+                      <Link key={action.label} to={action.path} className="inline-flex min-h-11 items-center rounded-md border border-iron-200 px-3 py-2 text-sm font-semibold text-iron-700">
+                        {action.label}
+                      </Link>
+                    ))}
+                  </div>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        ) : isLoading ? (
+          <p className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">Loading active quotes and jobs…</p>
+        ) : (
+          <div className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-600">
+            No active quotes or jobs need attention. Start a verbal quote or open the tender tools below.
+          </div>
+        )}
+      </section>
+
       <section className="rounded-xl border border-brand-gold/30 bg-white p-5 shadow-sm" aria-labelledby="resume-work-title">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 id="resume-work-title" className="text-xl font-semibold text-iron-950">Resume unfinished work</h2>
-            <p className="mt-1 text-sm text-iron-500">IHOS keeps your in-progress forms here until you finish or discard them.</p>
+            <h2 id="resume-work-title" className="text-xl font-semibold text-iron-950">Resume unfinished forms</h2>
+            <p className="mt-1 text-sm text-iron-500">Your in-progress forms remain here until you finish or discard them.</p>
           </div>
           <span className="rounded-full bg-iron-100 px-3 py-1 text-xs font-semibold text-iron-700">{drafts.length} open</span>
         </div>
-        {draftError ? <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">{draftError}</div> : null}
         {drafts.length ? (
           <div className="mt-4 divide-y divide-iron-100 rounded-md border border-iron-100">
             {drafts.map((draft) => (
@@ -67,27 +185,128 @@ export function MVPWorkflowPage() {
                   <div className="mt-1 text-xs text-iron-500">Saved {new Date(draft.last_saved_at).toLocaleString()}</div>
                 </div>
                 <div className="flex gap-2">
-                  <Link to={resumePath(draft)} className="rounded-md bg-iron-950 px-3 py-2 text-sm font-semibold text-white">Continue</Link>
-                  <button type="button" onClick={() => void discardDraft(draft)} className="rounded-md border border-iron-200 px-3 py-2 text-sm font-semibold text-iron-700">Discard</button>
+                  <Link to={resumePath(draft)} className="inline-flex min-h-11 items-center rounded-md bg-iron-950 px-3 py-2 text-sm font-semibold text-white">Continue</Link>
+                  <button type="button" onClick={() => void discardDraft(draft)} className="min-h-11 rounded-md border border-iron-200 px-3 py-2 text-sm font-semibold text-iron-700">Discard</button>
                 </div>
               </div>
             ))}
           </div>
         ) : (
-          <p className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">No unfinished forms. Start anywhere below; your entries will save automatically.</p>
+          <p className="mt-4 rounded-md bg-iron-50 p-4 text-sm text-iron-500">No unfinished forms. Entries save automatically after you start.</p>
         )}
       </section>
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {steps.map((step) => (
-          <Link key={step.label} to={modulePathWithProjectContext(step.path, activeProject)} className="rounded-md border border-iron-100 bg-white p-5 transition hover:border-iron-300">
-            <div className="text-base font-semibold text-iron-950">{step.label}</div>
-            <p className="mt-2 text-sm leading-6 text-iron-500">{step.detail}</p>
-            <div className="mt-4 text-sm font-semibold text-iron-800">Open module</div>
-          </Link>
-        ))}
-      </div>
+
+      <section aria-labelledby="tender-tools-title">
+        <h2 id="tender-tools-title" className="text-xl font-semibold text-iron-950">Formal tender and bid tools</h2>
+        <p className="mt-1 text-sm text-iron-500">Use these modules for tender work that needs drawings, takeoff, RFQs, and a formal bid package.</p>
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {tenderTools.map((tool) => (
+            <Link key={tool.label} to={modulePathWithProjectContext(tool.path, activeProject)} className="rounded-md border border-iron-100 bg-white p-5 transition hover:border-iron-300">
+              <div className="text-base font-semibold text-iron-950">{tool.label}</div>
+              <p className="mt-2 text-sm leading-6 text-iron-500">{tool.detail}</p>
+              <div className="mt-4 text-sm font-semibold text-iron-800">Open module</div>
+            </Link>
+          ))}
+        </div>
+      </section>
     </section>
   );
+}
+
+export function buildMvpWorkQueue(
+  quotes: CustomerQuote[],
+  projects: Project[],
+  launchByProjectId: Record<string, ProjectLaunchDashboard>,
+): WorkQueueItem[] {
+  const items: WorkQueueItem[] = [];
+  const activeQuoteProjectIds = new Set(
+    quotes.filter((quote) => quote.status === "draft" || quote.status === "sent").map((quote) => quote.project_id),
+  );
+  const projectIds = new Set(projects.map((project) => project.id));
+
+  for (const quote of quotes) {
+    if (quote.status === "draft" || quote.status === "sent") {
+      items.push({
+        id: `quote-${quote.id}`,
+        title: `${quote.customer_name} — ${quote.project_name}`,
+        reference: quote.quote_number,
+        stage: quote.status === "draft" ? "Quote draft" : "Customer decision",
+        detail: quote.status === "draft"
+          ? `${formatMoney(quote.total)} quote is saved but not sent. Finish the scope, price, assumptions, and exclusions.`
+          : `${formatMoney(quote.total)} quote is recorded as sent. Record acceptance, decline, or a revised scope when the customer responds.`,
+        nextLabel: quote.status === "draft" ? "Finish and send quote" : "Record customer decision",
+        nextPath: `/customer-quotes?quoteId=${encodeURIComponent(quote.id)}&action=${quote.status === "draft" ? "edit" : "decision"}`,
+        secondaryActions: [{ label: "Open project", path: `/projects/${quote.project_id}` }],
+      });
+    } else if (quote.status === "accepted" && !projectIds.has(quote.project_id)) {
+      items.push({
+        id: `accepted-quote-${quote.id}`,
+        title: `${quote.customer_name} — ${quote.project_name}`,
+        reference: quote.job_number ?? quote.quote_number,
+        stage: "Awarded job",
+        detail: "The quote is accepted and its permanent job number is recorded. Open the awarded project to continue launch controls.",
+        nextLabel: "Open awarded project",
+        nextPath: `/projects/${quote.project_id}`,
+        secondaryActions: [],
+      });
+    }
+  }
+
+  for (const project of projects) {
+    if (project.status === "archived" || project.status === "completed" || activeQuoteProjectIds.has(project.id)) continue;
+    const projectContext = { id: project.id, name: project.name };
+    if (project.status === "awarded") {
+      const launch = launchByProjectId[project.id];
+      const ready = launch?.mobilization_status === "ready";
+      items.push({
+        id: `project-${project.id}`,
+        title: project.name,
+        reference: project.project_number ?? "Awarded",
+        stage: ready ? "Launch controls ready" : "Awarded job launch",
+        detail: launch
+          ? ready
+            ? `All ${launch.checklist_total_count} start controls are confirmed. Continue into delivery while keeping budget, PO, safety, and documents current.`
+            : `${launch.checklist_completed_count} of ${launch.checklist_total_count} start controls are confirmed. Next: ${launch.next_incomplete_control?.label ?? "review the launch dashboard"}`
+          : "The job is awarded, but its launch summary is temporarily unavailable. Open the project workspace to continue safely.",
+        nextLabel: ready ? "Begin project operations" : "Complete launch controls",
+        nextPath: ready ? withProjectContext("/project-operations", projectContext) : `/projects/${project.id}`,
+        secondaryActions: [
+          { label: "Budget", path: withProjectContext("/finance", projectContext) },
+          { label: "PO requests", path: withProjectContext("/request-po", projectContext) },
+          { label: "Safety", path: withProjectContext("/safety-operations", projectContext) },
+          { label: "Documents", path: withProjectContext("/documents", projectContext) },
+        ],
+      });
+    } else if (project.status === "construction") {
+      items.push({
+        id: `project-${project.id}`,
+        title: project.name,
+        reference: project.project_number ?? "Active job",
+        stage: "Active delivery",
+        detail: "This job is in construction. Continue field delivery, cost control, safety, documents, and daily records in project context.",
+        nextLabel: "Continue project operations",
+        nextPath: withProjectContext("/project-operations", projectContext),
+        secondaryActions: [
+          { label: "Finance", path: withProjectContext("/finance", projectContext) },
+          { label: "Safety", path: withProjectContext("/safety-operations", projectContext) },
+        ],
+      });
+    } else {
+      items.push({
+        id: `project-${project.id}`,
+        title: project.name,
+        reference: project.project_number ?? (project.status === "tendering" ? "Tender" : "Opportunity"),
+        stage: project.status === "tendering" ? "Tender in progress" : "Opportunity",
+        detail: project.status === "tendering"
+          ? "Continue documents, takeoff, estimating, supplier RFQs, and bid-package readiness."
+          : "Review the opportunity and decide whether it belongs in Customer Quotes or the formal tender workflow.",
+        nextLabel: "Open project workspace",
+        nextPath: `/projects/${project.id}`,
+        secondaryActions: [],
+      });
+    }
+  }
+  return items;
 }
 
 function resumePath(draft: WorkflowDraft) {
@@ -100,4 +319,8 @@ function resumePath(draft: WorkflowDraft) {
   const params = new URLSearchParams({ draftId: draft.id });
   if (draft.project_id) params.set("projectId", draft.project_id);
   return `${paths[draft.workflow_type]}?${params.toString()}`;
+}
+
+function formatMoney(value: string) {
+  return new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD", maximumFractionDigits: 0 }).format(Number(value));
 }

--- a/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fieldOperationsApi } from "../api/fieldOperations";
+import { PurchaseOrderRequestPage } from "./PurchaseOrderRequestPage";
+
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "admin-1", email: "admin@ironhousecontracting.com", role: "admin" },
+    portalRole: "management",
+  }),
+}));
+
+vi.mock("../api/fieldOperations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/fieldOperations")>();
+  return {
+    ...actual,
+    fieldOperationsApi: {
+      ...actual.fieldOperationsApi,
+      bootstrap: vi.fn(),
+      createRecord: vi.fn(),
+    },
+  };
+});
+
+describe("PurchaseOrderRequestPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    window.history.replaceState({}, "", "/request-po?projectId=job-1&projectName=Linked+Job");
+    vi.mocked(fieldOperationsApi.bootstrap).mockResolvedValue({
+      projects: [{ id: "job-1", name: "Linked Job", project_number: "IH-2026-030" }],
+      suppliers: [],
+      cost_codes: [],
+      records: [],
+    } as never);
+  });
+
+  it("preselects the job carried from the guided workflow", async () => {
+    render(<PurchaseOrderRequestPage />);
+
+    expect(await screen.findByRole("combobox", { name: "Job" })).toHaveValue("job-1");
+    expect(screen.getByRole("option", { name: "IH-2026-030 Linked Job" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/PurchaseOrderRequestPage.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.tsx
@@ -4,6 +4,7 @@ import { fieldOperationsApi, FieldOperationsBootstrap, FieldRecord } from "../ap
 import { useAuth } from "../contexts/AuthContext";
 import { DraftSaveIndicator } from "../components/DraftSaveIndicator";
 import { useWorkflowDraft } from "../hooks/useWorkflowDraft";
+import { readEffectiveProjectContext } from "../utils/projectContext";
 
 const today = () => new Date().toISOString().slice(0, 10);
 
@@ -14,8 +15,9 @@ function buildPoNumber(jobNumber: string) {
 
 export function PurchaseOrderRequestPage() {
   const { user, portalRole } = useAuth();
+  const routedProjectId = readEffectiveProjectContext(window.location.search).projectId ?? "";
   const [data, setData] = useState<FieldOperationsBootstrap | null>(null);
-  const [projectId, setProjectId] = useState("");
+  const [projectId, setProjectId] = useState(routedProjectId);
   const [supplierId, setSupplierId] = useState("");
   const [costCode, setCostCode] = useState("");
   const [purpose, setPurpose] = useState("");
@@ -54,7 +56,10 @@ export function PurchaseOrderRequestPage() {
     ready: bootstrapReady,
     enabled: draftEnabled,
     onRestore: (saved) => {
-      setProjectId(typeof saved.projectId === "string" ? saved.projectId : "");
+      const requestedDraft = new URLSearchParams(window.location.search).has("draftId");
+      setProjectId(requestedDraft
+        ? (typeof saved.projectId === "string" ? saved.projectId : "")
+        : routedProjectId || (typeof saved.projectId === "string" ? saved.projectId : ""));
       setSupplierId(typeof saved.supplierId === "string" ? saved.supplierId : "");
       setCostCode(typeof saved.costCode === "string" ? saved.costCode : "");
       setPurpose(typeof saved.purpose === "string" ? saved.purpose : "");

--- a/frontend/src/pages/SafetyOperationsPage.test.tsx
+++ b/frontend/src/pages/SafetyOperationsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -43,6 +43,7 @@ describe("SafetyOperationsPage", () => {
     });
     vi.mocked(fieldOperationsApi.bootstrap).mockResolvedValue({
       employees: [{ id: "worker-1", first_name: "Crew", last_name: "Member", email: "crew@example.com" }],
+      projects: [{ id: "project-1", name: "River Road", project_number: "IH-2026-001" }],
       records: [{
         id: "incident-1",
         record_type: "incident",
@@ -91,6 +92,8 @@ describe("SafetyOperationsPage", () => {
         submitted_by: "manager@example.com",
       }],
     } as never);
+    vi.mocked(fieldOperationsApi.createRecord).mockResolvedValue({} as never);
+    window.history.replaceState({}, "", "/safety-operations");
   });
 
   it("shows durable incident review and management-only first-aid workflows", async () => {
@@ -116,5 +119,27 @@ describe("SafetyOperationsPage", () => {
     expect(screen.getByText(/Minimum necessary operational record/)).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Crew Member" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save confidential record" })).toBeInTheDocument();
+  });
+
+  it("links new safety controls to the project carried from the workflow", async () => {
+    window.history.replaceState({}, "", "/safety-operations?projectId=project-1&projectName=River+Road");
+    const user = userEvent.setup();
+
+    render(<SafetyOperationsPage />);
+
+    expect(await screen.findByText("New safety records will be linked to River Road.")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Project / location")).toHaveValue("River Road");
+    await user.type(screen.getByPlaceholderText("Task and work limits"), "Excavate storm connection");
+    await user.type(screen.getByPlaceholderText("Responsible supervisor"), "Site supervisor");
+    await user.type(screen.getByPlaceholderText("Controls and verification evidence required"), "Locate and expose utilities");
+    await user.click(screen.getByRole("button", { name: "Save blocked permit" }));
+
+    await waitFor(() => expect(fieldOperationsApi.createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        record_type: "safety_permit",
+        project_id: "project-1",
+        details: expect.objectContaining({ project: "River Road" }),
+      }),
+    ));
   });
 });

--- a/frontend/src/pages/SafetyOperationsPage.tsx
+++ b/frontend/src/pages/SafetyOperationsPage.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
 import { AlertTriangle, ClipboardList, Copy, Download, FileWarning, HeartPulse, QrCode, Radio, ShieldAlert, Siren } from "lucide-react";
 
-import { Employee, FieldRecord, SafetyAnalytics, fieldOperationsApi } from "../api/fieldOperations";
+import { Employee, FieldOperationsBootstrap, FieldRecord, SafetyAnalytics, fieldOperationsApi } from "../api/fieldOperations";
 import { useAuth } from "../contexts/AuthContext";
 
 type View = "permits" | "actions" | "emergency" | "incidents" | "first-aid";
@@ -11,9 +11,12 @@ export function SafetyOperationsPage() {
   const { user } = useAuth();
   const [records, setRecords] = useState<FieldRecord[]>([]);
   const [employees, setEmployees] = useState<Employee[]>([]);
+  const [projects, setProjects] = useState<FieldOperationsBootstrap["projects"]>([]);
   const [analytics, setAnalytics] = useState<SafetyAnalytics | null>(null);
   const fieldLink = useMemo(() => new URLSearchParams(window.location.search), []);
   const linkedRecordId = fieldLink.get("record");
+  const linkedProjectId = fieldLink.get("projectId");
+  const linkedProjectName = fieldLink.get("projectName") ?? projects.find((project) => project.id === linkedProjectId)?.name ?? "";
   const [view, setView] = useState<View>(fieldLink.get("view") === "emergency" ? "emergency" : "permits");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -24,6 +27,7 @@ export function SafetyOperationsPage() {
       const data = await fieldOperationsApi.bootstrap();
       const safetyAnalytics = canManageOccurrences ? await fieldOperationsApi.safetyAnalytics() : null;
       setEmployees(data.employees);
+      setProjects(data.projects);
       setRecords(data.records.filter((record) => TYPES.includes(record.record_type)));
       setAnalytics(safetyAnalytics);
       setError(null);
@@ -65,6 +69,7 @@ export function SafetyOperationsPage() {
     try {
       await fieldOperationsApi.createRecord({
         record_type: recordType,
+        project_id: linkedProjectId || null,
         employee_id: employeeId || null,
         work_date: occurredAt.slice(0, 10) || new Date().toISOString().slice(0, 10),
         title: String(data.get(titleField)),
@@ -104,6 +109,7 @@ export function SafetyOperationsPage() {
       <p className="mt-2 max-w-3xl text-sm text-iron-100">Database-backed permit readiness, corrective actions, emergency cards, incident review and privacy-scoped first-aid occurrence records.</p>
     </header>
     {error ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800">{error}</div> : null}
+    {linkedProjectId ? <div className="rounded-md border border-brand-gold/40 bg-brand-gold/10 p-3 text-sm font-semibold text-iron-800">New safety records will be linked to {linkedProjectName || linkedProjectId}.</div> : null}
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
       <Metric label="Blocked permits" value={analytics?.blocked_permits ?? permits.filter((permit) => permit.status === "blocked").length} icon={<ShieldAlert />} />
       <Metric label="Overdue actions" value={analytics?.overdue_corrective_actions ?? overdue} icon={<AlertTriangle />} />
@@ -129,9 +135,9 @@ export function SafetyOperationsPage() {
       {navigation.map(([key, label]) => <button key={key} type="button" onClick={() => setView(key)} className={`min-h-11 shrink-0 rounded-md px-4 py-2 text-sm font-semibold ${view === key ? "bg-brand-gold text-brand-black" : "text-iron-600"}`}>{label}</button>)}
     </nav>
     {loading ? <p className="rounded-xl border bg-white p-6 text-sm text-iron-500">Loading safety records…</p> : null}
-    {!loading && view === "permits" ? <PermitView records={permits} create={create} transition={transition} /> : null}
+    {!loading && view === "permits" ? <PermitView records={permits} create={create} transition={transition} projectName={linkedProjectName} /> : null}
     {!loading && view === "actions" ? <ActionView records={actions} create={create} transition={transition} /> : null}
-    {!loading && view === "emergency" ? <EmergencyView records={cards} create={create} /> : null}
+    {!loading && view === "emergency" ? <EmergencyView records={cards} create={create} projectName={linkedProjectName} /> : null}
     {!loading && view === "incidents" ? <IncidentView records={incidents} employees={employees} canCreate={canManageOccurrences} create={create} transition={transition} /> : null}
     {!loading && view === "first-aid" && canManageOccurrences ? <FirstAidView records={firstAid} employees={employees} create={create} /> : null}
   </section>;
@@ -140,16 +146,16 @@ export function SafetyOperationsPage() {
 type Create = (event: FormEvent<HTMLFormElement>, recordType: string, titleField: string) => Promise<void>;
 type Transition = (record: FieldRecord, status: string, prompt: string) => Promise<void>;
 
-function PermitView({ records, create, transition }: { records: FieldRecord[]; create: Create; transition: Transition }) {
-  return <Grid><form onSubmit={(event) => void create(event, "safety_permit", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create permit readiness record</h2><select name="type" className="control"><option>Ground Disturbance</option><option>Confined Space</option><option>Lockout / Energy Isolation</option><option>Critical Lift</option><option>Traffic Control</option></select><Input name="project" placeholder="Project / location" /><Area name="task" placeholder="Task and work limits" /><Input name="supervisor" placeholder="Responsible supervisor" /><Area name="controls" placeholder="Controls and verification evidence required" /><label className="block text-xs font-semibold text-iron-500">Permit expiry<input name="expires" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save blocked permit</Save></form><Register empty="No permit readiness records." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{detail(record, "type")} · {record.work_date}</div><h3 className="font-semibold">{detail(record, "project")}</h3><p className="text-sm text-iron-600">{detail(record, "task")}</p><p className="mt-2 text-xs text-iron-500">Supervisor: {detail(record, "supervisor")} · Expires: {detail(record, "expires") || "Not set"}</p></div><Status value={record.status} /></div><p className="mt-3 rounded-md bg-iron-50 p-3 text-sm">{detail(record, "controls")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "at_risk", "Record the review evidence and remaining risk.")}>Mark at risk</Small><Small dark onClick={() => void transition(record, "ready", "Record the field verification that supports release.")}>Verify ready</Small></div></article>)} /></Grid>;
+function PermitView({ records, create, transition, projectName }: { records: FieldRecord[]; create: Create; transition: Transition; projectName: string }) {
+  return <Grid><form onSubmit={(event) => void create(event, "safety_permit", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create permit readiness record</h2><select name="type" className="control"><option>Ground Disturbance</option><option>Confined Space</option><option>Lockout / Energy Isolation</option><option>Critical Lift</option><option>Traffic Control</option></select><Input name="project" placeholder="Project / location" defaultValue={projectName} /><Area name="task" placeholder="Task and work limits" /><Input name="supervisor" placeholder="Responsible supervisor" /><Area name="controls" placeholder="Controls and verification evidence required" /><label className="block text-xs font-semibold text-iron-500">Permit expiry<input name="expires" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save blocked permit</Save></form><Register empty="No permit readiness records." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{detail(record, "type")} · {record.work_date}</div><h3 className="font-semibold">{detail(record, "project")}</h3><p className="text-sm text-iron-600">{detail(record, "task")}</p><p className="mt-2 text-xs text-iron-500">Supervisor: {detail(record, "supervisor")} · Expires: {detail(record, "expires") || "Not set"}</p></div><Status value={record.status} /></div><p className="mt-3 rounded-md bg-iron-50 p-3 text-sm">{detail(record, "controls")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "at_risk", "Record the review evidence and remaining risk.")}>Mark at risk</Small><Small dark onClick={() => void transition(record, "ready", "Record the field verification that supports release.")}>Verify ready</Small></div></article>)} /></Grid>;
 }
 
 function ActionView({ records, create, transition }: { records: FieldRecord[]; create: Create; transition: Transition }) {
   return <Grid><form onSubmit={(event) => void create(event, "corrective_action", "finding")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create corrective action</h2>{[["finding", "Finding"], ["risk", "Risk / consequence"], ["immediate", "Immediate control"], ["permanent", "Permanent action"], ["owner", "Action owner"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} />)}<label className="block text-xs font-semibold text-iron-500">Due date<input required name="due" type="date" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save action</Save></form><Register empty="No corrective actions." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between"><div><h3 className="font-semibold">{detail(record, "finding")}</h3><p className="text-sm text-iron-500">Owner: {detail(record, "owner")} · Due: {detail(record, "due")}</p></div><Status value={record.status} /></div><p className="mt-3 text-sm"><b>Immediate:</b> {detail(record, "immediate")}</p><p className="mt-1 text-sm"><b>Permanent:</b> {detail(record, "permanent")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "verification", "Record completion evidence for management verification.")}>Submit evidence</Small><Small dark onClick={() => void transition(record, "closed", "Record how effectiveness was verified before closure.")}>Verify and close</Small></div></article>)} /></Grid>;
 }
 
-function EmergencyView({ records, create }: { records: FieldRecord[]; create: Create }) {
-  return <Grid><form onSubmit={(event) => void create(event, "emergency_action_card", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create emergency action card</h2>{[["project", "Project"], ["address", "Site address / access point"], ["muster", "Muster point"], ["firstAid", "First aid location and attendant"], ["emergencyLead", "Emergency lead and contact"], ["rescue", "Rescue / evacuation method"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} />)}<Save>Save emergency card</Save></form><Register empty="No emergency cards." items={records.map((record) => <article id={`emergency-card-${record.id}`} key={record.id} className="scroll-mt-6 rounded-lg border border-red-200 bg-red-50 p-5"><div className="flex items-center gap-2"><Radio className="text-red-700" /><h3 className="font-semibold text-red-950">{detail(record, "project")}</h3></div><dl className="mt-4 grid gap-2 text-sm"><div><dt className="font-semibold">Address/access:</dt><dd>{detail(record, "address")}</dd></div><div><dt className="font-semibold">Muster point:</dt><dd>{detail(record, "muster")}</dd></div><div><dt className="font-semibold">First aid:</dt><dd>{detail(record, "firstAid")}</dd></div><div><dt className="font-semibold">Emergency lead:</dt><dd>{detail(record, "emergencyLead")}</dd></div><div><dt className="font-semibold">Rescue/evacuation:</dt><dd>{detail(record, "rescue")}</dd></div></dl><p className="mt-3 text-xs text-red-800">Created {record.work_date}. Confirm with the crew and replace when conditions change.</p><EmergencyFieldAccess record={record} /></article>)} /></Grid>;
+function EmergencyView({ records, create, projectName }: { records: FieldRecord[]; create: Create; projectName: string }) {
+  return <Grid><form onSubmit={(event) => void create(event, "emergency_action_card", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create emergency action card</h2>{[["project", "Project"], ["address", "Site address / access point"], ["muster", "Muster point"], ["firstAid", "First aid location and attendant"], ["emergencyLead", "Emergency lead and contact"], ["rescue", "Rescue / evacuation method"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} defaultValue={name === "project" ? projectName : undefined} />)}<Save>Save emergency card</Save></form><Register empty="No emergency cards." items={records.map((record) => <article id={`emergency-card-${record.id}`} key={record.id} className="scroll-mt-6 rounded-lg border border-red-200 bg-red-50 p-5"><div className="flex items-center gap-2"><Radio className="text-red-700" /><h3 className="font-semibold text-red-950">{detail(record, "project")}</h3></div><dl className="mt-4 grid gap-2 text-sm"><div><dt className="font-semibold">Address/access:</dt><dd>{detail(record, "address")}</dd></div><div><dt className="font-semibold">Muster point:</dt><dd>{detail(record, "muster")}</dd></div><div><dt className="font-semibold">First aid:</dt><dd>{detail(record, "firstAid")}</dd></div><div><dt className="font-semibold">Emergency lead:</dt><dd>{detail(record, "emergencyLead")}</dd></div><div><dt className="font-semibold">Rescue/evacuation:</dt><dd>{detail(record, "rescue")}</dd></div></dl><p className="mt-3 text-xs text-red-800">Created {record.work_date}. Confirm with the crew and replace when conditions change.</p><EmergencyFieldAccess record={record} /></article>)} /></Grid>;
 }
 
 function EmergencyFieldAccess({ record }: { record: FieldRecord }) {
@@ -237,7 +243,7 @@ function detail(record: FieldRecord, key: string) { const value = record.details
 function employeeName(id: string | null, employees: Employee[]) { const employee = employees.find((item) => item.id === id); return employee ? `${employee.first_name} ${employee.last_name}` : ""; }
 function message(value: unknown) { return value instanceof Error ? value.message : "Unable to complete the safety operation."; }
 function Grid({ children }: { children: ReactNode }) { return <div className="grid gap-6 xl:grid-cols-[390px_1fr]">{children}</div>; }
-function Input({ required = true, ...props }: { name: string; placeholder: string; type?: string; required?: boolean }) { return <input required={required} {...props} className="w-full rounded-md border p-2 text-sm" />; }
+function Input({ required = true, ...props }: { name: string; placeholder: string; type?: string; required?: boolean; defaultValue?: string }) { return <input required={required} {...props} className="w-full rounded-md border p-2 text-sm" />; }
 function Area(props: { name: string; placeholder: string }) { return <textarea required {...props} className="h-24 w-full rounded-md border p-2 text-sm" />; }
 function Save({ children }: { children: ReactNode }) { return <button className="w-full rounded-md bg-brand-gold p-2 text-sm font-semibold">{children}</button>; }
 function Small({ children, dark = false, onClick }: { children: ReactNode; dark?: boolean; onClick: () => void }) { return <button type="button" onClick={onClick} className={`min-h-11 rounded-md px-3 text-xs font-semibold ${dark ? "bg-iron-950 text-white" : "border"}`}>{children}</button>; }


### PR DESCRIPTION
## Summary

- replace the static MVP module list with a live, iPad-friendly quote-to-job work queue
- derive one next action for draft/sent quotes, awarded jobs, launch-ready jobs, construction jobs, tenders, and opportunities
- suppress the duplicate opportunity card created behind an active Customer Quote
- retain durable owner-scoped Resume unfinished forms
- keep formal tender and bid tools as a separate path
- keep available work usable when quotes, projects, drafts, or one launch summary is temporarily unavailable
- deep-link to the targeted Customer Quote and add explicit decline/expiry decisions
- carry the selected job into Finance, PO Requests, Safety Operations, Documents, and Project Operations
- persist project ID on new safety controls and preselect the linked job in Finance and PO Requests

## Stack

This draft is stacked on #254, which follows direct-to-main quote PR #253. Retarget each PR to `main` after its prerequisite lands.

Closes #255

## Validation

- Frontend full suite: 94 passed
- Guided workflow/quote/finance/PO/safety targeted: 10 passed
- TypeScript production build: passed
- Visual design lock: passed
- React Router RSC boundary: passed
- `git diff --check`: passed

## Controls

The queue is read-only orchestration. It does not send, accept, award, approve, purchase, create safety evidence, or deploy automatically. Existing management, revision, and checklist gates remain authoritative. Quote decline/expiry requires explicit confirmation and a new revision to reopen.