### PR TITLE
Show selected project first on iPad

### DIFF
--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -148,6 +148,7 @@ describe("ProjectWorkspacePage", () => {
     renderWorkspace("/projects");
 
     expect(await screen.findByText(project.name)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Project Filters" }).closest(".order-last")).toBeNull();
     expect(screen.getByRole("columnheader", { name: "Ready" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Docs" })).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Job #" })).toBeInTheDocument();
@@ -232,6 +233,7 @@ describe("ProjectWorkspacePage", () => {
     renderWorkspace(`/projects/${project.id}`);
 
     expect(await screen.findByRole("heading", { name: project.name })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Project Filters" }).closest(".order-last")).not.toBeNull();
     expect(screen.getByText("City of Surrey - Surrey")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Archive" })).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Awarded project workspace" })).not.toBeInTheDocument();

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -242,7 +242,7 @@ export function ProjectWorkspacePage() {
       {isLoading ? <Notice tone="neutral" message="Loading projects..." /> : null}
 
       <div className="grid gap-6 xl:grid-cols-[420px_1fr]">
-        <div className="min-w-0 space-y-6">
+        <div className={["min-w-0 space-y-6", projectId ? "order-last xl:order-none" : ""].filter(Boolean).join(" ")}>
           <ProjectFilters
             status={statusFilter}
             search={searchFilter}


### PR DESCRIPTION
Closes #308
Parent: #268

## Summary
- moves the project-management list below the selected project on stacked/mobile layouts
- preserves the existing desktop two-column order at the `xl` breakpoint
- leaves the unselected `/projects` route unchanged
- adds regression assertions for selected and unselected ordering

## Production evidence
Physical iPad acceptance after deploy #48 proved the correct Bennett project was selected, but its controls appeared only after scrolling past the full project list.

## Controls
- CSS ordering only; no data mutation or workflow action
- locked Iron House visual design preserved
- no production deployment

## Validation
GitHub CI and Release Readiness required. Physical iPad verification remains a separate deployment gate.