### PR TITLE
Separate production release and trusted tooling workspaces

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha }}
+          path: .release
           clean: true
           fetch-depth: 0
           persist-credentials: false
@@ -84,6 +85,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify approved main release
+        working-directory: .release
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
         run: |
@@ -114,6 +116,7 @@ jobs:
           cmp --silent "$trusted_wrapper" "$installed_wrapper"
 
       - name: Execute restricted production cutover
+        working-directory: .release
         env:
           RELEASE_SHA: ${{ inputs.release_sha }}
         run: >-


### PR DESCRIPTION
Closes #293.

Checks out the exact approved release under `.release` and trusted workflow tooling under `.deploy-tooling`. Exact release verification and the restricted production wrapper now run from `.release`, while installed-wrapper comparison continues against the trusted workflow checkout. This keeps both repositories clean and independently verifiable.

Protected approval, exact evidence validation, and endpoint/release verification remain unchanged.