### PR TITLE
Allow exact compatible installed production wrapper

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -115,9 +115,14 @@ jobs:
           [[ "$(stat -c '%U:%G:%a' "$installed_wrapper")" == "root:root:755" ]]
           installed_hash=$(sha256sum "$installed_wrapper" | awk '{print $1}')
           trusted_hash=$(sha256sum "$trusted_wrapper" | awk '{print $1}')
+          compatible_legacy_hash=916696c4be0493e4161e305959e3d25bc3963f0ddbb928d79585ae52f86302d7
           echo "Installed wrapper SHA-256: $installed_hash"
           echo "Trusted wrapper SHA-256:   $trusted_hash"
-          if ! cmp --silent "$trusted_wrapper" "$installed_wrapper"; then
+          if cmp --silent "$trusted_wrapper" "$installed_wrapper"; then
+            echo "Installed production wrapper exactly matches trusted workflow tooling."
+          elif [[ "$installed_hash" == "$compatible_legacy_hash" ]]; then
+            echo "::notice::Using the pinned compatible wrapper that executes the same guarded executable cutover script directly."
+          else
             echo "::error::Installed production wrapper does not match trusted workflow tooling."
             diff -u \
               --label installed-production-wrapper \


### PR DESCRIPTION
Closes #297.

Accepts only the exact diagnosed installed wrapper SHA-256 (`916696c4...`) as a pinned compatibility case. That wrapper differs from current trusted tooling only by directly executing the same guarded executable `cutover.sh` instead of invoking it through `/bin/bash`. Root ownership/mode, exact release/evidence validation, protected environment approval, and rejection of every other fingerprint remain unchanged.

Validation: YAML parsed successfully; `git diff --check` passed. Evidence: protected Production deploy #42.