### PR TITLE
Fix production wrapper verification and legacy duplicate dispatch

### DIFF
--- a/.github/workflows/finish-approved-production-deploy.yml
+++ b/.github/workflows/finish-approved-production-deploy.yml
@@ -11,11 +11,6 @@ on:
         description: Successful Release readiness run for the exact release SHA
         required: true
         type: string
-  push:
-    branches: [main]
-    paths:
-      - ".github/workflows/finish-approved-production-deploy.yml"
-
 permissions:
   actions: write
   contents: read
@@ -31,25 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 130
     env:
-      RELEASE_SHA: ${{ inputs.release_sha || 'd4c4fd34afc2cffaad0550c0ac802fb9fe126e6c' }}
-      RELEASE_REF: release-evidence/d4c4fd3
+      RELEASE_SHA: ${{ inputs.release_sha }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Verify approved release and exact evidence ref
-        if: github.event_name == 'push'
-        run: |
-          set -euo pipefail
-          git fetch --quiet origin main "$RELEASE_REF"
-          git cat-file -e "$RELEASE_SHA^{commit}"
-          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
-          test "$(git rev-parse "origin/$RELEASE_REF")" = "$RELEASE_SHA"
-
       - name: Verify manually approved release and evidence
-        if: github.event_name == 'workflow_dispatch'
         id: manual_evidence
         env:
           EVIDENCE_RUN_ID: ${{ inputs.evidence_run_id }}
@@ -66,52 +50,10 @@ jobs:
           test "$(jq -r .name <<<"$run")" = "Release readiness"
           echo "evidence_run_id=$EVIDENCE_RUN_ID" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch exact CI and Release Readiness gates
-        if: github.event_name == 'push'
-        id: gate_dispatch
-        run: |
-          set -euo pipefail
-          started="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          echo "started=$started" >> "$GITHUB_OUTPUT"
-          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_REF"
-          gh workflow run release-readiness.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_REF"
-
-      - name: Wait for exact CI and Release Readiness gates
-        if: github.event_name == 'push'
-        id: gates
-        env:
-          STARTED: ${{ steps.gate_dispatch.outputs.started }}
-        run: |
-          set -euo pipefail
-          for attempt in $(seq 1 120); do
-            runs="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${RELEASE_SHA}&event=workflow_dispatch&per_page=100")"
-            ci="$(jq -r --arg started "$STARTED" '([.workflow_runs[] | select(.name == "CI" and .created_at >= $started)] | sort_by(.created_at) | last // {}) | [.id // "", .status // "", .conclusion // ""] | @tsv' <<<"$runs")"
-            readiness="$(jq -r --arg started "$STARTED" '([.workflow_runs[] | select(.name == "Release readiness" and .created_at >= $started)] | sort_by(.created_at) | last // {}) | [.id // "", .status // "", .conclusion // ""] | @tsv' <<<"$runs")"
-            IFS=$'\t' read -r ci_id ci_status ci_conclusion <<<"$ci"
-            IFS=$'\t' read -r rr_id rr_status rr_conclusion <<<"$readiness"
-
-            if [[ "$ci_status" == "completed" && "$ci_conclusion" != "success" ]]; then
-              echo "blocker=CI run ${ci_id} concluded ${ci_conclusion}" >> "$GITHUB_OUTPUT"
-              exit 1
-            fi
-            if [[ "$rr_status" == "completed" && "$rr_conclusion" != "success" ]]; then
-              echo "blocker=Release Readiness run ${rr_id} concluded ${rr_conclusion}" >> "$GITHUB_OUTPUT"
-              exit 1
-            fi
-            if [[ "$ci_status" == "completed" && "$ci_conclusion" == "success" && "$rr_status" == "completed" && "$rr_conclusion" == "success" ]]; then
-              echo "ci_run_id=$ci_id" >> "$GITHUB_OUTPUT"
-              echo "evidence_run_id=$rr_id" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            sleep 30
-          done
-          echo "blocker=Timed out waiting for exact CI and Release Readiness runs for ${RELEASE_SHA}" >> "$GITHUB_OUTPUT"
-          exit 1
-
       - name: Dispatch approved Production deploy
         id: dispatch
         env:
