### PR TITLE
Simplify generated job codes and PO numbers

### DIFF
--- a/backend/app/services/projects.py
+++ b/backend/app/services/projects.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
@@ -183,11 +183,17 @@ def _update_awarded_project(
 
 def _next_job_number(db: Session, award_year: int | None = None) -> str:
     year = award_year or datetime.now(IRON_HOUSE_TIME_ZONE).year
-    prefix = f"{JOB_NUMBER_PREFIX}-{year}-"
+    prefix = f"{JOB_NUMBER_PREFIX}{year}"
+    legacy_prefix = f"{JOB_NUMBER_PREFIX}-{year}-"
     existing = db.scalars(
-        select(Project.project_number).where(Project.project_number.like(f"{prefix}%"))
+        select(Project.project_number).where(
+            or_(
+                Project.project_number.like(f"{prefix}%"),
+                Project.project_number.like(f"{legacy_prefix}%"),
+            )
+        )
     ).all()
-    pattern = re.compile(rf"^{re.escape(prefix)}(\d+)$")
+    pattern = re.compile(rf"^(?:{re.escape(prefix)}|{re.escape(legacy_prefix)})(\d+)$")
     sequences = [
         int(match.group(1)) for number in existing if number and (match := pattern.match(number))
     ]

--- a/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
@@ -87,6 +87,26 @@ describe("PurchaseOrderRequestPage", () => {
     await waitFor(() => expect(jobSelect).toHaveValue("job-2"));
     expect(screen.getByPlaceholderText(/20 m of 200 mm PVC/)).toHaveValue("Aggregate");
   });
+
+  it("generates a PO with one separator and a hyphen-free job code", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(12345678);
+    vi.mocked(fieldOperationsApi.createRecord).mockResolvedValue({} as never);
+    const user = userEvent.setup();
+    renderPo("/request-po?projectId=job-1&projectName=Linked+Job");
+
+    await screen.findByRole("combobox", { name: "Job" });
+    await user.type(screen.getByPlaceholderText(/20 m of 200 mm PVC/), "Pipe and fittings");
+    await user.click(screen.getByRole("button", { name: "Request PO" }));
+
+    await waitFor(() => expect(fieldOperationsApi.createRecord).toHaveBeenCalledWith(expect.objectContaining({
+      title: "PO12345678-IH2026030 — Pipe and fittings",
+      details: expect.objectContaining({
+        po_number: "PO12345678-IH2026030",
+        job_number: "IH-2026-030",
+      }),
+    })));
+    expect(await screen.findByText("Created PO12345678-IH2026030 and sent for approval.")).toBeInTheDocument();
+  });
 });
 
 function renderPo(path: string) {

--- a/frontend/src/pages/PurchaseOrderRequestPage.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.tsx
@@ -11,7 +11,8 @@ const today = () => new Date().toISOString().slice(0, 10);
 
 function buildPoNumber(jobNumber: string) {
   const sequence = Date.now().toString().slice(-8);
-  return `PO-${sequence}-${jobNumber}`;
+  const jobCode = jobNumber.replace(/[^a-z0-9]/gi, "").toUpperCase();
+  return `PO${sequence}-${jobCode}`;
 }
 
 export function PurchaseOrderRequestPage() {

--- a/scripts/staging-smoke-test.sh
+++ b/scripts/staging-smoke-test.sh
@@ -74,6 +74,7 @@ read_quote_state() {
   python - <<'PY'
 import json
 import os
+import re
 from uuid import UUID
 
 payload = json.loads(open(os.environ["BODY_FILE"], encoding="utf-8").read())
@@ -90,7 +91,7 @@ if os.environ["EXPECTED_PROJECT_ID"] and project_id != os.environ["EXPECTED_PROJ
 job_number = payload.get("job_number")
 if os.environ["JOB_EXPECTATION"] == "absent" and job_number is not None:
     raise SystemExit(f"Non-binding quote state unexpectedly has job number {job_number!r}.")
-if os.environ["JOB_EXPECTATION"] == "present" and not str(job_number or "").startswith("IH-"):
+if os.environ["JOB_EXPECTATION"] == "present" and not re.fullmatch(r"IH\d{7}", str(job_number or "")):
     raise SystemExit(f"Accepted quote has invalid job number {job_number!r}.")
 revision = int(payload.get("record_revision") or 0)
 if revision < 1:

--- a/tests/backend/test_customer_quotes.py
+++ b/tests/backend/test_customer_quotes.py
@@ -192,7 +192,7 @@ def test_management_acceptance_atomically_awards_project_and_is_idempotent() -> 
     body = accepted.json()
     assert body["status"] == "accepted"
     assert body["record_revision"] == 2
-    assert body["job_number"].startswith("IH-2026-")
+    assert body["job_number"].startswith("IH2026")
     assert body["accepted_by"] == "test-admin@ironhousecontracting.com"
 
     project = client.get(f"/api/v1/projects/{created['project_id']}").json()

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -64,10 +64,10 @@ def test_awarded_project_creation_generates_sequential_job_numbers() -> None:
 
     assert first.status_code == 201
     assert second.status_code == 201
-    assert first.json()["project_number"] == f"IH-{year}-001"
-    assert second.json()["project_number"] == f"IH-{year}-002"
-    assert first.json()["workspace_root"] == f"IH-{year}-001_FirstAward"
-    assert second.json()["workspace_root"] == f"IH-{year}-002_SecondAward"
+    assert first.json()["project_number"] == f"IH{year}001"
+    assert second.json()["project_number"] == f"IH{year}002"
+    assert first.json()["workspace_root"] == f"IH{year}001_FirstAward"
+    assert second.json()["workspace_root"] == f"IH{year}002_SecondAward"
 
 
 def test_transition_to_awarded_generates_job_number() -> None:
@@ -78,12 +78,12 @@ def test_transition_to_awarded_generates_job_number() -> None:
 
     assert response.status_code == 200
     assert response.json()["status"] == "awarded"
-    assert response.json()["project_number"] == f"IH-{year}-001"
-    assert response.json()["workspace_root"] == f"IH-{year}-001_TenderWithoutNumber"
+    assert response.json()["project_number"] == f"IH{year}001"
+    assert response.json()["workspace_root"] == f"IH{year}001_TenderWithoutNumber"
 
     workspace = client.get(f"/api/v1/projects/{project['id']}/workspace")
     assert workspace.status_code == 200
-    assert workspace.json()["job_number"] == f"IH-{year}-001"
+    assert workspace.json()["job_number"] == f"IH{year}001"
     assert any(entry["path"].endswith("/13_Award_Handoff") for entry in workspace.json()["entries"])
 
     checklist = client.get(f"/api/v1/projects/{project['id']}/start-checklist")
@@ -234,7 +234,7 @@ def test_award_generation_skips_existing_numbers_and_preserves_explicit_number()
     assert explicit.json()["project_number"] == f"IH-{year}-009"
     assert explicit.json()["workspace_root"] == f"IH-{year}-009_ExistingAward"
     assert generated.status_code == 201
-    assert generated.json()["project_number"] == f"IH-{year}-010"
+    assert generated.json()["project_number"] == f"IH{year}010"
 
 
 def test_award_generation_retries_a_unique_collision() -> None:


### PR DESCRIPTION
## Summary

- generate new awarded-job codes as `IHYYYYNNN` with no internal hyphens
- continue sequencing across both legacy `IH-YYYY-NNN` and new compact job codes
- generate POs as `PO########-JOBCODE` with exactly one hyphen
- normalize legacy/custom job codes only for new PO composition without rewriting stored history

## Examples

- job: `IH2026001`
- PO: `PO12345678-IH2026001`

## Validation

- backend: 460 passed
- focused project and customer quote tests: 27 passed
- frontend: 36 files / 108 tests passed
- focused PO tests: 4 passed
- Ruff passed
- TypeScript and production build passed
- visual design lock passed
- React Router RSC security boundary passed
- `git diff --check` passed

## Data control

Existing job numbers and historical POs are not migrated or rewritten.

Closes #274