### PR TITLE
Add recoverable bulk smoke/test cleanup

### DIFF
--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -180,6 +180,29 @@ describe("ProjectWorkspacePage", () => {
     expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
   });
 
+  it("moves only the filtered smoke/test projects to recoverable trash after confirmation", async () => {
+    const smokeProjects: Project[] = [
+      { ...project, id: "33333333-3333-4333-8333-333333333333", name: "Release smoke 20260823-100046", project_number: "SMOKE-20260823-100046" },
+      { ...project, id: "44444444-4444-4444-8444-444444444444", name: "Release smoke 20260823-131404", project_number: "SMOKE-20260823-131404" },
+    ];
+    const fetchMock = mockProjectApiWithProjects([project, ...smokeProjects]);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWorkspace("/projects");
+
+    await screen.findByText(project.name);
+    await user.click(screen.getByRole("checkbox", { name: "Smoke/test projects only" }));
+    await user.click(screen.getByRole("button", { name: "Move 2 filtered smoke/test projects to Trash" }));
+
+    await screen.findByText("2 smoke/test projects moved to Trash. They can be restored by an administrator.");
+    const deletes = fetchMock.mock.calls.filter(([, options]) => options?.method === "DELETE");
+    expect(deletes).toHaveLength(2);
+    expect(deletes.map(([, options]) => JSON.parse(String(options?.body)).confirmation_name)).toEqual(
+      smokeProjects.map((item) => item.name),
+    );
+    expect(screen.queryByText(project.name)).not.toBeInTheDocument();
+  });
+
   it("creates an awarded project and delegates job-number generation to IHOS", async () => {
     const fetchMock = mockProjectApi();
     const user = userEvent.setup();
@@ -468,9 +491,16 @@ function mockProjectApi(
   return fetchMock;
 }
 
-function mockProjectApiWithProjects(projects: Project[]) {
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+function mockProjectApiWithProjects(initialProjects: Project[]) {
+  let projects = initialProjects;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
     const url = input.toString();
+    if (options?.method === "DELETE") {
+      const deleted = projects.find((item) => url.endsWith(`/projects/${item.id}`));
+      if (!deleted) return jsonResponse({ detail: "Not found" }, 404);
+      projects = projects.filter((item) => item.id !== deleted.id);
+      return jsonResponse({ ...deleted, deleted_at: "2026-08-23T15:00:00Z" });
+    }
     if (url.endsWith("/projects")) return jsonResponse({ items: projects, total: projects.length });
     const dashboardProject = projects.find((item) => url.endsWith(`/projects/${item.id}/dashboard`));
     if (dashboardProject) return jsonResponse({ ...dashboard, project_id: dashboardProject.id });

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -47,6 +47,8 @@ export function ProjectWorkspacePage() {
   const [statusFilter, setStatusFilter] = useState("");
   const [searchFilter, setSearchFilter] = useState("");
   const [smokeTestOnly, setSmokeTestOnly] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [bulkDeleteResult, setBulkDeleteResult] = useState<string | null>(null);
   const [showTrash, setShowTrash] = useState(false);
   const [activeTab, setActiveTab] = useState("Overview");
   const [isLoading, setIsLoading] = useState(true);
@@ -131,6 +133,34 @@ export function ProjectWorkspacePage() {
     await refresh();
   }
 
+  async function moveFilteredSmokeTestsToTrash(filteredProjects: Project[]) {
+    if (!isAdmin || bulkDeleting || filteredProjects.length === 0) return;
+    const confirmed = window.confirm(
+      `Move all ${filteredProjects.length} filtered smoke/test projects to recoverable Trash?\n\nNo other projects will be changed.`,
+    );
+    if (!confirmed) return;
+    setBulkDeleting(true);
+    setBulkDeleteResult(null);
+    setError(null);
+    let moved = 0;
+    try {
+      for (const project of filteredProjects) {
+        await projectsApi.delete(project.id, project.name);
+        moved += 1;
+      }
+      setBulkDeleteResult(`${moved} smoke/test projects moved to Trash. They can be restored by an administrator.`);
+    } catch (currentError) {
+      setError(
+        `${moved} projects moved to Trash before cleanup stopped. ${
+          currentError instanceof Error ? currentError.message : "Unable to complete smoke/test cleanup."
+        }`,
+      );
+    } finally {
+      await refresh();
+      setBulkDeleting(false);
+    }
+  }
+
   async function updateStartChecklistItem(code: string, completed: boolean) {
     if (!selectedProject || savingChecklistCode) return;
     setSavingChecklistCode(code);
@@ -188,6 +218,7 @@ export function ProjectWorkspacePage() {
       </div>
 
       {error ? <Notice tone="error" message={error} /> : null}
+      {bulkDeleteResult ? <Notice tone="neutral" message={bulkDeleteResult} /> : null}
       {isLoading ? <Notice tone="neutral" message="Loading projects..." /> : null}
 
       <div className="grid gap-6 xl:grid-cols-[420px_1fr]">
@@ -200,6 +231,19 @@ export function ProjectWorkspacePage() {
             onSearchChange={setSearchFilter}
             onSmokeTestOnlyChange={setSmokeTestOnly}
           />
+          {isAdmin && smokeTestOnly && !showTrash && filteredProjects.length > 0 ? (
+            <button
+              type="button"
+              disabled={bulkDeleting}
+              onClick={() => void moveFilteredSmokeTestsToTrash(filteredProjects)}
+              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-red-200 bg-white px-3 py-2 text-sm font-semibold text-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Trash2 className="h-4 w-4" />
+              {bulkDeleting
+                ? "Moving smoke/test projects to Trash..."
+                : `Move ${filteredProjects.length} filtered smoke/test projects to Trash`}
+            </button>
+          ) : null}
           {isAdmin ? (
             <button
               type="button"


### PR DESCRIPTION
Closes #303

## Summary
- adds an admin-only bulk Trash action when the strict Smoke/test filter is active
- shows the exact filtered count before execution
- requires an in-app confirmation
- calls the existing exact-name recoverable delete endpoint sequentially
- reports partial progress safely if any request fails
- refreshes the project list after completion

## Safety
- no permanent deletion
- no legitimate unfiltered project is included
- restore remains available through View trash
- production inventory of 84 exact Release smoke records was reviewed and explicitly confirmed by the administrator on 2026-08-23

## Validation
- focused ProjectWorkspacePage tests: 12 passed