-          EVIDENCE_RUN_ID: ${{ steps.gates.outputs.evidence_run_id || steps.manual_evidence.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ID: ${{ steps.manual_evidence.outputs.evidence_run_id }}
         run: |
           set -euo pipefail
           started="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -182,26 +124,20 @@ jobs:
       - name: Record deployment success
         if: success()
         env:
-          CI_RUN_ID: ${{ steps.gates.outputs.ci_run_id }}
-          EVIDENCE_RUN_ID: ${{ steps.gates.outputs.evidence_run_id || steps.manual_evidence.outputs.evidence_run_id }}
+          EVIDENCE_RUN_ID: ${{ steps.manual_evidence.outputs.evidence_run_id }}
           PRODUCTION_RUN_ID: ${{ steps.dispatch.outputs.production_run_id }}
         run: |
-          ci_record=""
-          if [[ -n "$CI_RUN_ID" ]]; then
-            ci_record="CI: ${CI_RUN_ID}. "
-          fi
-          gh issue comment 168 --repo "$GITHUB_REPOSITORY" --body "Production deployment completed for \`${RELEASE_SHA}\`. ${ci_record}Release Readiness: ${EVIDENCE_RUN_ID}. Production deploy: ${PRODUCTION_RUN_ID}. Public health/readiness and exact release ID verification passed."
+          gh issue comment 168 --repo "$GITHUB_REPOSITORY" --body "Production deployment completed for \`${RELEASE_SHA}\`. Release Readiness: ${EVIDENCE_RUN_ID}. Production deploy: ${PRODUCTION_RUN_ID}. Public health/readiness and exact release ID verification passed."
           gh issue close 168 --repo "$GITHUB_REPOSITORY" --reason completed
 
       - name: Record blocker for operator follow-up
         if: failure()
         env:
-          GATE_BLOCKER: ${{ steps.gates.outputs.blocker }}
           DISPATCH_BLOCKER: ${{ steps.dispatch.outputs.blocker }}
           PRODUCTION_BLOCKER: ${{ steps.production.outputs.blocker }}
           PRODUCTION_RUN_ID: ${{ steps.dispatch.outputs.production_run_id }}
         run: |
-          blocker="${GATE_BLOCKER:-${DISPATCH_BLOCKER:-${PRODUCTION_BLOCKER:-Endpoint verification failed}}}"
+          blocker="${DISPATCH_BLOCKER:-${PRODUCTION_BLOCKER:-Endpoint verification failed}}"
           body="Approved production deployment for \`${RELEASE_SHA}\` stopped without bypassing gates.\n\n**Blocker:** ${blocker}\n\n**Exact next action:** correct the reported failing gate or production step, rerun the affected gate if needed, then rerun this finish workflow."
           if [[ -n "${PRODUCTION_RUN_ID:-}" ]]; then
             body="${body}\n\nProduction run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${PRODUCTION_RUN_ID}"

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -68,19 +68,19 @@ jobs:
           [[ "$run_result" == "success" ]]
           [[ "$run_name" == "Release readiness" ]]
 
-      - name: Checkout trusted deploy tooling at workflow commit
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          ref: ${{ github.workflow_sha }}
-          path: .deploy-tooling
-          persist-credentials: false
-
       - name: Checkout approved release SHA
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha }}
           clean: true
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout trusted deploy tooling at workflow commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .deploy-tooling
           persist-credentials: false
 
       - name: Verify approved main release


### PR DESCRIPTION
Closes #289.

- Checks out the approved release before trusted deploy tooling so the root checkout cannot clean `.deploy-tooling` before wrapper verification.
- Makes the Finish workflow manual-only with required exact SHA/evidence inputs.
- Removes the legacy hard-coded release fallback and automatic push dispatch that created stale duplicate runs.
- Preserves the protected production environment, exact evidence validation, installed-wrapper comparison, and public release verification.

Validation: both workflows parse as YAML; `git diff --check` passed.