### PR TITLE
Keep awarded project selected when launch controls fail

### DIFF
--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -255,7 +255,7 @@ describe("ProjectWorkspacePage", () => {
     renderWorkspace(`/projects/${awardedProject.id}`);
 
     expect(await screen.findByRole("heading", { name: awardedProject.name })).toBeInTheDocument();
-    expect(screen.getByText(/Bennet Sidewalk is selected, but its launch dashboard could not be loaded/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`${awardedProject.name} is selected, but its launch dashboard could not be loaded`, "i"))).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Awarded project workspace" })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Awarded job start checklist" })).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Job launch dashboard" })).not.toBeInTheDocument();

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -241,6 +241,26 @@ describe("ProjectWorkspacePage", () => {
     expect(fetchMock.mock.calls.some(([url]) => url.toString().includes("/launch-dashboard"))).toBe(false);
   });
 
+  it("keeps the awarded project selected when optional launch controls fail", async () => {
+    const fetchMock = mockProjectApi(awardedProject, awardedWorkspace, awardedStartChecklist);
+    const originalImplementation = fetchMock.getMockImplementation();
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, options?: RequestInit) => {
+      if (input.toString().endsWith(`/projects/${awardedProject.id}/launch-dashboard`)) {
+        return jsonResponse({ detail: "Launch dashboard unavailable" }, 500);
+      }
+      if (!originalImplementation) throw new Error("Project API mock is unavailable");
+      return originalImplementation(input, options);
+    });
+
+    renderWorkspace(`/projects/${awardedProject.id}`);
+
+    expect(await screen.findByRole("heading", { name: awardedProject.name })).toBeInTheDocument();
+    expect(screen.getByText(/Bennet Sidewalk is selected, but its launch dashboard could not be loaded/i)).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Awarded project workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Awarded job start checklist" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Job launch dashboard" })).not.toBeInTheDocument();
+  });
+
   it("shows the stable prepared workspace for an awarded job", async () => {
     mockProjectApi(awardedProject, awardedWorkspace);
 

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -42,6 +42,7 @@ export function ProjectWorkspacePage() {
   const [workspace, setWorkspace] = useState<AwardedProjectWorkspace | null>(null);
   const [launchDashboard, setLaunchDashboard] = useState<ProjectLaunchDashboard | null>(null);
   const [startChecklist, setStartChecklist] = useState<ProjectStartChecklist | null>(null);
+  const [projectLoadWarning, setProjectLoadWarning] = useState<string | null>(null);
   const [savingChecklistCode, setSavingChecklistCode] = useState<string | null>(null);
   const [dashboardByProjectId, setDashboardByProjectId] = useState<Record<string, ProjectDashboard>>({});
   const [statusFilter, setStatusFilter] = useState("");
@@ -57,6 +58,7 @@ export function ProjectWorkspacePage() {
   const refresh = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    setProjectLoadWarning(null);
     try {
       const list = await projectsApi.list(statusFilter, showTrash);
       const visibleProjects = showTrash ? list.items.filter((project) => project.deleted_at) : list.items;
@@ -67,17 +69,34 @@ export function ProjectWorkspacePage() {
       setDashboardByProjectId(Object.fromEntries(summaries));
       if (projectId) {
         const detail = await projectsApi.detail(projectId);
-        const [summary, provisionedWorkspace, provisionedStartChecklist, launchSummary] = await Promise.all([
-          projectsApi.dashboard(projectId),
-          detail.workspace_root ? projectsApi.workspace(projectId) : Promise.resolve(null),
-          detail.workspace_root ? projectsApi.startChecklist(projectId) : Promise.resolve(null),
-          detail.workspace_root ? projectsApi.launchDashboard(projectId) : Promise.resolve(null),
-        ]);
+        const summary = await projectsApi.dashboard(projectId);
         setSelectedProject(detail);
         setDashboard(summary);
-        setWorkspace(provisionedWorkspace);
-        setLaunchDashboard(launchSummary);
-        setStartChecklist(provisionedStartChecklist);
+        setWorkspace(null);
+        setLaunchDashboard(null);
+        setStartChecklist(null);
+
+        if (detail.workspace_root) {
+          const [workspaceResult, checklistResult, launchResult] = await Promise.allSettled([
+            projectsApi.workspace(projectId),
+            projectsApi.startChecklist(projectId),
+            projectsApi.launchDashboard(projectId),
+          ]);
+          setWorkspace(workspaceResult.status === "fulfilled" ? workspaceResult.value : null);
+          setStartChecklist(checklistResult.status === "fulfilled" ? checklistResult.value : null);
+          setLaunchDashboard(launchResult.status === "fulfilled" ? launchResult.value : null);
+
+          const unavailable = [
+            workspaceResult.status === "rejected" ? "workspace summary" : null,
+            checklistResult.status === "rejected" ? "start checklist" : null,
+            launchResult.status === "rejected" ? "launch dashboard" : null,
+          ].filter(Boolean);
+          if (unavailable.length) {
+            setProjectLoadWarning(
+              `${detail.name} is selected, but its ${unavailable.join(", ")} could not be loaded. Available project controls remain usable.`,
+            );
+          }
+        }
       } else {
         setSelectedProject(null);
         setDashboard(null);
@@ -218,6 +237,7 @@ export function ProjectWorkspacePage() {
       </div>
 
       {error ? <Notice tone="error" message={error} /> : null}
+      {projectLoadWarning ? <Notice tone="error" message={projectLoadWarning} /> : null}
       {bulkDeleteResult ? <Notice tone="neutral" message={bulkDeleteResult} /> : null}
       {isLoading ? <Notice tone="neutral" message="Loading projects..." /> : null}
 


### PR DESCRIPTION
Closes #306
Parent: #268

## Summary
- loads the selected project and core dashboard before optional awarded-job controls
- isolates workspace, start-checklist, and launch-dashboard failures with `Promise.allSettled`
- keeps the exact `/projects/:projectId` project selected when one optional control fails
- shows a project-scoped warning while leaving available controls usable
- adds a regression test for a launch-dashboard HTTP 500

## Production reproduction
`MVP Workflow → Bennet Sidewalk → Complete launch controls` previously opened the generic Projects page with no project selected because one rejected launch request discarded all successful project responses.

## Controls
- no production data change
- no deployment
- locked visual design preserved
- protected production approval unchanged

## Validation
GitHub CI and Release Readiness required. Physical iPad production verification remains a separate protected deployment gate.