### PR TITLE
Run disposable quote-to-job smoke on main

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -150,6 +150,7 @@ jobs:
           STAGING_EMAIL: ${{ env.BOOTSTRAP_ADMIN_EMAIL }}
           STAGING_PASSWORD: ${{ env.BOOTSTRAP_ADMIN_PASSWORD }}
           STAGING_SYNTHETIC_DATA: "true"
+          STAGING_MVP_SYNTHETIC_DATA: "true"
           STAGING_SYNTHETIC_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}
         run: scripts/staging-smoke-test.sh
       - name: Create pre-backup recovery sentinel

--- a/docs/validation/quote-to-job-staging-smoke.md
+++ b/docs/validation/quote-to-job-staging-smoke.md
@@ -1,0 +1,38 @@
+# Quote-to-job disposable staging smoke
+
+## Purpose
+
+The release-readiness workflow validates the complete Customer Quote to awarded-job path through the deployed HTTP stack. This provides a browser-independent acceptance route when cloud-browser or iPad tooling is unavailable.
+
+## Safety boundary
+
+The extended lifecycle runs only when both flags are present:
+
+```text
+STAGING_SYNTHETIC_DATA=true
+STAGING_MVP_SYNTHETIC_DATA=true
+```
+
+The GitHub release-readiness workflow sets both flags only inside its disposable Docker staging stack. The ordinary shared-staging deployment does not enable the lifecycle. Running the script without administrator credentials fails before synthetic data is created.
+
+All request payloads and session cookies live in a permission-restricted `mktemp` directory and are removed on exit. The synthetic suffix accepts only letters, digits, dots, underscores, and hyphens.
+
+## Verified lifecycle
+
+1. Authenticate the disposable staging administrator.
+2. Create a uniquely named Customer Quote and linked opportunity.
+3. Verify the draft has a record revision and no job number.
+4. Record the quote as sent and verify it remains non-binding.
+5. Record management acceptance with an explicit disposable-staging reference.
+6. Verify the accepted quote has a generated `IH-` job number.
+7. Verify the linked project is awarded and its job number matches.
+8. Verify the awarded workspace exists.
+9. Verify all ten project-start controls exist and begin unchecked/not ready.
+10. Verify the launch dashboard matches the job and identifies the next control without inferring readiness.
+11. Authenticate a synthetic viewer and verify the launch dashboard is denied with HTTP 403.
+
+Any unexpected HTTP status or state mismatch stops the release gate. Generated quote, project, revision, and job identifiers are parsed from API responses rather than assumed.
+
+## Manual use
+
+The base smoke remains safe for shared staging when the MVP synthetic flag is omitted. Do not enable `STAGING_MVP_SYNTHETIC_DATA` against shared staging without a separately approved test-data plan because accepted quotes are intentionally immutable and allocate permanent staging job numbers.

--- a/scripts/staging-smoke-test.sh
+++ b/scripts/staging-smoke-test.sh
@@ -16,6 +16,9 @@ viewer_login_file="$smoke_dir/viewer-login.json"
 viewer_change_file="$smoke_dir/viewer-change.json"
 viewer_create_file="$smoke_dir/viewer-create.json"
 viewer_denial_file="$smoke_dir/viewer-denial.json"
+mvp_quote_file="$smoke_dir/mvp-quote.json"
+mvp_status_file="$smoke_dir/mvp-status.json"
+mvp_accept_file="$smoke_dir/mvp-accept.json"
 
 trap 'rm -rf "$smoke_dir"' EXIT
 umask 077
@@ -58,6 +61,169 @@ request_one_of() {
   esac
 }
 
