### PR TITLE
Authorize protected production release d4c4fd3

### DIFF
--- a/.github/workflows/finish-approved-production-deploy.yml
+++ b/.github/workflows/finish-approved-production-deploy.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 130
     env:
-      RELEASE_SHA: 55295263d861e60c535cc0b41185dcd8b18ae4e8
-      RELEASE_REF: release-evidence/55295263
+      RELEASE_SHA: d4c4fd34afc2cffaad0550c0ac802fb9fe126e6c
+      RELEASE_REF: release-evidence/d4c4fd3
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #280

## Owner authorization
Jeremie Peters explicitly instructed `Deploy`.

## Exact release
- Release SHA: `d4c4fd34afc2cffaad0550c0ac802fb9fe126e6c`
- Immutable ref: `release-evidence/d4c4fd3`
- Main Release Readiness: run `32593226141` / #416 — success

## Change
Updates only the exact release SHA and immutable evidence ref consumed by the checked-in `Finish approved production deploy` workflow.

After merge, that workflow will:
1. verify the release/ref relationship;
2. dispatch exact CI and Release Readiness gates;
3. dispatch Production deploy with the successful evidence run;
4. preserve the protected `production` environment and required reviewer;
5. verify public health/readiness and exact release identity.

## Controls
- no Cloud Browser dependency
- no production reviewer bypass
- no DNS, secret, certificate, database, backup-policy, or arbitrary shell changes
- production remains unchanged until protected deployment approval and runner checks pass