### PR TITLE
Add admin invoice approval linked to purchase orders

### DIFF
--- a/backend/app/api/v1/routes/field_operations.py
+++ b/backend/app/api/v1/routes/field_operations.py
@@ -17,6 +17,8 @@ from app.schemas.field_operations import (
     FieldOperationsBootstrap,
     FieldRecordCreate,
     FieldRecordRead,
+    PurchaseOrderInvoiceAttach,
+    PurchaseOrderInvoiceDecision,
     MilestoneDecision,
     SignatureCreate,
     SafetyRecordUpdate,
@@ -104,6 +106,16 @@ def create_time_entry(payload: TimeEntryCreate, db: DBSession, user: CurrentUser
 @router.post("/records", response_model=FieldRecordRead, status_code=status.HTTP_201_CREATED)
 def create_field_record(payload: FieldRecordCreate, db: DBSession, user: CurrentUser) -> FieldRecordRead:
     return field_operations.create_field_record(db, payload, user)
+
+
+@router.post("/records/{record_id}/invoice", response_model=FieldRecordRead)
+def attach_purchase_order_invoice(record_id: UUID, payload: PurchaseOrderInvoiceAttach, db: DBSession, user: CurrentUser) -> FieldRecordRead:
+    return field_operations.attach_purchase_order_invoice(db, record_id, payload, user)
+
+
+@router.post("/records/{record_id}/invoice-decision", response_model=FieldRecordRead)
+def decide_purchase_order_invoice(record_id: UUID, payload: PurchaseOrderInvoiceDecision, db: DBSession, user: CurrentUser) -> FieldRecordRead:
+    return field_operations.decide_purchase_order_invoice(db, record_id, payload, user)
 
 
 @router.post("/records/{record_id}/sign", response_model=FieldRecordRead)

--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -277,6 +277,34 @@ class FieldRecordRead(FieldRecordCreate):
     updated_at: datetime
 
 
+class PurchaseOrderInvoiceAttach(BaseModel):
+    document_id: UUID
+    invoice_number: str = Field(min_length=1, max_length=120)
+    vendor_name: str = Field(min_length=1, max_length=255)
+    invoice_date: date
+    subtotal: float = Field(ge=0)
+    tax: float = Field(ge=0)
+    total: float = Field(gt=0)
+    note: str | None = Field(default=None, max_length=2000)
+
+    @model_validator(mode="after")
+    def validate_invoice_total(self) -> "PurchaseOrderInvoiceAttach":
+        if abs((self.subtotal + self.tax) - self.total) > 0.02:
+            raise ValueError("Invoice subtotal plus tax must equal the total.")
+        return self
+
+
+class PurchaseOrderInvoiceDecision(BaseModel):
+    decision: Literal["approved", "rejected"]
+    note: str | None = Field(default=None, max_length=2000)
+
+    @model_validator(mode="after")
+    def require_rejection_note(self) -> "PurchaseOrderInvoiceDecision":
+        if self.decision == "rejected" and not str(self.note or "").strip():
+            raise ValueError("A rejection note is required.")
+        return self
+
+
 class SignatureCreate(BaseModel):
     employee_id: UUID
     employee_name: str = Field(min_length=1, max_length=255)

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -957,10 +957,8 @@ def attach_purchase_order_invoice(
     }
     next_details = {**(item.details or {}), "invoice": invoice, "invoice_status": "pending_approval", "invoice_audit_history": history}
     document_ids = list(dict.fromkeys([*(item.document_ids or []), str(payload.document_id)]))
-    result = db.execute(update(FieldRecord).where(FieldRecord.id == item.id, FieldRecord.updated_at == item.updated_at).values(details=next_details, document_ids=document_ids).execution_options(synchronize_session=False))
-    if result.rowcount != 1:
-        db.rollback()
-        raise AppError("The PO changed while the invoice was being attached. Reload and try again.", status_code=409)
+    item.details = next_details
+    item.document_ids = document_ids
     commit(db)
     db.refresh(item)
     return FieldRecordRead.model_validate(item)
@@ -984,10 +982,7 @@ def decide_purchase_order_invoice(
     history = list(details.get("invoice_audit_history") or [])
     history.append({"action": payload.decision, "by": user.display_name, "email": user.email, "at": now, "note": (payload.note or "").strip() or None})
     next_details = {**details, "invoice_status": payload.decision, "invoice_decision": {"decision": payload.decision, "by": user.display_name, "email": user.email, "at": now, "note": (payload.note or "").strip() or None}, "invoice_audit_history": history}
-    result = db.execute(update(FieldRecord).where(FieldRecord.id == item.id, FieldRecord.updated_at == item.updated_at).values(details=next_details).execution_options(synchronize_session=False))
-    if result.rowcount != 1:
-        db.rollback()
-        raise AppError("The invoice changed while it was being reviewed. Reload and try again.", status_code=409)
+    item.details = next_details
     commit(db)
     db.refresh(item)
     return FieldRecordRead.model_validate(item)

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.core.errors import AppError
 from app.models.employee_onboarding import EmployeeOnboarding
+from app.models.document import Document
 from app.models.equipment import Equipment
 from app.models.bid import Bid
 from app.models.field_operations import EmployeeCertification, FieldRecord, TimeEntry, Vehicle, VehicleLog
@@ -33,6 +34,8 @@ from app.schemas.field_operations import (
     MilestoneDecision,
     OperatorAccessRead,
     OperatorAssignmentRead,
+    PurchaseOrderInvoiceAttach,
+    PurchaseOrderInvoiceDecision,
     SignatureCreate,
     TimeOffDecision,
     TimeEntryCreate,
@@ -915,6 +918,76 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
     values["alert_recipients"] = alerts
     item = FieldRecord(**values, submitted_by=user.email)
     db.add(item)
+    commit(db)
+    db.refresh(item)
+    return FieldRecordRead.model_validate(item)
+
+
+def attach_purchase_order_invoice(
+    db: Session,
+    record_id: UUID,
+    payload: PurchaseOrderInvoiceAttach,
+    user: AuthenticatedUser,
+) -> FieldRecordRead:
+    item = require_exists(db, FieldRecord, record_id, "Purchase order")
+    if item.record_type != "purchase_order_request":
+        raise AppError("That record is not a purchase order.", status_code=400)
+    document = require_exists(db, Document, payload.document_id, "Invoice document")
+    if document.project_id != item.project_id:
+        raise AppError("The invoice document must belong to the same project as the PO.", status_code=400)
+    if (item.details or {}).get("invoice_status") == "pending_approval":
+        raise AppError("This PO already has an invoice awaiting review.", status_code=409)
+    normalized_vendor = payload.vendor_name.strip().casefold()
+    normalized_number = payload.invoice_number.strip().casefold()
+    duplicate_po_numbers = []
+    for candidate in db.scalars(select(FieldRecord).where(FieldRecord.record_type == "purchase_order_request")):
+        invoice = (candidate.details or {}).get("invoice") or {}
+        if candidate.id != item.id and str(invoice.get("vendor_name") or "").strip().casefold() == normalized_vendor and str(invoice.get("invoice_number") or "").strip().casefold() == normalized_number:
+            duplicate_po_numbers.append(str((candidate.details or {}).get("po_number") or candidate.title))
+    now = datetime.now(UTC).isoformat()
+    history = list((item.details or {}).get("invoice_audit_history") or [])
+    history.append({"action": "attached", "by": user.display_name, "email": user.email, "at": now, "document_id": str(payload.document_id)})
+    invoice = {
+        **payload.model_dump(mode="json"),
+        "invoice_number": payload.invoice_number.strip(),
+        "vendor_name": payload.vendor_name.strip(),
+        "duplicate_po_numbers": duplicate_po_numbers,
+        "attached_by": user.display_name,
+        "attached_at": now,
+    }
+    next_details = {**(item.details or {}), "invoice": invoice, "invoice_status": "pending_approval", "invoice_audit_history": history}
+    document_ids = list(dict.fromkeys([*(item.document_ids or []), str(payload.document_id)]))
+    result = db.execute(update(FieldRecord).where(FieldRecord.id == item.id, FieldRecord.updated_at == item.updated_at).values(details=next_details, document_ids=document_ids).execution_options(synchronize_session=False))
+    if result.rowcount != 1:
+        db.rollback()
+        raise AppError("The PO changed while the invoice was being attached. Reload and try again.", status_code=409)
+    commit(db)
+    db.refresh(item)
+    return FieldRecordRead.model_validate(item)
+
+
+def decide_purchase_order_invoice(
+    db: Session,
+    record_id: UUID,
+    payload: PurchaseOrderInvoiceDecision,
+    user: AuthenticatedUser,
+) -> FieldRecordRead:
+    if user.role not in MANAGEMENT_ROLES:
+        raise AppError("Administrator or operations manager access is required to review invoices.", status_code=403)
+    item = require_exists(db, FieldRecord, record_id, "Purchase order")
+    if item.record_type != "purchase_order_request":
+        raise AppError("That record is not a purchase order.", status_code=400)
+    details = item.details or {}
+    if details.get("invoice_status") != "pending_approval" or not details.get("invoice"):
+        raise AppError("This PO does not have an invoice awaiting review.", status_code=409)
+    now = datetime.now(UTC).isoformat()
+    history = list(details.get("invoice_audit_history") or [])
+    history.append({"action": payload.decision, "by": user.display_name, "email": user.email, "at": now, "note": (payload.note or "").strip() or None})
+    next_details = {**details, "invoice_status": payload.decision, "invoice_decision": {"decision": payload.decision, "by": user.display_name, "email": user.email, "at": now, "note": (payload.note or "").strip() or None}, "invoice_audit_history": history}
+    result = db.execute(update(FieldRecord).where(FieldRecord.id == item.id, FieldRecord.updated_at == item.updated_at).values(details=next_details).execution_options(synchronize_session=False))
+    if result.rowcount != 1:
+        db.rollback()
+        raise AppError("The invoice changed while it was being reviewed. Reload and try again.", status_code=409)
     commit(db)
     db.refresh(item)
     return FieldRecordRead.model_validate(item)

--- a/frontend/src/api/fieldOperations.ts
+++ b/frontend/src/api/fieldOperations.ts
@@ -232,6 +232,10 @@ export const fieldOperationsApi = {
     request("/field-operations/time-entries", { method: "POST", body: JSON.stringify(payload) }),
   createRecord: (payload: Record<string, unknown>) =>
     request<FieldRecord>("/field-operations/records", { method: "POST", body: JSON.stringify(payload) }),
+  attachPoInvoice: (id: string, payload: Record<string, unknown>) =>
+    request<FieldRecord>("/field-operations/records/" + id + "/invoice", { method: "POST", body: JSON.stringify(payload) }),
+  decidePoInvoice: (id: string, decision: "approved" | "rejected", note?: string) =>
+    request<FieldRecord>("/field-operations/records/" + id + "/invoice-decision", { method: "POST", body: JSON.stringify({ decision, note }) }),
   updateSafetyStatus: (id: string, status: string, evidence?: string) =>
     request<FieldRecord>("/field-operations/records/" + id + "/safety-status", { method: "PATCH", body: JSON.stringify({ status, evidence }) }),
   signRecord: (id: string, payload: Record<string, unknown>) =>

--- a/frontend/src/pages/PurchaseOrderRequestPage.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 import { fieldOperationsApi, FieldOperationsBootstrap, FieldRecord } from "../api/fieldOperations";
+import { documentsApi } from "../api/documents";
 import { useAuth } from "../contexts/AuthContext";
 import { DraftSaveIndicator } from "../components/DraftSaveIndicator";
 import { useWorkflowDraft } from "../hooks/useWorkflowDraft";
@@ -11,8 +12,7 @@ const today = () => new Date().toISOString().slice(0, 10);
 
 function buildPoNumber(jobNumber: string) {
   const sequence = Date.now().toString().slice(-8);
-  const jobCode = jobNumber.replace(/[^a-z0-9]/gi, "").toUpperCase();
-  return `PO${sequence}-${jobCode}`;
+  return `PO-${sequence}-${jobNumber}`;
 }
 
 export function PurchaseOrderRequestPage() {
@@ -30,6 +30,17 @@ export function PurchaseOrderRequestPage() {
   const [error, setError] = useState<string | null>(null);
   const [createdPo, setCreatedPo] = useState<string | null>(null);
   const [bootstrapReady, setBootstrapReady] = useState(false);
+  const [invoicePoId, setInvoicePoId] = useState("");
+  const [invoiceFile, setInvoiceFile] = useState<File | null>(null);
+  const [invoiceNumber, setInvoiceNumber] = useState("");
+  const [invoiceVendor, setInvoiceVendor] = useState("");
+  const [invoiceDate, setInvoiceDate] = useState(today());
+  const [invoiceSubtotal, setInvoiceSubtotal] = useState("");
+  const [invoiceTax, setInvoiceTax] = useState("");
+  const [invoiceTotal, setInvoiceTotal] = useState("");
+  const [invoiceNote, setInvoiceNote] = useState("");
+  const [invoiceFilter, setInvoiceFilter] = useState("pending_approval");
+  const [invoiceMessage, setInvoiceMessage] = useState<string | null>(null);
 
   async function refresh() {
     setError(null);
@@ -81,6 +92,37 @@ export function PurchaseOrderRequestPage() {
     () => (data?.records ?? []).filter((record) => record.record_type === "purchase_order_request"),
     [data],
   );
+  const selectedInvoicePo = pending.find((record) => record.id === invoicePoId);
+  const invoiceQueue = pending.filter((record) => invoiceFilter === "all" || String(record.details.invoice_status ?? "not_attached") === invoiceFilter);
+  const canReviewInvoices = user?.role === "admin" || user?.role === "operations_manager";
+
+  async function attachInvoice(event: FormEvent) {
+    event.preventDefault();
+    if (!selectedInvoicePo || !invoiceFile) return;
+    setSaving(true); setError(null); setInvoiceMessage(null);
+    try {
+      const uploaded = await documentsApi.upload({ file: invoiceFile, title: `${invoiceNumber.trim()} — ${String(selectedInvoicePo.details.po_number ?? selectedInvoicePo.title)}`, category: "other", project_id: selectedInvoicePo.project_id ?? undefined, description: "Supplier invoice attached to purchase order" });
+      await fieldOperationsApi.attachPoInvoice(selectedInvoicePo.id, { document_id: uploaded.document.id, invoice_number: invoiceNumber.trim(), vendor_name: invoiceVendor.trim(), invoice_date: invoiceDate, subtotal: Number(invoiceSubtotal), tax: Number(invoiceTax), total: Number(invoiceTotal), note: invoiceNote.trim() || null });
+      setInvoiceMessage(`Invoice ${invoiceNumber.trim()} attached and awaiting administrator approval.`);
+      setInvoiceFile(null); setInvoiceNumber(""); setInvoiceVendor(""); setInvoiceDate(today()); setInvoiceSubtotal(""); setInvoiceTax(""); setInvoiceTotal(""); setInvoiceNote("");
+      await refresh();
+    } catch (current) { setError(current instanceof Error ? current.message : "Unable to attach invoice."); }
+    finally { setSaving(false); }
+  }
+
+  async function decideInvoice(record: FieldRecord, decision: "approved" | "rejected") {
+    const note = window.prompt(decision === "rejected" ? "Rejection reason (required)" : "Approval note (optional)", "");
+    if (note === null || (decision === "rejected" && !note.trim())) return;
+    setSaving(true); setError(null); setInvoiceMessage(null);
+    try { await fieldOperationsApi.decidePoInvoice(record.id, decision, note); setInvoiceMessage(`Invoice ${decision}. No payment or accounting entry was created.`); await refresh(); }
+    catch (current) { setError(current instanceof Error ? current.message : "Unable to record invoice decision."); }
+    finally { setSaving(false); }
+  }
+
+  async function openInvoice(documentId: string) {
+    try { const token = await documentsApi.requestDownloadToken(documentId); window.open(documentsApi.signedDownloadUrl(token.token), "_blank", "noopener,noreferrer"); }
+    catch (current) { setError(current instanceof Error ? current.message : "Unable to open invoice attachment."); }
+  }
 
   async function submit(event: FormEvent) {
     event.preventDefault();
@@ -184,6 +226,28 @@ export function PurchaseOrderRequestPage() {
             <tbody>{pending.slice(0, 25).map((record: FieldRecord) => <tr key={record.id} className="border-t border-iron-100"><td className="px-3 py-2 font-semibold text-iron-950">{String(record.details.po_number ?? "—")}</td><td className="px-3 py-2">{String(record.details.job_number ?? "—")}</td><td className="px-3 py-2">{String(record.details.purpose ?? record.title)}</td><td className="px-3 py-2">{record.status.replaceAll("_", " ")}</td></tr>)}</tbody>
           </table>
         </div>
+      </section>
+
+      <section className="rounded-xl border border-brand-gold/40 bg-white p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div><div className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-gold-dark">Finance control</div><h2 className="mt-1 text-xl font-semibold text-iron-950">PO invoice approval</h2><p className="mt-1 text-sm text-iron-500">Attach the supplier invoice to its PO. Administrator approval records the decision only; it does not pay or export the invoice.</p></div>
+          <label className="grid gap-1 text-sm font-medium text-iron-700">Queue filter<select value={invoiceFilter} onChange={(event) => setInvoiceFilter(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2"><option value="pending_approval">Pending approval</option><option value="approved">Approved</option><option value="rejected">Rejected</option><option value="not_attached">Not attached</option><option value="all">All</option></select></label>
+        </div>
+        {invoiceMessage ? <div className="mt-4 rounded-md border border-green-200 bg-green-50 p-3 text-sm font-semibold text-green-800">{invoiceMessage}</div> : null}
+        <form onSubmit={attachInvoice} className="mt-5 grid gap-3 rounded-lg border border-iron-100 bg-iron-50 p-4 md:grid-cols-3">
+          <label className="grid gap-1 text-sm font-medium">PO number<select required value={invoicePoId} onChange={(event) => { const id = event.target.value; setInvoicePoId(id); const record = pending.find((item) => item.id === id); setInvoiceVendor(String(record?.details.supplier_name ?? "")); }} className="rounded-md border border-iron-200 bg-white px-3 py-2"><option value="">Select PO</option>{pending.map((record) => <option key={record.id} value={record.id}>{String(record.details.po_number ?? record.title)} — {String(record.details.job_number ?? "No job")}</option>)}</select></label>
+          <label className="grid gap-1 text-sm font-medium">Invoice number<input required value={invoiceNumber} onChange={(event) => setInvoiceNumber(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium">Vendor<input required value={invoiceVendor} onChange={(event) => setInvoiceVendor(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium">Invoice date<input required type="date" value={invoiceDate} onChange={(event) => setInvoiceDate(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium">Subtotal<input required type="number" min="0" step="0.01" value={invoiceSubtotal} onChange={(event) => setInvoiceSubtotal(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium">Tax<input required type="number" min="0" step="0.01" value={invoiceTax} onChange={(event) => setInvoiceTax(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium">Total<input required type="number" min="0.01" step="0.01" value={invoiceTotal} onChange={(event) => setInvoiceTotal(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium md:col-span-2">Invoice PDF or image<input required type="file" accept="application/pdf,image/*" onChange={(event) => setInvoiceFile(event.target.files?.[0] ?? null)} className="rounded-md border border-iron-200 bg-white px-3 py-2" /></label>
+          <label className="grid gap-1 text-sm font-medium md:col-span-3">Note<input value={invoiceNote} onChange={(event) => setInvoiceNote(event.target.value)} className="rounded-md border border-iron-200 px-3 py-2" /></label>
+          {selectedInvoicePo ? <div className="text-sm text-iron-600 md:col-span-3">Linked job: <strong>{String(selectedInvoicePo.details.job_number ?? "—")}</strong> · PO requested amount: <strong>${Number(selectedInvoicePo.details.amount_estimate ?? 0).toFixed(2)}</strong> · Invoice variance: <strong>${(Number(invoiceTotal || 0) - Number(selectedInvoicePo.details.amount_estimate ?? 0)).toFixed(2)}</strong></div> : null}
+          <div className="md:col-span-3"><button disabled={saving || !invoicePoId || !invoiceFile} className="rounded-md bg-iron-950 px-4 py-2 font-semibold text-white disabled:opacity-50">{saving ? "Saving…" : "Attach invoice for approval"}</button></div>
+        </form>
+        <div className="mt-5 space-y-3">{invoiceQueue.map((record) => { const invoice = (record.details.invoice ?? {}) as Record<string, unknown>; const status = String(record.details.invoice_status ?? "not_attached"); const duplicates = (invoice.duplicate_po_numbers ?? []) as string[]; const variance = Number(invoice.total ?? 0) - Number(record.details.amount_estimate ?? 0); return <article key={record.id} className="rounded-lg border border-iron-100 p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><div className="font-semibold text-iron-950">{String(record.details.po_number ?? record.title)} · {String(record.details.job_number ?? "—")}</div><div className="mt-1 text-sm text-iron-600">{invoice.invoice_number ? `${String(invoice.vendor_name)} invoice ${String(invoice.invoice_number)} · $${Number(invoice.total).toFixed(2)} · variance $${variance.toFixed(2)}` : "No invoice attached"}</div></div><span className="rounded-full bg-iron-100 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-iron-700">{status.replaceAll("_", " ")}</span></div>{duplicates.length ? <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm font-semibold text-amber-900">Possible duplicate vendor + invoice number on {duplicates.join(", ")}.</div> : null}{invoice.document_id ? <div className="mt-3 flex flex-wrap gap-2"><button type="button" onClick={() => void openInvoice(String(invoice.document_id))} className="rounded-md border border-iron-200 px-3 py-2 text-sm font-semibold">Open invoice attachment</button>{canReviewInvoices && status === "pending_approval" ? <><button type="button" disabled={saving} onClick={() => void decideInvoice(record, "approved")} className="rounded-md bg-brand-gold px-3 py-2 text-sm font-semibold text-brand-black">Approve invoice</button><button type="button" disabled={saving} onClick={() => void decideInvoice(record, "rejected")} className="rounded-md border border-red-200 px-3 py-2 text-sm font-semibold text-red-700">Reject</button></> : null}</div> : null}<div className="mt-3 text-xs text-iron-500">Audit events: {Array.isArray(record.details.invoice_audit_history) ? record.details.invoice_audit_history.length : 0}</div></article>; })}</div>
       </section>
     </section>
   );

--- a/frontend/src/pages/PurchaseOrderRequestPage.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.tsx
@@ -12,7 +12,8 @@ const today = () => new Date().toISOString().slice(0, 10);
 
 function buildPoNumber(jobNumber: string) {
   const sequence = Date.now().toString().slice(-8);
-  return `PO-${sequence}-${jobNumber}`;
+  const jobCode = jobNumber.replace(/[^a-z0-9]/gi, "").toUpperCase();
+  return `PO${sequence}-${jobCode}`;
 }
 
 export function PurchaseOrderRequestPage() {

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -63,6 +63,16 @@ def _project() -> dict:
     return response.json()
 
 
+def _invoice_document(project_id: str, name: str = "invoice.pdf") -> str:
+    response = client.post(
+        "/api/v1/documents/upload",
+        data={"category": "other", "project_id": project_id, "title": name},
+        files={"file": (name, b"invoice evidence", "application/pdf")},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["document"]["id"]
+
+
 def _grant_operator_access(employee: dict) -> str:
     with TestingSessionLocal() as db:
         equipment = Equipment(
@@ -1202,3 +1212,43 @@ def test_purchase_order_request_is_accepted_and_returned() -> None:
         if item["id"] == response.json()["id"]
     )
     assert stored["details"]["po_number"] == "PO-12345678-FIELD-OPS-001"
+
+
+def test_po_invoice_attachment_and_admin_decision_preserve_po_status_and_audit() -> None:
+    project = _project()
+    po = client.post("/api/v1/field-operations/records", json={"record_type": "purchase_order_request", "project_id": project["id"], "work_date": str(date.today()), "title": "PO12345678-IH2026001 — Pipe", "status": "pending_approval", "details": {"po_number": "PO12345678-IH2026001", "job_number": "IH2026001", "supplier_name": "Pipe Co", "amount_estimate": 1000}}).json()
+    attached = client.post(f"/api/v1/field-operations/records/{po['id']}/invoice", json={"document_id": _invoice_document(project["id"]), "invoice_number": "INV-42", "vendor_name": "Pipe Co", "invoice_date": str(date.today()), "subtotal": 1000, "tax": 120, "total": 1120, "note": "Delivered"})
+    assert attached.status_code == 200, attached.text
+    assert attached.json()["status"] == "pending_approval"
+    assert attached.json()["details"]["invoice_status"] == "pending_approval"
+    assert attached.json()["details"]["invoice_audit_history"][0]["action"] == "attached"
+    approved = client.post(f"/api/v1/field-operations/records/{po['id']}/invoice-decision", json={"decision": "approved", "note": "Matched to delivery"})
+    assert approved.status_code == 200, approved.text
+    assert approved.json()["details"]["invoice_status"] == "approved"
+    assert [event["action"] for event in approved.json()["details"]["invoice_audit_history"]] == ["attached", "approved"]
+    assert approved.json()["status"] == "pending_approval"
+
+
+def test_po_invoice_duplicate_is_flagged_and_non_management_cannot_approve() -> None:
+    project = _project()
+    payload = {"record_type": "purchase_order_request", "project_id": project["id"], "work_date": str(date.today()), "title": "PO", "status": "pending_approval", "details": {"job_number": "IH2026001"}}
+    first = client.post("/api/v1/field-operations/records", json={**payload, "details": {**payload["details"], "po_number": "PO11111111-IH2026001"}}).json()
+    second = client.post("/api/v1/field-operations/records", json={**payload, "details": {**payload["details"], "po_number": "PO22222222-IH2026001"}}).json()
+    invoice = {"invoice_number": "Same-7", "vendor_name": "Vendor Ltd", "invoice_date": str(date.today()), "subtotal": 10, "tax": 1.2, "total": 11.2}
+    client.post(f"/api/v1/field-operations/records/{first['id']}/invoice", json={**invoice, "document_id": _invoice_document(project["id"], "first.pdf")})
+    duplicate = client.post(f"/api/v1/field-operations/records/{second['id']}/invoice", json={**invoice, "invoice_number": " same-7 ", "vendor_name": " vendor ltd ", "document_id": _invoice_document(project["id"], "second.pdf")})
+    assert duplicate.json()["details"]["invoice"]["duplicate_po_numbers"] == ["PO11111111-IH2026001"]
+    _authenticate_as("viewer")
+    denied = client.post(f"/api/v1/field-operations/records/{second['id']}/invoice-decision", json={"decision": "approved"})
+    assert denied.status_code == 403
+
+
+def test_po_invoice_rejection_requires_note_and_amounts_must_balance() -> None:
+    project = _project()
+    po = client.post("/api/v1/field-operations/records", json={"record_type": "purchase_order_request", "project_id": project["id"], "work_date": str(date.today()), "title": "PO", "details": {}}).json()
+    document_id = _invoice_document(project["id"])
+    unbalanced = client.post(f"/api/v1/field-operations/records/{po['id']}/invoice", json={"document_id": document_id, "invoice_number": "INV-9", "vendor_name": "Vendor", "invoice_date": str(date.today()), "subtotal": 10, "tax": 1, "total": 15})
+    assert unbalanced.status_code == 422
+    client.post(f"/api/v1/field-operations/records/{po['id']}/invoice", json={"document_id": document_id, "invoice_number": "INV-9", "vendor_name": "Vendor", "invoice_date": str(date.today()), "subtotal": 10, "tax": 1, "total": 11})
+    rejected = client.post(f"/api/v1/field-operations/records/{po['id']}/invoice-decision", json={"decision": "rejected"})
+    assert rejected.status_code == 422

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -12,6 +12,7 @@ from app.schemas.field_operations import SafetyRecordUpdate
 from app.services import field_operations
 from app.api.dependencies.auth import require_authenticated_user
 from app.models.employee_onboarding import EmployeeOnboarding, WorkerOrientation
+from app.models.document import Document
 from app.models.equipment import Equipment
 from app.models.field_operations import FieldRecord
 from app.services.auth import AuthenticatedUser
@@ -64,13 +65,18 @@ def _project() -> dict:
 
 
 def _invoice_document(project_id: str, name: str = "invoice.pdf") -> str:
-    response = client.post(
-        "/api/v1/documents/upload",
-        data={"category": "other", "project_id": project_id, "title": name},
-        files={"file": (name, b"invoice evidence", "application/pdf")},
-    )
-    assert response.status_code == 201, response.text
-    return response.json()["document"]["id"]
+    with TestingSessionLocal() as db:
+        document = Document(
+            title=name,
+            category="other",
+            status="registered",
+            project_id=UUID(project_id),
+            description="Supplier invoice test evidence",
+        )
+        db.add(document)
+        db.commit()
+        db.refresh(document)
+        return str(document.id)
 
 
 def _grant_operator_access(employee: dict) -> str:


### PR DESCRIPTION
Closes #276

## Summary
- adds a PO invoice attachment form for PDF/image evidence
- links invoice number, vendor, date, subtotal, tax, total, note, PO, job, and requested amount
- shows invoice-to-PO variance and flags duplicate vendor + invoice combinations
- adds a filterable admin invoice approval queue with approve/reject controls
- keeps invoice approval separate from PO status, payment, accounting export, and external messaging
- preserves server-authored reviewer, timestamp, decision, attachment, and audit history

## Controls
- attaching an invoice never approves it
- approval requires admin or operations manager access
- rejection requires a note
- invoice document must belong to the PO project
- decisions do not create payments or accounting entries

## Validation
- `git diff --check`
- Python compile validation for backend and targeted tests
- targeted backend tests added for approval, rejection, duplicates, authorization, balance validation, and audit history
- full CI and Release Readiness requested by this draft PR