### PR TITLE
Seed award pricing baseline and draft procurement controls

### DIFF
--- a/backend/app/schemas/project_launch.py
+++ b/backend/app/schemas/project_launch.py
@@ -25,3 +25,9 @@ class ProjectLaunchDashboard(BaseModel):
     pending_po_request_count: int
     safety_record_counts: dict[str, int]
     document_count: int
+    award_baseline_source: str | None
+    award_pricing_subtotal: float
+    award_cost_budget_status: str
+    uncoded_award_line_count: int
+    procurement_requirement_count: int
+    procurement_plan_status: str

--- a/backend/app/services/customer_quotes.py
+++ b/backend/app/services/customer_quotes.py
@@ -31,6 +31,13 @@ QUOTE_NUMBER_WIDTH = 3
 QUOTE_NUMBER_RETRY_LIMIT = 20
 MONEY = Decimal("0.01")
 
+PROCUREMENT_RULES = (
+    ("rental", ("rental", "rent ", "roller", "skid steer", "excavator", "cutoff saw", "cut-off saw")),
+    ("trucking", ("trucking", "tandem", "haul", "disposal", "dump fee", "delivery")),
+    ("subcontract", ("subcontract", "paving", "concrete placing", "finishing", "testing", "coring")),
+    ("material", ("pipe", "fitting", "concrete", "asphalt", "aggregate", "gravel", "sand", "topsoil")),
+)
+
 
 def _money(value: Decimal) -> Decimal:
     return value.quantize(MONEY, rounding=ROUND_HALF_UP)
