### PR TITLE
Add iPad-friendly project search and smoke/test filter

### DIFF
--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -156,6 +156,30 @@ describe("ProjectWorkspacePage", () => {
     expect(screen.getByText("7")).toBeInTheDocument();
   });
 
+  it("filters projects by searchable fields and the smoke/test cleanup control", async () => {
+    const smokeProject: Project = {
+      ...project,
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "Release smoke 20260823-100046",
+      project_number: "SMOKE-20260823-100046",
+    };
+    mockProjectApiWithProjects([project, smokeProject]);
+    const user = userEvent.setup();
+    renderWorkspace("/projects");
+
+    expect(await screen.findByText(project.name)).toBeInTheDocument();
+    expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
+
+    await user.type(screen.getByRole("searchbox", { name: "Search projects" }), "100046");
+    expect(screen.queryByText(project.name)).not.toBeInTheDocument();
+    expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
+
+    await user.clear(screen.getByRole("searchbox", { name: "Search projects" }));
+    await user.click(screen.getByRole("checkbox", { name: "Smoke/test projects only" }));
+    expect(screen.queryByText(project.name)).not.toBeInTheDocument();
+    expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
+  });
+
   it("creates an awarded project and delegates job-number generation to IHOS", async () => {
     const fetchMock = mockProjectApi();
     const user = userEvent.setup();
@@ -440,6 +464,18 @@ function mockProjectApi(
     return jsonResponse({ detail: "Not found" }, 404);
   });
 
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function mockProjectApiWithProjects(projects: Project[]) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url.endsWith("/projects")) return jsonResponse({ items: projects, total: projects.length });
+    const dashboardProject = projects.find((item) => url.endsWith(`/projects/${item.id}/dashboard`));
+    if (dashboardProject) return jsonResponse({ ...dashboard, project_id: dashboardProject.id });
+    throw new Error(`Unhandled request: ${url}`);
+  });
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
 }

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { Activity, BookOpen, Calculator, CalendarDays, FileStack, FolderKanban, Plus, RefreshCw, RotateCcw, ShieldCheck, Table2, Trash2, Users } from "lucide-react";
+import { Activity, BookOpen, Calculator, CalendarDays, FileStack, FolderKanban, Plus, RefreshCw, RotateCcw, Search, ShieldCheck, Table2, Trash2, Users } from "lucide-react";
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
@@ -45,6 +45,8 @@ export function ProjectWorkspacePage() {
   const [savingChecklistCode, setSavingChecklistCode] = useState<string | null>(null);
   const [dashboardByProjectId, setDashboardByProjectId] = useState<Record<string, ProjectDashboard>>({});
   const [statusFilter, setStatusFilter] = useState("");
+  const [searchFilter, setSearchFilter] = useState("");
+  const [smokeTestOnly, setSmokeTestOnly] = useState(false);
   const [showTrash, setShowTrash] = useState(false);
   const [activeTab, setActiveTab] = useState("Overview");
   const [isLoading, setIsLoading] = useState(true);
@@ -154,6 +156,18 @@ export function ProjectWorkspacePage() {
     }
   }
 