+read_quote_state() {
+  local expected_status="$1"
+  local job_expectation="$2"
+  local expected_quote_id="${3:-}"
+  local expected_project_id="${4:-}"
+  BODY_FILE="$body_file" \
+  EXPECTED_STATUS="$expected_status" \
+  JOB_EXPECTATION="$job_expectation" \
+  EXPECTED_QUOTE_ID="$expected_quote_id" \
+  EXPECTED_PROJECT_ID="$expected_project_id" \
+  python - <<'PY'
+import json
+import os
+from uuid import UUID
+
+payload = json.loads(open(os.environ["BODY_FILE"], encoding="utf-8").read())
+if payload.get("status") != os.environ["EXPECTED_STATUS"]:
+    raise SystemExit(
+        f"Expected quote status {os.environ['EXPECTED_STATUS']!r}, got {payload.get('status')!r}."
+    )
+quote_id = str(UUID(str(payload.get("id"))))
+project_id = str(UUID(str(payload.get("project_id"))))
+if os.environ["EXPECTED_QUOTE_ID"] and quote_id != os.environ["EXPECTED_QUOTE_ID"]:
+    raise SystemExit("Quote ID changed during the synthetic lifecycle.")
+if os.environ["EXPECTED_PROJECT_ID"] and project_id != os.environ["EXPECTED_PROJECT_ID"]:
+    raise SystemExit("Project ID changed during the synthetic lifecycle.")
+job_number = payload.get("job_number")
+if os.environ["JOB_EXPECTATION"] == "absent" and job_number is not None:
+    raise SystemExit(f"Non-binding quote state unexpectedly has job number {job_number!r}.")
+if os.environ["JOB_EXPECTATION"] == "present" and not str(job_number or "").startswith("IH-"):
+    raise SystemExit(f"Accepted quote has invalid job number {job_number!r}.")
+revision = int(payload.get("record_revision") or 0)
+if revision < 1:
+    raise SystemExit("Quote revision is missing or invalid.")
+print(f"{quote_id}\t{project_id}\t{revision}\t{job_number or ''}")
+PY
+}
+
+run_mvp_quote_job_checks() {
+  local synthetic_suffix="$1"
+  local quote_metadata
+  local quote_id
+  local project_id
+  local quote_revision
+  local job_number
+
+  SYNTHETIC_SUFFIX="$synthetic_suffix" python - <<'PY' > "$mvp_quote_file"
+import json
+import os
+from datetime import date, timedelta
+
+suffix = os.environ["SYNTHETIC_SUFFIX"]
+print(json.dumps({
+    "project_name": f"Disposable staging quote-to-job {suffix}",
+    "customer_name": f"Synthetic Customer {suffix}",
+    "customer_email": f"staging-mvp-{suffix}@example.invalid",
+    "site_address": "100 Disposable Staging Way",
+    "scope_summary": "Synthetic quote-to-job release gate. No external customer or commitment.",
+    "line_items": [{
+        "description": "Synthetic civil work",
+        "quantity": "1",
+        "unit": "LS",
+        "unit_price": "1000.00",
+    }],
+    "assumptions": ["Disposable CI environment only"],
+    "exclusions": ["External submission and real construction"],
+    "gst_rate": "5.00",
+    "quote_date": date.today().isoformat(),
+    "valid_until": (date.today() + timedelta(days=30)).isoformat(),
+    "notes": f"Release-readiness synthetic record {suffix}",
+}))
+PY
+  request \
+    "$API_URL$API_PREFIX/customer-quotes" \
+    "201" \
+    --cookie "$cookie_file" \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data-binary "@$mvp_quote_file"
+  quote_metadata="$(read_quote_state "draft" "absent")"
+  IFS=$'\t' read -r quote_id project_id quote_revision job_number <<< "$quote_metadata"
+
+  QUOTE_REVISION="$quote_revision" python - <<'PY' > "$mvp_status_file"
+import json
+import os
+
+print(json.dumps({"expected_revision": int(os.environ["QUOTE_REVISION"]), "status": "sent"}))
+PY
+  request \
+    "$API_URL$API_PREFIX/customer-quotes/$quote_id/status" \
+    "200" \
+    --cookie "$cookie_file" \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data-binary "@$mvp_status_file"
+  quote_metadata="$(read_quote_state "sent" "absent" "$quote_id" "$project_id")"
+  IFS=$'\t' read -r quote_id project_id quote_revision job_number <<< "$quote_metadata"
+
+  QUOTE_REVISION="$quote_revision" SYNTHETIC_SUFFIX="$synthetic_suffix" python - <<'PY' > "$mvp_accept_file"
+import json
+import os
+
+print(json.dumps({
+    "expected_revision": int(os.environ["QUOTE_REVISION"]),
+    "acceptance_reference": f"Disposable staging acceptance {os.environ['SYNTHETIC_SUFFIX']}",
+    "acceptance_note": "Synthetic release gate only; not an external commitment.",
+}))
+PY
+  request \
+    "$API_URL$API_PREFIX/customer-quotes/$quote_id/accept" \
+    "200" \
+    --cookie "$cookie_file" \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data-binary "@$mvp_accept_file"
+  quote_metadata="$(read_quote_state "accepted" "present" "$quote_id" "$project_id")"
+  IFS=$'\t' read -r quote_id project_id quote_revision job_number <<< "$quote_metadata"
+
+  request "$API_URL$API_PREFIX/projects/$project_id" "200" --cookie "$cookie_file"
+  BODY_FILE="$body_file" EXPECTED_JOB_NUMBER="$job_number" python - <<'PY'
+import json
+import os
+
+payload = json.loads(open(os.environ["BODY_FILE"], encoding="utf-8").read())
+if payload.get("status") != "awarded":
+    raise SystemExit(f"Expected awarded project, got {payload.get('status')!r}.")
+if payload.get("project_number") != os.environ["EXPECTED_JOB_NUMBER"]:
+    raise SystemExit("Awarded project job number differs from accepted quote.")
+if not payload.get("workspace_root") or not payload.get("workspace_provisioned_at"):
+    raise SystemExit("Awarded project workspace was not provisioned.")
+PY
+
+  request "$API_URL$API_PREFIX/projects/$project_id/workspace" "200" --cookie "$cookie_file"
+  request "$API_URL$API_PREFIX/projects/$project_id/start-checklist" "200" --cookie "$cookie_file"
+  BODY_FILE="$body_file" python - <<'PY'
+import json
+import os
+
+payload = json.loads(open(os.environ["BODY_FILE"], encoding="utf-8").read())
+if payload.get("status") != "not_ready":
+    raise SystemExit("New awarded job must begin with launch controls not ready.")
+if payload.get("completed_count") != 0 or payload.get("total_count") != 10:
+    raise SystemExit("New awarded job does not have the expected ten unchecked start controls.")
+PY
+
+  request "$API_URL$API_PREFIX/projects/$project_id/launch-dashboard" "200" --cookie "$cookie_file"
+  BODY_FILE="$body_file" EXPECTED_JOB_NUMBER="$job_number" python - <<'PY'
+import json
+import os
+
+payload = json.loads(open(os.environ["BODY_FILE"], encoding="utf-8").read())
+if payload.get("job_number") != os.environ["EXPECTED_JOB_NUMBER"]:
+    raise SystemExit("Launch dashboard job number differs from the accepted quote.")
+if payload.get("mobilization_status") != "not_ready":
+    raise SystemExit("Launch dashboard inferred readiness for a new job.")
+if payload.get("checklist_completed_count") != 0 or payload.get("checklist_total_count") != 10:
+    raise SystemExit("Launch dashboard checklist summary is incorrect.")
+if not payload.get("next_incomplete_control"):
+    raise SystemExit("Launch dashboard did not identify the next incomplete control.")
+PY
+  printf '%s\n' "$project_id"
+}
+
 assert_viewer_permissions() {
   BODY_FILE="$body_file" python - <<'PY'
 import json
@@ -85,6 +251,7 @@ run_viewer_checks() {
   local email="$1"
   local password="$2"
   local changed_password="${3:-}"
+  local restricted_launch_project_id="${4:-}"
 
   write_login_payload "$viewer_login_file" "$email" "$password"
   request \
@@ -129,6 +296,12 @@ PY
     --header "Content-Type: application/json" \
     --request POST \
     --data-binary "@$viewer_denial_file"
+  if [[ -n "$restricted_launch_project_id" ]]; then
+    request \
+      "$API_URL$API_PREFIX/projects/$restricted_launch_project_id/launch-dashboard" \
+      "403" \
+      --cookie "$viewer_cookie_file"
+  fi
   request \
     "$API_URL$API_PREFIX/auth/logout" \
     "204" \
@@ -169,6 +342,15 @@ if [[ -n "${STAGING_EMAIL:-}" || -n "${STAGING_PASSWORD:-}" ]]; then
   for path in projects suppliers rfqs bids documents equipment; do
     request "$API_URL$API_PREFIX/$path" "200" --cookie "$cookie_file"
   done
+  request "$API_URL$API_PREFIX/customer-quotes" "200" --cookie "$cookie_file"
+  request "$API_URL$API_PREFIX/workflow-drafts" "200" --cookie "$cookie_file"
+
+  if [[ "${STAGING_MVP_SYNTHETIC_DATA:-false}" == "true" && "${STAGING_SYNTHETIC_DATA:-false}" != "true" ]]; then
+    echo "STAGING_MVP_SYNTHETIC_DATA requires STAGING_SYNTHETIC_DATA=true for a disposable viewer boundary check." >&2
+    exit 1
+  fi
+
+  synthetic_mvp_project_id=""
 
   if [[ "${STAGING_SYNTHETIC_DATA:-false}" == "true" ]]; then
     synthetic_suffix="${STAGING_SYNTHETIC_SUFFIX:-$(date +%s)-$$}"
@@ -202,6 +384,10 @@ PY
       --header "Content-Type: application/json" \
       --request POST \
       --data-binary "@$viewer_create_file"
+    if [[ "${STAGING_MVP_SYNTHETIC_DATA:-false}" == "true" ]]; then
+      synthetic_mvp_project_id="$(run_mvp_quote_job_checks "$synthetic_suffix" | tail -n 1)"
+      echo "PASS disposable quote-to-job lifecycle [$synthetic_mvp_project_id]"
+    fi
   elif [[ -n "${STAGING_VIEWER_EMAIL:-}" || -n "${STAGING_VIEWER_PASSWORD:-}" ]]; then
     if [[ -z "${STAGING_VIEWER_EMAIL:-}" || -z "${STAGING_VIEWER_PASSWORD:-}" ]]; then
       echo "Set both STAGING_VIEWER_EMAIL and STAGING_VIEWER_PASSWORD for role checks." >&2
@@ -223,12 +409,12 @@ PY
   request "$API_URL$API_PREFIX/auth/me" "401" --cookie "$cookie_file"
 
   if [[ "${STAGING_SYNTHETIC_DATA:-false}" == "true" ]]; then
-    run_viewer_checks "$viewer_email" "$viewer_initial_password" "$viewer_accepted_password"
+    run_viewer_checks "$viewer_email" "$viewer_initial_password" "$viewer_accepted_password" "$synthetic_mvp_project_id"
   elif [[ -n "${STAGING_VIEWER_EMAIL:-}" ]]; then
     run_viewer_checks "$STAGING_VIEWER_EMAIL" "$STAGING_VIEWER_PASSWORD"
   fi
-elif [[ "${STAGING_SYNTHETIC_DATA:-false}" == "true" ]]; then
-  echo "STAGING_SYNTHETIC_DATA requires STAGING_EMAIL and STAGING_PASSWORD." >&2
+elif [[ "${STAGING_SYNTHETIC_DATA:-false}" == "true" || "${STAGING_MVP_SYNTHETIC_DATA:-false}" == "true" ]]; then
+  echo "Synthetic staging data requires STAGING_EMAIL and STAGING_PASSWORD." >&2
   exit 1
 fi
 

--- a/tests/backend/test_staging_config.py
+++ b/tests/backend/test_staging_config.py
@@ -81,6 +81,7 @@ def test_release_workflow_uses_disposable_staging_and_immutable_evidence() -> No
     assert "Disposable staging smoke, rollback, and evidence" in workflow
     assert "scripts/staging-smoke-test.sh" in workflow
     assert "STAGING_SYNTHETIC_DATA: \"true\"" in workflow
+    assert "STAGING_MVP_SYNTHETIC_DATA: \"true\"" in workflow
     assert "scripts/staging_rollback_probe.py verify-absent" in workflow
     assert "--profile staging" in workflow
     assert "--production-baseline 55afaa689603263c1ad415436e90cce6679808c3" in workflow

--- a/tests/backend/test_staging_smoke_script.py
+++ b/tests/backend/test_staging_smoke_script.py
@@ -45,8 +45,25 @@ def test_staging_smoke_proves_viewer_role_denials_and_synthetic_opt_in() -> None
         '    "$API_URL$API_PREFIX/projects" \\\n'
         '    "403"'
     ) in script
-    assert "STAGING_SYNTHETIC_DATA requires STAGING_EMAIL and STAGING_PASSWORD" in script
+    assert "Synthetic staging data requires STAGING_EMAIL and STAGING_PASSWORD" in script
     assert "Set both STAGING_VIEWER_EMAIL and STAGING_VIEWER_PASSWORD" in script
+
+
+def test_disposable_mvp_smoke_proves_quote_to_job_lifecycle_and_viewer_boundary() -> None:
+    script = (ROOT / "scripts/staging-smoke-test.sh").read_text()
+
+    assert 'if [[ "${STAGING_MVP_SYNTHETIC_DATA:-false}" == "true"' in script
+    assert "STAGING_MVP_SYNTHETIC_DATA requires STAGING_SYNTHETIC_DATA=true" in script
+    assert '"$API_URL$API_PREFIX/customer-quotes"' in script
+    assert 'read_quote_state "draft" "absent"' in script
+    assert 'read_quote_state "sent" "absent"' in script
+    assert 'read_quote_state "accepted" "present"' in script
+    assert '"$API_URL$API_PREFIX/projects/$project_id/workspace"' in script
+    assert '"$API_URL$API_PREFIX/projects/$project_id/start-checklist"' in script
+    assert '"$API_URL$API_PREFIX/projects/$project_id/launch-dashboard"' in script
+    assert '"$API_URL$API_PREFIX/projects/$restricted_launch_project_id/launch-dashboard"' in script
+    assert "New awarded job does not have the expected ten unchecked start controls." in script
+    assert "Launch dashboard inferred readiness for a new job." in script
 
 
 def test_staging_rollback_probe_requires_post_restore_absence() -> None:


### PR DESCRIPTION
## Summary

Direct-to-main follow-up for #260. GitHub merged the stacked PR into its temporary guided-workflow base before it could be retargeted.

- add a separately gated disposable quote-to-job staging smoke flow
- prove draft and sent quotes do not generate jobs
- accept a synthetic quote with explicit evidence and verify the awarded project, job number, workspace, ten-item checklist, launch readiness, and viewer authorization boundary
- keep shared staging and production untouched by default

Closes #257

## Validation

- shell syntax and targeted staging configuration/smoke tests passed locally
- targeted Ruff and diff checks passed
- the full disposable Docker lifecycle will run in Release Readiness CI on this direct-to-main PR

## Controls

The synthetic lifecycle requires both staging synthetic-data gates and runs only against the disposable CI stack. It does not mutate shared staging or production.