@@ -62,6 +69,71 @@ def _totals(items: list[CustomerQuoteLineItem], gst_rate: Decimal) -> tuple[list
 
 def _clean_list(values: list[str]) -> list[str]:
     return [value.strip() for value in values if value.strip()]
+
+
+def _procurement_category(description: str) -> str | None:
+    normalized = description.casefold()
+    return next((category for category, terms in PROCUREMENT_RULES if any(term in normalized for term in terms)), None)
+
+
+def _initialize_award_controls(project: Project, quote: CustomerQuote, actor_email: str) -> None:
+    """Store an idempotent award baseline without treating customer pricing as a cost budget."""
+    metadata = dict(project.metadata_json or {})
+    baseline = metadata.get("award_pricing_baseline") or {}
+    if baseline.get("source_quote_id") == str(quote.id):
+        return
+    lines = []
+    requirements = []
+    for index, source in enumerate(quote.line_items_json or [], start=1):
+        source_line_id = f"{quote.id}:{index}"
+        description = str(source.get("description") or "").strip()
+        lines.append({
+            "source_line_id": source_line_id,
+            "description": description,
+            "quantity": source.get("quantity"),
+            "unit": source.get("unit"),
+            "customer_unit_price": source.get("unit_price"),
+            "customer_price_amount": source.get("amount"),
+            "cost_code": None,
+            "cost_budget_amount": None,
+            "status": "needs_cost_allocation",
+        })
+        category = _procurement_category(description)
+        if category:
+            requirements.append({
+                "requirement_id": source_line_id,
+                "source_line_id": source_line_id,
+                "category": category,
+                "description": description,
+                "quantity": source.get("quantity"),
+                "unit": source.get("unit"),
+                "status": "not_started",
+                "vendor_id": None,
+                "po_number": None,
+                "required_on_site_date": None,
+                "approval": None,
+            })
+    now = datetime.now(UTC).isoformat()
+    metadata["award_pricing_baseline"] = {
+        "source_quote_id": str(quote.id),
+        "source_quote_number": quote.quote_number,
+        "source_quote_revision": quote.record_revision,
+        "pricing_subtotal": str(quote.subtotal),
+        "basis": "accepted_customer_quote_price",
+        "cost_budget_status": "needs_cost_allocation",
+        "lines": lines,
+        "created_by": actor_email,
+        "created_at": now,
+    }
+    metadata["procurement_plan"] = {
+        "source_quote_id": str(quote.id),
+        "status": "draft",
+        "requirements": requirements,
+        "created_by": actor_email,
+        "created_at": now,
+        "automatic_commitment": False,
+    }
+    project.metadata_json = metadata
 
 
 def _next_quote_number(db: Session) -> str:
@@ -426,6 +498,8 @@ def accept_customer_quote(
         quote = _load_quote(db, quote_id, for_update=True)
         project = _load_project(db, quote.project_id, for_update=True)
         if quote.status == CustomerQuoteStatus.accepted.value:
+            _initialize_award_controls(project, quote, actor_email)
+            db.commit()
             return _read(quote, project)
         if quote.record_revision != payload.expected_revision:
             raise AppError("This quote changed in another session. Reload before accepting.", status_code=409)
@@ -446,6 +520,7 @@ def accept_customer_quote(
         project.contract_value = quote.total
         try:
             projects.prepare_project_award(db, project)
+            _initialize_award_controls(project, quote, actor_email)
             db.commit()
         except IntegrityError:
             db.rollback()

--- a/backend/app/services/project_launch.py
+++ b/backend/app/services/project_launch.py
@@ -78,6 +78,11 @@ def get_project_launch_dashboard(db: Session, project_id: UUID) -> ProjectLaunch
     document_count = int(
         db.scalar(select(func.count(Document.id)).where(Document.project_id == project_id)) or 0
     )
+    metadata = project.metadata_json or {}
+    award_baseline = metadata.get("award_pricing_baseline") or {}
+    procurement_plan = metadata.get("procurement_plan") or {}
+    award_lines = award_baseline.get("lines") or []
+    requirements = procurement_plan.get("requirements") or []
     total_count = len(checklist)
     return ProjectLaunchDashboard(
         project_id=project.id,
@@ -104,4 +109,10 @@ def get_project_launch_dashboard(db: Session, project_id: UUID) -> ProjectLaunch
         pending_po_request_count=sum(row.status == "pending_approval" for row in po_rows),
         safety_record_counts=safety_counts,
         document_count=document_count,
+        award_baseline_source=award_baseline.get("source_quote_number"),
+        award_pricing_subtotal=round(float(award_baseline.get("pricing_subtotal") or 0), 2),
+        award_cost_budget_status=str(award_baseline.get("cost_budget_status") or "not_started"),
+        uncoded_award_line_count=sum(not line.get("cost_code") for line in award_lines),
+        procurement_requirement_count=len(requirements),
+        procurement_plan_status=str(procurement_plan.get("status") or "not_started"),
     )

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -124,6 +124,12 @@ export type ProjectLaunchDashboard = {
   pending_po_request_count: number;
   safety_record_counts: Record<string, number>;
   document_count: number;
+  award_baseline_source: string | null;
+  award_pricing_subtotal: number;
+  award_cost_budget_status: string;
+  uncoded_award_line_count: number;
+  procurement_requirement_count: number;
+  procurement_plan_status: string;
 };
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";

--- a/frontend/src/pages/MVPWorkflowPage.test.tsx
+++ b/frontend/src/pages/MVPWorkflowPage.test.tsx
@@ -369,5 +369,11 @@ function launchDashboard(job: Project, status: "ready" | "not_ready"): ProjectLa
     pending_po_request_count: 1,
     safety_record_counts: { safety_permit: 1 },
     document_count: 4,
+    award_baseline_source: "Q-2026-001",
+    award_pricing_subtotal: 100000,
+    award_cost_budget_status: "needs_cost_allocation",
+    uncoded_award_line_count: 5,
+    procurement_requirement_count: 2,
+    procurement_plan_status: "draft",
   };
 }

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -122,6 +122,12 @@ const awardedLaunchDashboard: ProjectLaunchDashboard = {
     corrective_action: 0,
   },
   document_count: 7,
+  award_baseline_source: "Q-2026-001",
+  award_pricing_subtotal: 125000,
+  award_cost_budget_status: "needs_cost_allocation",
+  uncoded_award_line_count: 4,
+  procurement_requirement_count: 3,
+  procurement_plan_status: "draft",
 };
 
 let releaseChecklistUpdate: (() => void) | null = null;

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -511,6 +511,16 @@ function ProjectLaunchDashboardCard({
           detail="Project-linked records only"
         />
         <LaunchMetric label="Documents" value={String(dashboard.document_count)} detail="Project-linked records only" />
+        <LaunchMetric
+          label="Award pricing baseline"
+          value={dashboard.award_baseline_source ?? "Not initialized"}
+          detail={dashboard.award_baseline_source ? `${formatCurrency(dashboard.award_pricing_subtotal)} customer pricing · ${dashboard.uncoded_award_line_count} line(s) need cost codes` : "Accept a controlled customer quote to initialize."}
+        />
+        <LaunchMetric
+          label="Procurement plan"
+          value={label(dashboard.procurement_plan_status)}
+          detail={`${dashboard.procurement_requirement_count} draft requirement(s) · no automatic commitment`}
+        />
       </div>
 
       <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">

--- a/tests/backend/test_customer_quotes.py
+++ b/tests/backend/test_customer_quotes.py
@@ -199,6 +199,26 @@ def test_management_acceptance_atomically_awards_project_and_is_idempotent() -> 
     assert project["status"] == "awarded"
     assert project["project_number"] == body["job_number"]
     assert project["contract_value"] == 12600.0
+    baseline = project["metadata"]["award_pricing_baseline"]
+    assert baseline["source_quote_id"] == created["id"]
+    assert baseline["source_quote_number"] == created["quote_number"]
+    assert baseline["pricing_subtotal"] == "12000.00"
+    assert baseline["basis"] == "accepted_customer_quote_price"
+    assert baseline["cost_budget_status"] == "needs_cost_allocation"
+    assert len(baseline["lines"]) == 2
+    assert all(line["cost_budget_amount"] is None for line in baseline["lines"])
+    procurement = project["metadata"]["procurement_plan"]
+    assert procurement["status"] == "draft"
+    assert procurement["automatic_commitment"] is False
+    assert all(item["vendor_id"] is None and item["po_number"] is None for item in procurement["requirements"])
+    launch = client.get(f"/api/v1/projects/{created['project_id']}/launch-dashboard")
+    assert launch.status_code == 200
+    assert launch.json()["award_baseline_source"] == created["quote_number"]
+    assert launch.json()["award_pricing_subtotal"] == 12000.0
+    assert launch.json()["award_cost_budget_status"] == "needs_cost_allocation"
+    assert launch.json()["uncoded_award_line_count"] == 2
+    assert launch.json()["procurement_requirement_count"] == 1
+    assert launch.json()["procurement_plan_status"] == "draft"
 
     checklist = client.get(f"/api/v1/projects/{created['project_id']}/start-checklist")
     assert checklist.status_code == 200
@@ -208,6 +228,9 @@ def test_management_acceptance_atomically_awards_project_and_is_idempotent() -> 
     assert repeated.status_code == 200
     assert repeated.json()["job_number"] == body["job_number"]
     assert repeated.json()["record_revision"] == 2
+    repeated_project = client.get(f"/api/v1/projects/{created['project_id']}").json()
+    assert repeated_project["metadata"]["award_pricing_baseline"]["created_at"] == baseline["created_at"]
+    assert repeated_project["metadata"]["procurement_plan"]["requirements"] == procurement["requirements"]
 
 
 def test_estimator_can_prepare_but_cannot_accept_customer_quote() -> None:

--- a/tests/backend/test_project_launch.py
+++ b/tests/backend/test_project_launch.py
@@ -57,6 +57,12 @@ def test_awarded_project_launch_dashboard_starts_with_derived_controls() -> None
             "corrective_action": 0,
         },
         "document_count": 0,
+        "award_baseline_source": None,
+        "award_pricing_subtotal": 0.0,
+        "award_cost_budget_status": "not_started",
+        "uncoded_award_line_count": 0,
+        "procurement_requirement_count": 0,
+        "procurement_plan_status": "not_started",
     }
 
 


### PR DESCRIPTION
Closes #278
Parent: #268

## Summary
- initializes a traceable award pricing baseline when management accepts a customer quote
- preserves source quote, revision, source line identity, quantities, units, customer pricing, and unallocated cost fields
- classifies likely material, rental, trucking, and subcontract requirements into a draft procurement plan
- exposes the award baseline and draft procurement status on the awarded job launch dashboard
- makes repeated acceptance idempotent without duplicating lines or requirements

## Financial and procurement controls
- customer quote pricing is explicitly not treated as a cost budget
- cost codes and cost-budget amounts remain visibly unallocated until reviewed
- procurement requirements remain draft/not started
- no vendor, PO number, required-on-site date, approval, payment, external message, or purchasing commitment is inferred

## Validation
- `git diff --check`
- Python compile validation
- backend tests added for source traceability, pricing reconciliation, open cost allocation, draft procurement, no automatic commitments, dashboard visibility, and idempotency
- frontend job-launch dashboard fixture and rendering updated
- full CI and Release Readiness requested by this draft PR