+  const normalizedSearch = searchFilter.trim().toLocaleLowerCase();
+  const smokeTestMarker = /(?:^|[^a-z0-9])(smoke|test)(?:[^a-z0-9]|$)/i;
+  const filteredProjects = projects.filter((project) => {
+    const searchable = [project.project_number, project.name, project.municipality, label(project.status)]
+      .filter(Boolean)
+      .join(" ")
+      .toLocaleLowerCase();
+    const matchesSearch = !normalizedSearch || searchable.includes(normalizedSearch);
+    const matchesSmokeTest = !smokeTestOnly || smokeTestMarker.test(`${project.project_number ?? ""} ${project.name}`);
+    return matchesSearch && matchesSmokeTest;
+  });
+
   return (
     <section className="space-y-6">
       <div className="flex flex-col gap-4 border-b border-iron-100 pb-6 lg:flex-row lg:items-end lg:justify-between">
@@ -178,7 +192,14 @@ export function ProjectWorkspacePage() {
 
       <div className="grid gap-6 xl:grid-cols-[420px_1fr]">
         <div className="min-w-0 space-y-6">
-          <ProjectFilters status={statusFilter} onStatusChange={setStatusFilter} />
+          <ProjectFilters
+            status={statusFilter}
+            search={searchFilter}
+            smokeTestOnly={smokeTestOnly}
+            onStatusChange={setStatusFilter}
+            onSearchChange={setSearchFilter}
+            onSmokeTestOnlyChange={setSmokeTestOnly}
+          />
           {isAdmin ? (
             <button
               type="button"
@@ -190,7 +211,7 @@ export function ProjectWorkspacePage() {
             </button>
           ) : null}
           <CreateProjectForm onSubmit={(payload) => void createProject(payload)} />
-          <ProjectList projects={projects} selectedId={projectId} dashboards={dashboardByProjectId} showTrash={showTrash} onRestore={(project) => void restoreProject(project)} />
+          <ProjectList projects={filteredProjects} selectedId={projectId} dashboards={dashboardByProjectId} showTrash={showTrash} onRestore={(project) => void restoreProject(project)} />
         </div>
         {selectedProject && dashboard ? (
           <ProjectDetail
@@ -221,15 +242,40 @@ export function ProjectWorkspacePage() {
   );
 }
 
-function ProjectFilters({ status, onStatusChange }: { status: string; onStatusChange: (value: string) => void }) {
+function ProjectFilters({
+  status,
+  search,
+  smokeTestOnly,
+  onStatusChange,
+  onSearchChange,
+  onSmokeTestOnlyChange,
+}: {
+  status: string;
+  search: string;
+  smokeTestOnly: boolean;
+  onStatusChange: (value: string) => void;
+  onSearchChange: (value: string) => void;
+  onSmokeTestOnlyChange: (value: boolean) => void;
+}) {
   return (
     <div className="rounded-md border border-iron-100 bg-white p-5">
       <h2 className="text-base font-semibold text-iron-950">Project Filters</h2>
+      <label className="relative mt-4 block">
+        <span className="sr-only">Search projects</span>
+        <Search aria-hidden="true" className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-iron-500" />
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => onSearchChange(event.target.value)}
+          className="w-full rounded-md border border-iron-100 py-2 pl-9 pr-3 text-sm"
+          placeholder="Search job #, name, municipality, or status"
+        />
+      </label>
       <select
         aria-label="Project status filter"
         value={status}
         onChange={(event) => onStatusChange(event.target.value)}
-        className="mt-4 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+        className="mt-3 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
       >
         <option value="">All statuses</option>
         {projectStatuses.map((item) => (
@@ -238,6 +284,15 @@ function ProjectFilters({ status, onStatusChange }: { status: string; onStatusCh
           </option>
         ))}
       </select>
+      <label className="mt-3 flex min-h-11 cursor-pointer items-center gap-3 rounded-md border border-iron-100 px-3 py-2 text-sm font-semibold text-iron-800">
+        <input
+          type="checkbox"
+          checked={smokeTestOnly}
+          onChange={(event) => onSmokeTestOnlyChange(event.target.checked)}
+          className="h-4 w-4 rounded border-iron-200"
+        />
+        Smoke/test projects only
+      </label>
     </div>
   );
 }


### PR DESCRIPTION
Closes #301

## Summary
- add project search by job number, name, municipality, and status
- add one-tap Smoke/test projects only filter
- compose text, status, and cleanup filters without changing server data
- preserve the locked IHOS visual design and iPad-sized controls

## Validation
- focused `ProjectWorkspacePage` test suite: 11 passed
- added coverage for text search and smoke/test filtering

No project records are changed or deleted by this PR.