### PR TITLE
Harden guided workflow recovery and routing

### DIFF
--- a/docs/guided-mvp-workflow.md
+++ b/docs/guided-mvp-workflow.md
@@ -21,17 +21,19 @@ The work queue derives one next action for each active item:
 - construction job: continue Project Operations; and
 - tender or unquoted opportunity: open the Project Workspace and choose the correct workflow.
 
-An active quote and its automatically created opportunity appear as one queue item, not duplicates.
+An active quote and its automatically created opportunity appear as one queue item, not duplicates. Deduplication applies only while the linked project is still an opportunity; an awarded or construction job always remains visible.
 
 ## Project context
 
 Queue links carry both the project ID and name. Project Operations, Finance, PO Requests, Safety Operations, and Documents open in that project context. New project-linked safety controls persist the project ID, and the PO and Finance modules preselect the routed job.
 
-A requested durable draft remains authoritative when a `draftId` is present. Otherwise, an explicit project link takes priority over a device recovery buffer when the PO form opens.
+A requested durable draft remains authoritative when a `draftId` is present. Otherwise, an explicit project link takes priority over a device recovery buffer when the PO form opens. Finance, PO Requests, and Safety Operations react when the routed project changes without requiring a page reload.
+
+A direct quote-edit link is also authoritative over an unrelated device recovery buffer. Declined and expired quotes expose **Start new revision**; saving that revision returns the quote to draft without exposing send, acceptance, or close controls before the revision is saved. Accepted quotes remain immutable.
 
 ## Partial availability
 
-Customer Quotes, Projects, workflow drafts, and each awarded-job launch summary load independently. If one source is temporarily unavailable, IHOS identifies the missing status and keeps the successfully loaded work usable. A single failed request must not blank the workflow page.
+Customer Quotes, Projects, workflow drafts, and each awarded-job launch summary load independently. The base queue renders as soon as its three registers settle, without waiting for launch summaries. Launch status is then requested for every awarded job that has a permanent job number, including legacy jobs without a recorded workspace root. IHOS limits launch requests to three at a time and abandons each request after eight seconds. If one source is temporarily unavailable, IHOS identifies the missing status and keeps the successfully loaded work usable. A single failed request must not blank the workflow page.
 
 ## Controls
 

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -184,7 +184,7 @@ export const projectsApi = {
     }),
   dashboard: (id: string) => request<ProjectDashboard>(`/projects/${id}/dashboard`),
   workspace: (id: string) => request<AwardedProjectWorkspace>(`/projects/${id}/workspace`),
-  launchDashboard: (id: string) => request<ProjectLaunchDashboard>(`/projects/${id}/launch-dashboard`),
+  launchDashboard: (id: string, options?: RequestInit) => request<ProjectLaunchDashboard>(`/projects/${id}/launch-dashboard`, options),
   startChecklist: (id: string) => requestOptional<ProjectStartChecklist>(`/projects/${id}/start-checklist`),
   updateStartChecklistItem: (id: string, code: string, completed: boolean) =>
     request<ProjectStartChecklist>(`/projects/${id}/start-checklist/${encodeURIComponent(code)}`, {

--- a/frontend/src/hooks/useWorkflowDraft.test.tsx
+++ b/frontend/src/hooks/useWorkflowDraft.test.tsx
@@ -13,7 +13,7 @@ function jsonResponse(payload: unknown, status = 200) {
   });
 }
 
-function Harness() {
+function Harness({ recoverLocal = true }: { recoverLocal?: boolean }) {
   const [value, setValue] = useState("");
   const draft = useWorkflowDraft({
     workflowType: "purchase_order_request",
@@ -21,6 +21,7 @@ function Harness() {
     payload: { value },
     ready: true,
     enabled: Boolean(value),
+    recoverLocal,
     onRestore: (saved) => setValue(typeof saved.value === "string" ? saved.value : ""),
   });
   return (
@@ -34,6 +35,7 @@ function Harness() {
 describe("useWorkflowDraft", () => {
   beforeEach(() => {
     window.history.replaceState({}, "", "/");
+    window.localStorage.clear();
     vi.stubGlobal("fetch", vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));
       return jsonResponse({
@@ -80,5 +82,17 @@ describe("useWorkflowDraft", () => {
 
     expect(await screen.findByDisplayValue("Recovered valves")).toBeInTheDocument();
     expect(screen.getByText("Recovered unsaved work from this device")).toBeInTheDocument();
+  });
+
+  it("can preserve an explicitly targeted record instead of restoring a device buffer", async () => {
+    window.localStorage.setItem(
+      "ihos:draft-recovery:purchase_order_request",
+      JSON.stringify({ payload: { value: "Unrelated recovered valves" }, savedAt: "2026-08-21T06:25:00Z" }),
+    );
+
+    render(<Harness recoverLocal={false} />);
+
+    await waitFor(() => expect(screen.getByLabelText("Purpose")).toHaveValue(""));
+    expect(screen.queryByText("Recovered unsaved work from this device")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/useWorkflowDraft.ts
+++ b/frontend/src/hooks/useWorkflowDraft.ts
@@ -16,6 +16,7 @@ type UseWorkflowDraftOptions<T extends Record<string, unknown>> = {
   projectId?: string | null;
   ready: boolean;
   enabled: boolean;
+  recoverLocal?: boolean;
   onRestore: (payload: T) => void;
   schemaVersion?: number;
 };
@@ -38,6 +39,7 @@ export function useWorkflowDraft<T extends Record<string, unknown>>({
   projectId = null,
   ready,
   enabled,
+  recoverLocal = true,
   onRestore,
   schemaVersion = 1,
 }: UseWorkflowDraftOptions<T>) {
@@ -79,7 +81,7 @@ export function useWorkflowDraft<T extends Record<string, unknown>>({
           replaceDraftId(null);
           setStatus("offline");
         }
-      } else {
+      } else if (recoverLocal) {
         try {
           const raw = window.localStorage.getItem(localKey);
           if (raw) {
@@ -97,7 +99,7 @@ export function useWorkflowDraft<T extends Record<string, unknown>>({
 
     void initialize();
     return () => { active = false; };
-  }, [localKey, ready, workflowType]);
+  }, [localKey, ready, recoverLocal, workflowType]);
 
   useEffect(() => {
     if (!ready || !initialized || !enabled) return;

--- a/frontend/src/pages/CustomerQuotesPage.test.tsx
+++ b/frontend/src/pages/CustomerQuotesPage.test.tsx
@@ -61,6 +61,8 @@ describe("CustomerQuotesPage", () => {
   beforeEach(() => {
     quoteBodies.length = 0;
     savedQuote = null;
+    window.localStorage.clear();
+    window.history.replaceState({}, "", "/customer-quotes");
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/customer-quotes") && !init?.method) {
@@ -70,6 +72,12 @@ describe("CustomerQuotesPage", () => {
         quoteBodies.push(JSON.parse(String(init.body)));
         savedQuote = quote("draft", 1);
         return json(savedQuote, 201);
+      }
+      if (url.endsWith("/customer-quotes/quote-1") && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body));
+        quoteBodies.push(body);
+        savedQuote = { ...quote("draft", 2), ...body, record_revision: 2 };
+        return json(savedQuote);
       }
       if (url.endsWith("/accept") && init?.method === "POST") {
         quoteBodies.push(JSON.parse(String(init.body)));
@@ -157,6 +165,13 @@ describe("CustomerQuotesPage", () => {
   it("opens a queued draft directly and records a sent quote decision", async () => {
     vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
     savedQuote = quote("draft", 1);
+    window.localStorage.setItem(
+      "ihos:draft-recovery:customer_quote",
+      JSON.stringify({
+        payload: { projectName: "Unrelated device recovery", customerName: "Wrong customer" },
+        savedAt: "2026-08-21T10:00:00Z",
+      }),
+    );
     const { unmount } = render(
       <MemoryRouter initialEntries={["/customer-quotes?quoteId=quote-1&action=edit"]}>
         <CustomerQuotesPage />
@@ -165,6 +180,7 @@ describe("CustomerQuotesPage", () => {
 
     expect(await screen.findByRole("heading", { name: "Edit Q-2026-001" })).toBeInTheDocument();
     expect(screen.getByLabelText("Project / work name")).toHaveValue("Smith drainage repair");
+    expect(screen.getByLabelText("Customer / company")).toHaveValue("Alex Smith");
     unmount();
 
     savedQuote = quote("sent", 1);
@@ -179,5 +195,25 @@ describe("CustomerQuotesPage", () => {
     await user.click(await screen.findByRole("button", { name: "Mark declined" }));
     await waitFor(() => expect(screen.getByText("declined")).toBeInTheDocument());
     expect(quoteBodies.at(-1)).toEqual({ expected_revision: 1, status: "declined", note: null });
+  });
+
+  it.each(["declined", "expired"] as const)("starts a controlled revision from a %s quote", async (status) => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    savedQuote = quote(status, 1);
+    const user = userEvent.setup();
+
+    render(<MemoryRouter><CustomerQuotesPage /></MemoryRouter>);
+
+    await user.click(await screen.findByRole("button", { name: "Start new revision" }));
+    expect(screen.getByRole("heading", { name: "New revision Q-2026-001" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Accept / award" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Mark sent" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Mark declined" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Mark expired" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save quote revision" }));
+
+    expect(await screen.findByText("Q-2026-001 saved in IHOS as draft.")).toBeInTheDocument();
+    expect(quoteBodies.at(-1)).toEqual(expect.objectContaining({ expected_revision: 1 }));
   });
 });

--- a/frontend/src/pages/CustomerQuotesPage.tsx
+++ b/frontend/src/pages/CustomerQuotesPage.tsx
@@ -88,12 +88,15 @@ export function CustomerQuotesPage() {
     siteAddress.trim() || scopeSummary.trim() || notes.trim() || assumptions.trim() || exclusions.trim() ||
     lineItems.some((line) => line.description.trim() || Number(line.unit_price) > 0),
   );
+  const targetParams = new URLSearchParams(location.search);
+  const targetedQuoteEdit = Boolean(targetParams.get("quoteId") && targetParams.get("action") === "edit");
   const draft = useWorkflowDraft({
     workflowType: "customer_quote",
     title: customerName.trim() ? `Customer quote — ${customerName.trim()}` : "Customer quote",
     payload: draftPayload,
     ready: registerReady,
     enabled: draftEnabled && !editing,
+    recoverLocal: !targetedQuoteEdit,
     onRestore: (saved) => {
       setProjectName(text(saved.projectName));
       setCustomerName(text(saved.customerName));
@@ -266,7 +269,7 @@ export function CustomerQuotesPage() {
 
       <form onSubmit={submit} className="space-y-5 rounded-xl border border-iron-100 bg-white p-5 shadow-sm">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div><h2 className="text-xl font-semibold text-iron-950">{editing ? `Edit ${editing.quote_number}` : "New verbal quote intake"}</h2><p className="mt-1 text-sm text-iron-500">Required information is saved in IHOS; nothing is sent or accepted by this form.</p></div>
+          <div><h2 className="text-xl font-semibold text-iron-950">{editing ? `${editing.status === "declined" || editing.status === "expired" ? "New revision" : "Edit"} ${editing.quote_number}` : "New verbal quote intake"}</h2><p className="mt-1 text-sm text-iron-500">Required information is saved in IHOS; nothing is sent or accepted by this form.</p></div>
           {editing ? <button type="button" onClick={reset} className="rounded-md border border-iron-200 px-3 py-2 text-sm font-semibold">Cancel edit</button> : null}
         </div>
         <div className="grid gap-4 md:grid-cols-2">
@@ -318,7 +321,8 @@ export function CustomerQuotesPage() {
         <div className="mt-4 overflow-x-auto"><table className="w-full text-left text-sm"><thead className="bg-iron-50 text-xs uppercase tracking-wide text-iron-500"><tr><th className="px-3 py-2">Quote</th><th className="px-3 py-2">Customer / project</th><th className="px-3 py-2">Total</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Job</th><th className="px-3 py-2">Actions</th></tr></thead><tbody>
           {quotes.map((quote) => {
             const targeted = new URLSearchParams(location.search).get("quoteId") === quote.id;
-            return <tr id={`quote-${quote.id}`} key={quote.id} className={["border-t border-iron-100", targeted ? "bg-brand-gold/10" : ""].join(" ")}><td className="px-3 py-3 font-semibold text-iron-950">{quote.quote_number}</td><td className="px-3 py-3"><div>{quote.customer_name}</div><div className="text-xs text-iron-500">{quote.project_name}</div></td><td className="px-3 py-3">{money.format(Number(quote.total))}</td><td className="px-3 py-3 capitalize">{quote.status}</td><td className="px-3 py-3">{quote.job_number ?? "Not awarded"}</td><td className="px-3 py-3"><div className="flex flex-wrap gap-2">{quote.status !== "accepted" && quote.status !== "declined" && quote.status !== "expired" ? <><button type="button" onClick={() => edit(quote)} className="font-semibold text-iron-700">Edit</button>{quote.status === "draft" ? <button type="button" onClick={() => void markSent(quote)} className="font-semibold text-iron-700">Mark sent</button> : null}{user?.role === "admin" || user?.role === "operations_manager" ? <button type="button" onClick={() => { setAccepting(quote); setAcceptanceReference(""); setAcceptanceNote(""); }} className="font-semibold text-emerald-700">Accept / award</button> : null}<button type="button" onClick={() => void closeQuote(quote, "declined")} className="font-semibold text-red-700">Mark declined</button><button type="button" onClick={() => void closeQuote(quote, "expired")} className="font-semibold text-iron-500">Mark expired</button></> : null}<a href={customerQuotesApi.pdfUrl(quote.id)} target="_blank" rel="noopener noreferrer" className="font-semibold text-iron-700">Open PDF</a><Link to={`/projects/${quote.project_id}`} className="font-semibold text-iron-700">Project</Link></div></td></tr>;
+            const closed = quote.status === "declined" || quote.status === "expired";
+            return <tr id={`quote-${quote.id}`} key={quote.id} className={["border-t border-iron-100", targeted ? "bg-brand-gold/10" : ""].join(" ")}><td className="px-3 py-3 font-semibold text-iron-950">{quote.quote_number}</td><td className="px-3 py-3"><div>{quote.customer_name}</div><div className="text-xs text-iron-500">{quote.project_name}</div></td><td className="px-3 py-3">{money.format(Number(quote.total))}</td><td className="px-3 py-3 capitalize">{quote.status}</td><td className="px-3 py-3">{quote.job_number ?? "Not awarded"}</td><td className="px-3 py-3"><div className="flex flex-wrap gap-2">{quote.status !== "accepted" ? <><button type="button" onClick={() => edit(quote)} className="font-semibold text-iron-700">{closed ? "Start new revision" : "Edit"}</button>{!closed && quote.status === "draft" ? <button type="button" onClick={() => void markSent(quote)} className="font-semibold text-iron-700">Mark sent</button> : null}{!closed && (user?.role === "admin" || user?.role === "operations_manager") ? <button type="button" onClick={() => { setAccepting(quote); setAcceptanceReference(""); setAcceptanceNote(""); }} className="font-semibold text-emerald-700">Accept / award</button> : null}{!closed ? <><button type="button" onClick={() => void closeQuote(quote, "declined")} className="font-semibold text-red-700">Mark declined</button><button type="button" onClick={() => void closeQuote(quote, "expired")} className="font-semibold text-iron-500">Mark expired</button></> : null}</> : null}<a href={customerQuotesApi.pdfUrl(quote.id)} target="_blank" rel="noopener noreferrer" className="font-semibold text-iron-700">Open PDF</a><Link to={`/projects/${quote.project_id}`} className="font-semibold text-iron-700">Project</Link></div></td></tr>;
           })}
           {!quotes.length ? <tr><td colSpan={6} className="px-3 py-8 text-center text-iron-500">No customer quotes yet.</td></tr> : null}
         </tbody></table></div>

--- a/frontend/src/pages/FinancialControlPage.test.tsx
+++ b/frontend/src/pages/FinancialControlPage.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BackupsIntake } from "../api/backups";
@@ -19,13 +21,14 @@ const item: BackupsIntake = {
 describe("FinancialControlPage Backups queues", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.localStorage.clear();
     window.history.replaceState({}, "", "/finance");
     vi.mocked(financeApi.getStartupExpenses).mockResolvedValue({ total_startup_costs: 0, owner_loan_payable: 0, reimbursed_to_owner: 0, pending_review: 0, approved_unreimbursed: 0, entries: [] });
     vi.mocked(financeApi.getBackupsReview).mockImplementation(async (destination) => ({ items: destination === "finance_packing_slips" ? [item] : [], total: destination === "finance_packing_slips" ? 1 : 0 }));
   });
 
   it("shows separate review-only intake, receipt, invoice, and packing-slip sections", async () => {
-    render(<FinancialControlPage />);
+    renderFinancial("/finance");
     expect(await screen.findByRole("heading", { name: "Backups review queues" })).toBeInTheDocument();
     for (const name of ["Finance intake", "Receipts", "Invoices", "Packing Slips"]) expect(screen.getByRole("heading", { name })).toBeInTheDocument();
     expect(screen.getByText(/quantity, quality, delivery acceptance, and project cost are not confirmed/i)).toBeInTheDocument();
@@ -54,9 +57,58 @@ describe("FinancialControlPage Backups queues", () => {
       cost_codes: [],
     });
 
-    render(<FinancialControlPage />);
+    renderFinancial("/finance?projectId=project-7&projectName=Linked+Job");
 
     expect(await screen.findByRole("combobox", { name: "Project" })).toHaveValue("project-7");
     await waitFor(() => expect(financeApi.getProject).toHaveBeenCalledWith("project-7"));
   });
+
+  it("updates the financial summary when the routed project changes without unmounting", async () => {
+    const user = userEvent.setup();
+    vi.mocked(projectsApi.list).mockResolvedValue({
+      items: [
+        { id: "project-7", name: "Linked Job" },
+        { id: "project-8", name: "Second Job" },
+      ],
+      total: 2,
+    } as never);
+    vi.mocked(financeApi.getProject).mockImplementation(async (projectId) => ({
+      project_id: projectId,
+      project_name: projectId === "project-7" ? "Linked Job" : "Second Job",
+      contract_value: 0,
+      budget: 0,
+      committed: 0,
+      actual: 0,
+      forecast_cost: 0,
+      cost_variance: 0,
+      forecast_profit: 0,
+      forecast_margin_percent: 0,
+      entries: [],
+      cost_codes: [],
+    }));
+
+    render(
+      <MemoryRouter initialEntries={["/finance?projectId=project-7&projectName=Linked+Job"]}>
+        <FinancialRouteHarness />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("combobox", { name: "Project" })).toHaveValue("project-7");
+    await user.click(screen.getByRole("button", { name: "Open second project" }));
+
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Project" })).toHaveValue("project-8"));
+    await waitFor(() => expect(financeApi.getProject).toHaveBeenCalledWith("project-8"));
+  });
 });
+
+function renderFinancial(path: string) {
+  return render(<MemoryRouter initialEntries={[path]}><FinancialControlPage /></MemoryRouter>);
+}
+
+function FinancialRouteHarness() {
+  const navigate = useNavigate();
+  return <>
+    <button type="button" onClick={() => navigate("/finance?projectId=project-8&projectName=Second+Job")}>Open second project</button>
+    <FinancialControlPage />
+  </>;
+}

--- a/frontend/src/pages/FinancialControlPage.tsx
+++ b/frontend/src/pages/FinancialControlPage.tsx
@@ -1,5 +1,6 @@
 import { DollarSign, Download, RefreshCw } from "lucide-react";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 import { BackupsIntake, BackupsReviewDestination } from "../api/backups";
 import { mediaApi } from "../api/media";
@@ -14,8 +15,10 @@ const money = new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD
 const today = () => new Date().toISOString().slice(0, 10);
 
 export function FinancialControlPage() {
-  const routedProjectId = readEffectiveProjectContext(window.location.search).projectId ?? "";
+  const location = useLocation();
+  const routedProjectId = readEffectiveProjectContext(location.search).projectId ?? "";
   const [projects, setProjects] = useState<Project[]>([]);
+  const [projectsReady, setProjectsReady] = useState(false);
   const [projectId, setProjectId] = useState(routedProjectId);
   const [summary, setSummary] = useState<FinancialSummary | null>(null);
   const [startup, setStartup] = useState<StartupExpenseSummary | null>(null);
@@ -24,8 +27,15 @@ export function FinancialControlPage() {
   const [startupDate, setStartupDate] = useState(today()); const [startupVendor, setStartupVendor] = useState(""); const [startupDescription, setStartupDescription] = useState(""); const [startupAmount, setStartupAmount] = useState(""); const [startupCategory, setStartupCategory] = useState("other"); const [startupReference, setStartupReference] = useState(""); const [startupOwner, setStartupOwner] = useState("");
   const [startupFiles, setStartupFiles] = useState<File[]>([]);
   const [error, setError] = useState<string | null>(null); const [loading, setLoading] = useState(false);
-  useEffect(() => { projectsApi.list().then((data) => { setProjects(data.items); if (routedProjectId && data.items.some((project) => project.id === routedProjectId)) void refresh(routedProjectId); }).catch(() => setError("Unable to load projects.")); void refreshStartup(); void refreshBackupsReview(); }, []);
-  async function refresh(id = projectId) { if (!id) return; setLoading(true); setError(null); try { setSummary(await financeApi.getProject(id)); } catch (current) { setError(current instanceof Error ? current.message : "Unable to load financials."); } finally { setLoading(false); } }
+  const summaryRequest = useRef(0);
+  useEffect(() => { projectsApi.list().then((data) => setProjects(data.items)).catch(() => setError("Unable to load projects.")).finally(() => setProjectsReady(true)); void refreshStartup(); void refreshBackupsReview(); }, []);
+  useEffect(() => {
+    if (!projectsReady || !routedProjectId || !projects.some((project) => project.id === routedProjectId)) return;
+    setProjectId(routedProjectId);
+    setSummary(null);
+    void refresh(routedProjectId);
+  }, [projects, projectsReady, routedProjectId]);
+  async function refresh(id = projectId) { if (!id) return; const request = summaryRequest.current + 1; summaryRequest.current = request; setLoading(true); setError(null); try { const next = await financeApi.getProject(id); if (request === summaryRequest.current) setSummary(next); } catch (current) { if (request === summaryRequest.current) setError(current instanceof Error ? current.message : "Unable to load financials."); } finally { if (request === summaryRequest.current) setLoading(false); } }
   async function refreshStartup() { try { setStartup(await financeApi.getStartupExpenses()); } catch (current) { setError(current instanceof Error ? current.message : "Unable to load startup costs."); } }
   async function refreshBackupsReview() { const destinations: BackupsReviewDestination[] = ["finance_intake", "finance_receipts", "finance_invoices", "finance_packing_slips"]; try { const queues = await Promise.all(destinations.map(async (destination) => [destination, (await financeApi.getBackupsReview(destination)).items] as const)); setBackupsReview(Object.fromEntries(queues)); } catch (current) { setError(current instanceof Error ? current.message : "Unable to load Backups review queues."); } }
   async function importBudget() { if (!projectId) return; setLoading(true); setError(null); try { setSummary(await financeApi.importEstimate(projectId)); } catch (current) { setError(current instanceof Error ? current.message : "Unable to import estimate."); } finally { setLoading(false); } }

--- a/frontend/src/pages/MVPWorkflowPage.test.tsx
+++ b/frontend/src/pages/MVPWorkflowPage.test.tsx
@@ -123,7 +123,7 @@ describe("MVPWorkflowPage", () => {
     );
 
     const launchCard = within(queue).getByText("Awarded launch job").closest("article");
-    expect(launchCard).toHaveTextContent("3 of 10 start controls");
+    await waitFor(() => expect(launchCard).toHaveTextContent("3 of 10 start controls"));
     expect(within(launchCard as HTMLElement).getByRole("link", { name: "Complete launch controls" })).toHaveAttribute(
       "href",
       `/projects/${launchJob.id}`,
@@ -145,7 +145,64 @@ describe("MVPWorkflowPage", () => {
       "href",
       expect.stringContaining(`projectId=${constructionJob.id}`),
     );
+    expect(within(constructionCard as HTMLElement).getByRole("link", { name: "PO requests" })).toHaveAttribute(
+      "href",
+      expect.stringContaining(`/request-po?projectId=${constructionJob.id}`),
+    );
+    expect(within(constructionCard as HTMLElement).getByRole("link", { name: "Documents" })).toHaveAttribute(
+      "href",
+      expect.stringContaining(`/documents?projectId=${constructionJob.id}`),
+    );
     expect(within(queue).getAllByRole("article")).toHaveLength(5);
+  });
+
+  it("shows awarded and construction records even if a stale active quote references them", async () => {
+    mockApi({
+      quotes: [customerQuote({ project_id: constructionJob.id, status: "draft" })],
+      projects: [constructionJob],
+    });
+
+    renderWorkflow();
+
+    const queue = await screen.findByLabelText("Active quote-to-job work queue");
+    expect(within(queue).getByText("Quote draft")).toBeInTheDocument();
+    expect(within(queue).getByText("Active delivery")).toBeInTheDocument();
+    expect(within(queue).getAllByRole("article")).toHaveLength(2);
+  });
+
+  it("renders awarded jobs before bounded launch summaries finish and includes legacy jobs", async () => {
+    let maxConcurrentLaunches = 0;
+    const jobs = Array.from({ length: 5 }, (_, index) => project({
+      id: `legacy-awarded-${index + 1}`,
+      name: `Legacy awarded ${index + 1}`,
+      status: "awarded",
+      project_number: `IH-2026-${30 + index}`,
+      workspace_root: null,
+    }));
+    const launches = Object.fromEntries(jobs.map((job) => [job.id, launchDashboard(job, "not_ready")]));
+    const fetchMock = mockApi({
+      projects: jobs,
+      launches,
+      launchDelay: 40,
+      onLaunchActivity: (active) => { maxConcurrentLaunches = Math.max(maxConcurrentLaunches, active); },
+    });
+
+    renderWorkflow();
+
+    expect(await screen.findByText("Legacy awarded 1")).toBeInTheDocument();
+    expect(screen.getByText("5 active")).toBeInTheDocument();
+    expect(screen.getAllByText(/launch summary is temporarily unavailable/i)).toHaveLength(5);
+
+    await waitFor(() => expect(
+      fetchMock.mock.calls.filter(([input]) => String(input).includes("/launch-dashboard")),
+    ).toHaveLength(5));
+    expect(maxConcurrentLaunches).toBe(3);
+    for (const job of jobs) {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(`/projects/${job.id}/launch-dashboard`),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    }
   });
 
   it("keeps available work usable when one source fails", async () => {
@@ -170,13 +227,18 @@ function mockApi({
   projects = [],
   launches = {},
   failQuotes = false,
+  launchDelay = 0,
+  onLaunchActivity,
 }: {
   drafts?: (typeof draft)[];
   quotes?: CustomerQuote[];
   projects?: Project[];
   launches?: Record<string, ProjectLaunchDashboard>;
   failQuotes?: boolean;
+  launchDelay?: number;
+  onLaunchActivity?: (active: number) => void;
 } = {}) {
+  let activeLaunches = 0;
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = input.toString();
     if (url.includes("/workflow-drafts/") && url.endsWith("/cancel") && init?.method === "POST") {
@@ -188,8 +250,16 @@ function mockApi({
     }
     const launchMatch = url.match(/\/projects\/([^/]+)\/launch-dashboard$/);
     if (launchMatch) {
-      const launch = launches[launchMatch[1]];
-      return launch ? response(launch) : response({ detail: "Unavailable" }, 503);
+      activeLaunches += 1;
+      onLaunchActivity?.(activeLaunches);
+      try {
+        if (launchDelay) await new Promise((resolve) => window.setTimeout(resolve, launchDelay));
+        const launch = launches[launchMatch[1]];
+        return launch ? response(launch) : response({ detail: "Unavailable" }, 503);
+      } finally {
+        activeLaunches -= 1;
+        onLaunchActivity?.(activeLaunches);
+      }
     }
     if (url.endsWith("/projects")) return response({ items: projects, total: projects.length });
     return response({ detail: "Not found" }, 404);

--- a/frontend/src/pages/MVPWorkflowPage.tsx
+++ b/frontend/src/pages/MVPWorkflowPage.tsx
@@ -40,6 +40,7 @@ export function MVPWorkflowPage() {
 
   useEffect(() => {
     let active = true;
+    const launchControllers = new Set<AbortController>();
     void (async () => {
       const errors: string[] = [];
       const [draftResult, quoteResult, projectResult] = await Promise.allSettled([
@@ -57,18 +58,35 @@ export function MVPWorkflowPage() {
       if (projectResult.status === "fulfilled") {
         setProjects(projectResult.value.items);
         const awarded = projectResult.value.items.filter(
-          (project) => project.status === "awarded" && project.workspace_root,
+          (project) => project.status === "awarded" && project.project_number,
         );
-        const launches = await Promise.allSettled(
-          awarded.map((project) => projectsApi.launchDashboard(project.id)),
-        );
-        if (!active) return;
-        const available: Record<string, ProjectLaunchDashboard> = {};
-        launches.forEach((result, index) => {
-          if (result.status === "fulfilled") available[awarded[index].id] = result.value;
-          else errors.push(`Launch status could not be loaded for ${awarded[index].name}.`);
-        });
-        setLaunchByProjectId(available);
+        setLoadErrors(errors);
+        setIsLoading(false);
+
+        let nextIndex = 0;
+        async function loadNextLaunch() {
+          while (active && nextIndex < awarded.length) {
+            const project = awarded[nextIndex];
+            nextIndex += 1;
+            const controller = new AbortController();
+            launchControllers.add(controller);
+            const timeout = window.setTimeout(() => controller.abort(), 8000);
+            try {
+              const launch = await projectsApi.launchDashboard(project.id, { signal: controller.signal });
+              if (active) setLaunchByProjectId((current) => ({ ...current, [project.id]: launch }));
+            } catch {
+              if (active) {
+                const message = `Launch status could not be loaded for ${project.name}.`;
+                setLoadErrors((current) => current.includes(message) ? current : [...current, message]);
+              }
+            } finally {
+              window.clearTimeout(timeout);
+              launchControllers.delete(controller);
+            }
+          }
+        }
+        void Promise.all(Array.from({ length: Math.min(3, awarded.length) }, () => loadNextLaunch()));
+        return;
       } else {
         errors.push("Projects could not be loaded.");
       }
@@ -76,7 +94,11 @@ export function MVPWorkflowPage() {
       setLoadErrors(errors);
       setIsLoading(false);
     })();
-    return () => { active = false; };
+    return () => {
+      active = false;
+      launchControllers.forEach((controller) => controller.abort());
+      launchControllers.clear();
+    };
   }, []);
 
   const workQueue = useMemo(
@@ -253,7 +275,11 @@ export function buildMvpWorkQueue(
   }
 
   for (const project of projects) {
-    if (project.status === "archived" || project.status === "completed" || activeQuoteProjectIds.has(project.id)) continue;
+    if (
+      project.status === "archived" ||
+      project.status === "completed" ||
+      (project.status === "opportunity" && activeQuoteProjectIds.has(project.id))
+    ) continue;
     const projectContext = { id: project.id, name: project.name };
     if (project.status === "awarded") {
       const launch = launchByProjectId[project.id];
@@ -288,7 +314,9 @@ export function buildMvpWorkQueue(
         nextPath: withProjectContext("/project-operations", projectContext),
         secondaryActions: [
           { label: "Finance", path: withProjectContext("/finance", projectContext) },
+          { label: "PO requests", path: withProjectContext("/request-po", projectContext) },
           { label: "Safety", path: withProjectContext("/safety-operations", projectContext) },
+          { label: "Documents", path: withProjectContext("/documents", projectContext) },
         ],
       });
     } else {

--- a/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fieldOperationsApi } from "../api/fieldOperations";
 import { PurchaseOrderRequestPage } from "./PurchaseOrderRequestPage";
@@ -29,17 +31,72 @@ describe("PurchaseOrderRequestPage", () => {
     window.localStorage.clear();
     window.history.replaceState({}, "", "/request-po?projectId=job-1&projectName=Linked+Job");
     vi.mocked(fieldOperationsApi.bootstrap).mockResolvedValue({
-      projects: [{ id: "job-1", name: "Linked Job", project_number: "IH-2026-030" }],
+      projects: [
+        { id: "job-1", name: "Linked Job", project_number: "IH-2026-030" },
+        { id: "job-2", name: "Second Job", project_number: "IH-2026-031" },
+      ],
       suppliers: [],
       cost_codes: [],
       records: [],
     } as never);
   });
 
+  afterEach(() => vi.unstubAllGlobals());
+
   it("preselects the job carried from the guided workflow", async () => {
-    render(<PurchaseOrderRequestPage />);
+    renderPo("/request-po?projectId=job-1&projectName=Linked+Job");
 
     expect(await screen.findByRole("combobox", { name: "Job" })).toHaveValue("job-1");
     expect(screen.getByRole("option", { name: "IH-2026-030 Linked Job" })).toBeInTheDocument();
   });
+
+  it("updates the selected job when workflow context changes without unmounting", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/request-po?projectId=job-1&projectName=Linked+Job"]}>
+        <PoRouteHarness />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("combobox", { name: "Job" })).toHaveValue("job-1");
+    await user.click(screen.getByRole("button", { name: "Open second job" }));
+
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Job" })).toHaveValue("job-2"));
+  });
+
+  it("keeps an explicit workflow draft authoritative over routed project context", async () => {
+    window.history.replaceState({}, "", "/request-po?draftId=draft-1&projectId=job-1&projectName=Linked+Job");
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({
+      id: "draft-1",
+      owner_account_id: "admin-1",
+      project_id: "job-2",
+      workflow_type: "purchase_order_request",
+      title: "PO request — Aggregate",
+      payload: { projectId: "job-2", supplierId: "", costCode: "", purpose: "Aggregate", amount: "" },
+      schema_version: 1,
+      revision: 2,
+      status: "active",
+      last_saved_at: "2026-08-21T12:00:00Z",
+      created_at: "2026-08-21T11:00:00Z",
+      updated_at: "2026-08-21T12:00:00Z",
+    }), { status: 200, headers: { "Content-Type": "application/json" } })));
+
+    renderPo("/request-po?draftId=draft-1&projectId=job-1&projectName=Linked+Job");
+
+    const jobSelect = await screen.findByRole("combobox", { name: "Job" });
+    await waitFor(() => expect(jobSelect).toHaveValue("job-2"));
+    expect(screen.getByPlaceholderText(/20 m of 200 mm PVC/)).toHaveValue("Aggregate");
+  });
 });
+
+function renderPo(path: string) {
+  return render(<MemoryRouter initialEntries={[path]}><PurchaseOrderRequestPage /></MemoryRouter>);
+}
+
+function PoRouteHarness() {
+  const navigate = useNavigate();
+  return <>
+    <button type="button" onClick={() => navigate("/request-po?projectId=job-2&projectName=Second+Job")}>Open second job</button>
+    <PurchaseOrderRequestPage />
+  </>;
+}

--- a/frontend/src/pages/PurchaseOrderRequestPage.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useLocation } from "react-router-dom";
 
 import { fieldOperationsApi, FieldOperationsBootstrap, FieldRecord } from "../api/fieldOperations";
 import { useAuth } from "../contexts/AuthContext";
@@ -15,7 +16,9 @@ function buildPoNumber(jobNumber: string) {
 
 export function PurchaseOrderRequestPage() {
   const { user, portalRole } = useAuth();
-  const routedProjectId = readEffectiveProjectContext(window.location.search).projectId ?? "";
+  const location = useLocation();
+  const routedProjectId = readEffectiveProjectContext(location.search).projectId ?? "";
+  const requestedDraftId = new URLSearchParams(location.search).get("draftId");
   const [data, setData] = useState<FieldOperationsBootstrap | null>(null);
   const [projectId, setProjectId] = useState(routedProjectId);
   const [supplierId, setSupplierId] = useState("");
@@ -39,6 +42,11 @@ export function PurchaseOrderRequestPage() {
   useEffect(() => {
     void refresh().finally(() => setBootstrapReady(true));
   }, []);
+  useEffect(() => {
+    if (!bootstrapReady || requestedDraftId || !routedProjectId) return;
+    if (!data?.projects.some((project) => project.id === routedProjectId)) return;
+    setProjectId(routedProjectId);
+  }, [bootstrapReady, data?.projects, requestedDraftId, routedProjectId]);
 
   const draftPayload = useMemo(() => ({
     projectId,
@@ -56,8 +64,7 @@ export function PurchaseOrderRequestPage() {
     ready: bootstrapReady,
     enabled: draftEnabled,
     onRestore: (saved) => {
-      const requestedDraft = new URLSearchParams(window.location.search).has("draftId");
-      setProjectId(requestedDraft
+      setProjectId(requestedDraftId
         ? (typeof saved.projectId === "string" ? saved.projectId : "")
         : routedProjectId || (typeof saved.projectId === "string" ? saved.projectId : ""));
       setSupplierId(typeof saved.supplierId === "string" ? saved.supplierId : "");

--- a/frontend/src/pages/SafetyOperationsPage.test.tsx
+++ b/frontend/src/pages/SafetyOperationsPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useNavigate } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fieldOperationsApi } from "../api/fieldOperations";
@@ -43,7 +44,10 @@ describe("SafetyOperationsPage", () => {
     });
     vi.mocked(fieldOperationsApi.bootstrap).mockResolvedValue({
       employees: [{ id: "worker-1", first_name: "Crew", last_name: "Member", email: "crew@example.com" }],
-      projects: [{ id: "project-1", name: "River Road", project_number: "IH-2026-001" }],
+      projects: [
+        { id: "project-1", name: "River Road", project_number: "IH-2026-001" },
+        { id: "project-2", name: "Mountain Road", project_number: "IH-2026-002" },
+      ],
       records: [{
         id: "incident-1",
         record_type: "incident",
@@ -98,7 +102,7 @@ describe("SafetyOperationsPage", () => {
 
   it("shows durable incident review and management-only first-aid workflows", async () => {
     const user = userEvent.setup();
-    render(<SafetyOperationsPage />);
+    renderSafety("/safety-operations");
 
     expect(await screen.findByText("Open incidents")).toBeInTheDocument();
     expect(screen.getByText("Management safety analytics")).toBeInTheDocument();
@@ -125,7 +129,7 @@ describe("SafetyOperationsPage", () => {
     window.history.replaceState({}, "", "/safety-operations?projectId=project-1&projectName=River+Road");
     const user = userEvent.setup();
 
-    render(<SafetyOperationsPage />);
+    renderSafety("/safety-operations?projectId=project-1&projectName=River+Road");
 
     expect(await screen.findByText("New safety records will be linked to River Road.")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Project / location")).toHaveValue("River Road");
@@ -142,4 +146,42 @@ describe("SafetyOperationsPage", () => {
       }),
     ));
   });
+
+  it("updates safety project context and form defaults without unmounting", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/safety-operations?projectId=project-1&projectName=River+Road"]}>
+        <SafetyRouteHarness />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("New safety records will be linked to River Road.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Open Mountain Road" }));
+
+    expect(await screen.findByText("New safety records will be linked to Mountain Road.")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Project / location")).toHaveValue("Mountain Road");
+    await user.type(screen.getByPlaceholderText("Task and work limits"), "Install drainage crossing");
+    await user.type(screen.getByPlaceholderText("Responsible supervisor"), "Site supervisor");
+    await user.type(screen.getByPlaceholderText("Controls and verification evidence required"), "Confirm locates and shoring");
+    await user.click(screen.getByRole("button", { name: "Save blocked permit" }));
+
+    await waitFor(() => expect(fieldOperationsApi.createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project_id: "project-2",
+        details: expect.objectContaining({ project: "Mountain Road" }),
+      }),
+    ));
+  });
 });
+
+function renderSafety(path: string) {
+  return render(<MemoryRouter initialEntries={[path]}><SafetyOperationsPage /></MemoryRouter>);
+}
+
+function SafetyRouteHarness() {
+  const navigate = useNavigate();
+  return <>
+    <button type="button" onClick={() => navigate("/safety-operations?projectId=project-2&projectName=Mountain+Road")}>Open Mountain Road</button>
+    <SafetyOperationsPage />
+  </>;
+}

--- a/frontend/src/pages/SafetyOperationsPage.tsx
+++ b/frontend/src/pages/SafetyOperationsPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
 import { AlertTriangle, ClipboardList, Copy, Download, FileWarning, HeartPulse, QrCode, Radio, ShieldAlert, Siren } from "lucide-react";
+import { useLocation } from "react-router-dom";
 
 import { Employee, FieldOperationsBootstrap, FieldRecord, SafetyAnalytics, fieldOperationsApi } from "../api/fieldOperations";
 import { useAuth } from "../contexts/AuthContext";
@@ -9,15 +10,17 @@ const TYPES = ["safety_permit", "corrective_action", "emergency_action_card", "i
 
 export function SafetyOperationsPage() {
   const { user } = useAuth();
+  const location = useLocation();
   const [records, setRecords] = useState<FieldRecord[]>([]);
   const [employees, setEmployees] = useState<Employee[]>([]);
   const [projects, setProjects] = useState<FieldOperationsBootstrap["projects"]>([]);
   const [analytics, setAnalytics] = useState<SafetyAnalytics | null>(null);
-  const fieldLink = useMemo(() => new URLSearchParams(window.location.search), []);
+  const fieldLink = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const linkedRecordId = fieldLink.get("record");
   const linkedProjectId = fieldLink.get("projectId");
   const linkedProjectName = fieldLink.get("projectName") ?? projects.find((project) => project.id === linkedProjectId)?.name ?? "";
-  const [view, setView] = useState<View>(fieldLink.get("view") === "emergency" ? "emergency" : "permits");
+  const routedView = readView(fieldLink.get("view"));
+  const [view, setView] = useState<View>(routedView);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const canManageOccurrences = user?.role === "admin" || user?.role === "operations_manager";
@@ -39,6 +42,7 @@ export function SafetyOperationsPage() {
   }
 
   useEffect(() => { void refresh(); }, []);
+  useEffect(() => { setView(routedView); }, [routedView]);
   useEffect(() => {
     if (!loading && view === "emergency" && linkedRecordId) {
       document.getElementById(`emergency-card-${linkedRecordId}`)?.scrollIntoView({ block: "start" });
@@ -147,7 +151,7 @@ type Create = (event: FormEvent<HTMLFormElement>, recordType: string, titleField
 type Transition = (record: FieldRecord, status: string, prompt: string) => Promise<void>;
 
 function PermitView({ records, create, transition, projectName }: { records: FieldRecord[]; create: Create; transition: Transition; projectName: string }) {
-  return <Grid><form onSubmit={(event) => void create(event, "safety_permit", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create permit readiness record</h2><select name="type" className="control"><option>Ground Disturbance</option><option>Confined Space</option><option>Lockout / Energy Isolation</option><option>Critical Lift</option><option>Traffic Control</option></select><Input name="project" placeholder="Project / location" defaultValue={projectName} /><Area name="task" placeholder="Task and work limits" /><Input name="supervisor" placeholder="Responsible supervisor" /><Area name="controls" placeholder="Controls and verification evidence required" /><label className="block text-xs font-semibold text-iron-500">Permit expiry<input name="expires" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save blocked permit</Save></form><Register empty="No permit readiness records." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{detail(record, "type")} · {record.work_date}</div><h3 className="font-semibold">{detail(record, "project")}</h3><p className="text-sm text-iron-600">{detail(record, "task")}</p><p className="mt-2 text-xs text-iron-500">Supervisor: {detail(record, "supervisor")} · Expires: {detail(record, "expires") || "Not set"}</p></div><Status value={record.status} /></div><p className="mt-3 rounded-md bg-iron-50 p-3 text-sm">{detail(record, "controls")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "at_risk", "Record the review evidence and remaining risk.")}>Mark at risk</Small><Small dark onClick={() => void transition(record, "ready", "Record the field verification that supports release.")}>Verify ready</Small></div></article>)} /></Grid>;
+  return <Grid><form key={projectName || "unlinked"} onSubmit={(event) => void create(event, "safety_permit", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create permit readiness record</h2><select name="type" className="control"><option>Ground Disturbance</option><option>Confined Space</option><option>Lockout / Energy Isolation</option><option>Critical Lift</option><option>Traffic Control</option></select><Input name="project" placeholder="Project / location" defaultValue={projectName} /><Area name="task" placeholder="Task and work limits" /><Input name="supervisor" placeholder="Responsible supervisor" /><Area name="controls" placeholder="Controls and verification evidence required" /><label className="block text-xs font-semibold text-iron-500">Permit expiry<input name="expires" type="datetime-local" className="mt-1 w-full rounded-md border p-2 text-sm" /></label><Save>Save blocked permit</Save></form><Register empty="No permit readiness records." items={records.map((record) => <article key={record.id} className="rounded-lg border p-4"><div className="flex justify-between gap-3"><div><div className="text-xs font-semibold text-brand-gold-dark">{detail(record, "type")} · {record.work_date}</div><h3 className="font-semibold">{detail(record, "project")}</h3><p className="text-sm text-iron-600">{detail(record, "task")}</p><p className="mt-2 text-xs text-iron-500">Supervisor: {detail(record, "supervisor")} · Expires: {detail(record, "expires") || "Not set"}</p></div><Status value={record.status} /></div><p className="mt-3 rounded-md bg-iron-50 p-3 text-sm">{detail(record, "controls")}</p><div className="mt-3 flex gap-2"><Small onClick={() => void transition(record, "at_risk", "Record the review evidence and remaining risk.")}>Mark at risk</Small><Small dark onClick={() => void transition(record, "ready", "Record the field verification that supports release.")}>Verify ready</Small></div></article>)} /></Grid>;
 }
 
 function ActionView({ records, create, transition }: { records: FieldRecord[]; create: Create; transition: Transition }) {
@@ -155,7 +159,7 @@ function ActionView({ records, create, transition }: { records: FieldRecord[]; c
 }
 
 function EmergencyView({ records, create, projectName }: { records: FieldRecord[]; create: Create; projectName: string }) {
-  return <Grid><form onSubmit={(event) => void create(event, "emergency_action_card", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create emergency action card</h2>{[["project", "Project"], ["address", "Site address / access point"], ["muster", "Muster point"], ["firstAid", "First aid location and attendant"], ["emergencyLead", "Emergency lead and contact"], ["rescue", "Rescue / evacuation method"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} defaultValue={name === "project" ? projectName : undefined} />)}<Save>Save emergency card</Save></form><Register empty="No emergency cards." items={records.map((record) => <article id={`emergency-card-${record.id}`} key={record.id} className="scroll-mt-6 rounded-lg border border-red-200 bg-red-50 p-5"><div className="flex items-center gap-2"><Radio className="text-red-700" /><h3 className="font-semibold text-red-950">{detail(record, "project")}</h3></div><dl className="mt-4 grid gap-2 text-sm"><div><dt className="font-semibold">Address/access:</dt><dd>{detail(record, "address")}</dd></div><div><dt className="font-semibold">Muster point:</dt><dd>{detail(record, "muster")}</dd></div><div><dt className="font-semibold">First aid:</dt><dd>{detail(record, "firstAid")}</dd></div><div><dt className="font-semibold">Emergency lead:</dt><dd>{detail(record, "emergencyLead")}</dd></div><div><dt className="font-semibold">Rescue/evacuation:</dt><dd>{detail(record, "rescue")}</dd></div></dl><p className="mt-3 text-xs text-red-800">Created {record.work_date}. Confirm with the crew and replace when conditions change.</p><EmergencyFieldAccess record={record} /></article>)} /></Grid>;
+  return <Grid><form key={projectName || "unlinked"} onSubmit={(event) => void create(event, "emergency_action_card", "project")} className="space-y-3 rounded-xl border bg-white p-6"><h2 className="font-semibold">Create emergency action card</h2>{[["project", "Project"], ["address", "Site address / access point"], ["muster", "Muster point"], ["firstAid", "First aid location and attendant"], ["emergencyLead", "Emergency lead and contact"], ["rescue", "Rescue / evacuation method"]].map(([name, placeholder]) => <Input key={name} name={name} placeholder={placeholder} defaultValue={name === "project" ? projectName : undefined} />)}<Save>Save emergency card</Save></form><Register empty="No emergency cards." items={records.map((record) => <article id={`emergency-card-${record.id}`} key={record.id} className="scroll-mt-6 rounded-lg border border-red-200 bg-red-50 p-5"><div className="flex items-center gap-2"><Radio className="text-red-700" /><h3 className="font-semibold text-red-950">{detail(record, "project")}</h3></div><dl className="mt-4 grid gap-2 text-sm"><div><dt className="font-semibold">Address/access:</dt><dd>{detail(record, "address")}</dd></div><div><dt className="font-semibold">Muster point:</dt><dd>{detail(record, "muster")}</dd></div><div><dt className="font-semibold">First aid:</dt><dd>{detail(record, "firstAid")}</dd></div><div><dt className="font-semibold">Emergency lead:</dt><dd>{detail(record, "emergencyLead")}</dd></div><div><dt className="font-semibold">Rescue/evacuation:</dt><dd>{detail(record, "rescue")}</dd></div></dl><p className="mt-3 text-xs text-red-800">Created {record.work_date}. Confirm with the crew and replace when conditions change.</p><EmergencyFieldAccess record={record} /></article>)} /></Grid>;
 }
 
 function EmergencyFieldAccess({ record }: { record: FieldRecord }) {
@@ -237,6 +241,12 @@ function FirstAidView({ records, employees, create }: { records: FieldRecord[]; 
 
 function EmployeeSelect({ employees, optional = false }: { employees: Employee[]; optional?: boolean }) {
   return <select required={!optional} name="employee_id" defaultValue="" className="w-full rounded-md border p-2 text-sm"><option value="">{optional ? "Affected worker, if applicable" : "Select worker"}</option>{employees.map((employee) => <option key={employee.id} value={employee.id}>{employee.first_name} {employee.last_name}</option>)}</select>;
+}
+
+function readView(value: string | null): View {
+  return value === "actions" || value === "emergency" || value === "incidents" || value === "first-aid"
+    ? value
+    : "permits";
 }
 
 function detail(record: FieldRecord, key: string) { const value = record.details[key]; return typeof value === "string" ? value : ""; }


### PR DESCRIPTION
## Summary

Stacked on #261 while its independent review is pending.

- let declined and expired quotes start a controlled revision while accepted quotes remain immutable
- keep a targeted quote edit authoritative over unrelated device recovery
- render the guided queue before launch summaries finish, cap launch requests at three, and time out stalled summaries
- include every awarded job with a permanent job number, including legacy records without a workspace root
- suppress quote/project duplicates only for opportunities and restore PO/Documents actions for construction
- update Finance, PO Requests, and Safety Operations when routed project context changes without unmounting
- preserve explicit durable-draft precedence in PO Requests

Closes #262

## Validation

- 104 frontend tests passed
- 452 backend/agent tests passed
- Ruff passed
- TypeScript production build passed
- visual-design lock passed
- React Router RSC boundary check passed
- exact published tree verified against the local validated tree (`66d03b42847c2ca39bfb2d77ea819f426bf2a722`)

## Controls

This change routes users to existing controlled actions. It does not send or accept quotes, award work, approve budgets or purchase orders, create safety evidence, deploy software, or mutate shared staging/production data.

## Stack dependency

Do not merge this PR into its temporary base as the final release path. After #261 reaches `main`, retarget or recreate this exact one-commit change against `main` and require independent review.