### PR TITLE
Recover protected production deploy after backend restart

### DIFF
--- a/backend/tests/test_production_deploy_recovery.py
+++ b/backend/tests/test_production_deploy_recovery.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_production_wrapper_recovers_one_stopped_compose_project() -> None:
+    wrapper = (
+        REPOSITORY_ROOT / "ops" / "digitalocean" / "production-deploy-wrapper.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "docker_ps+=(--all)" in wrapper
+    assert "sort -u" in wrapper
+    assert '"${#production_candidates[@]}" != 1' in wrapper
+    assert "Exactly one production Compose project is required" in wrapper
+
+
+def test_cutover_polls_exact_release_readiness_after_start() -> None:
+    cutover = (
+        REPOSITORY_ROOT / "ops" / "digitalocean" / "cutover.sh"
+    ).read_text(encoding="utf-8")
+
+    assert '"${compose[@]}" up -d --no-build' in cutover
+    assert "for attempt in $(seq 1 24)" in cutover
+    assert 'expected = os.environ["IHOS_RELEASE_ID"]' in cutover
+    assert "within 120 seconds" in cutover
+    assert '"${compose[@]}" up -d --no-build --wait' not in cutover

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -160,20 +160,36 @@ gateway_mutated=1
 install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
 nginx -t
 systemctl reload nginx
-"${compose[@]}" up -d --no-build --wait
-curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
-  "http://127.0.0.1:${IHOS_PORT:-8080}/readiness" | python -c '
-import json, os, sys
-payload = json.load(sys.stdin)
+"${compose[@]}" up -d --no-build
+
+readiness_url="http://127.0.0.1:${IHOS_PORT:-8080}/readiness"
+readiness_file=$(mktemp)
+readiness_ready=0
+for attempt in $(seq 1 24); do
+  if curl --fail --silent --show-error --connect-timeout 5 --max-time 10 \
+      "$readiness_url" >"$readiness_file" 2>/dev/null &&
+    READINESS_FILE="$readiness_file" python -c '
+import json, os
+with open(os.environ["READINESS_FILE"], encoding="utf-8") as source:
+    payload = json.load(source)
 release_id = payload.get("checks", {}).get("release_id")
 expected = os.environ["IHOS_RELEASE_ID"]
 if payload.get("status") != "ready" or release_id != expected:
-    raise SystemExit(
-        "Loopback readiness failed: status={}, release_id={}, expected={}".format(
-            payload.get("status"), release_id, expected
-        )
-    )
-'
+    raise SystemExit(1)
+'; then
+    readiness_ready=1
+    break
+  fi
+  echo "Waiting for exact production release readiness (attempt $attempt/24)."
+  sleep 5
+done
+rm -f "$readiness_file"
+
+if ((readiness_ready != 1)); then
+  echo "Loopback readiness did not confirm release $IHOS_RELEASE_ID within 120 seconds." >&2
+  "${compose[@]}" ps >&2 || true
+  exit 1
+fi
 application_ready=1
 
 install -m 0644 ops/digitalocean/nginx-live.conf "$gateway_config"

--- a/ops/digitalocean/production-deploy-wrapper.sh
+++ b/ops/digitalocean/production-deploy-wrapper.sh
@@ -73,24 +73,35 @@ if ! git_workflow merge-base --is-ancestor "$release_sha" origin/main; then
   exit 1
 fi
 
-production_container=
-production_project=
-while IFS= read -r container_id; do
-  config_files=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}' "$container_id")
-  if [[ "$config_files" == *docker-compose.production.yml* ]]; then
-    if [[ -n "$production_container" ]]; then
-      echo "Multiple running production frontend containers were found." >&2
-      exit 1
-    fi
-    production_container=$container_id
-    production_project=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$container_id")
+production_projects() {
+  local include_stopped=${1:-0}
+  local -a docker_ps=(docker ps)
+  if ((include_stopped == 1)); then
+    docker_ps+=(--all)
   fi
-done < <(docker ps --filter label=com.docker.compose.service=frontend --format '{{.ID}}')
+  docker_ps+=(--filter label=com.docker.compose.service=frontend --format '{{.ID}}')
 
-if [[ -z "$production_container" || -z "$production_project" ]]; then
-  echo "Running production Compose project could not be identified." >&2
+  while IFS= read -r container_id; do
+    config_files=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}' "$container_id")
+    if [[ "$config_files" == *docker-compose.production.yml* ]]; then
+      docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$container_id"
+    fi
+  done < <("${docker_ps[@]}")
+}
+
+mapfile -t production_candidates < <(production_projects 0 | sed '/^$/d' | sort -u)
+if (("${#production_candidates[@]}" == 0)); then
+  mapfile -t production_candidates < <(production_projects 1 | sed '/^$/d' | sort -u)
+  if (("${#production_candidates[@]}" == 1)); then
+    echo "Recovering stopped production Compose project: ${production_candidates[0]}"
+  fi
+fi
+
+if (("${#production_candidates[@]}" != 1)); then
+  echo "Exactly one production Compose project is required; found ${#production_candidates[@]}." >&2
   exit 1
 fi
+production_project=${production_candidates[0]}
 
 release_root="/opt/iron-house-os-releases/$release_sha"
 if [[ ! -d "$release_root/.git" ]]; then

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -94,7 +94,7 @@ def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None
         "/etc/nginx/sites-available/iron-house-os"
     )
     compose_build = '"${compose[@]}" build'
-    compose_up = '"${compose[@]}" up -d --no-build --wait'
+    compose_up = '"${compose[@]}" up -d --no-build'
 
     assert "previous_gateway=$(mktemp)" in cutover
     assert "application_ready=0" in cutover
@@ -102,7 +102,10 @@ def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None
     assert cutover.index(compose_build) < cutover.rindex(maintenance)
     assert cutover.rindex(maintenance) < cutover.index(compose_up)
     assert "release_id != expected" in cutover
-    assert "--connect-timeout 5 --max-time 30" in cutover
+    assert "for attempt in $(seq 1 24)" in cutover
+    assert "--connect-timeout 5 --max-time 10" in cutover
+    assert "within 120 seconds" in cutover
+    assert 'up -d --no-build --wait' not in cutover
 
 
 def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:


### PR DESCRIPTION
Closes #310.

## Changes
- Discover exactly one production Compose project from running frontend containers, falling back to stopped production-labelled containers only when none are running.
- Fail closed on zero or ambiguous project candidates.
- Replace Docker Compose's immediate `--wait` failure with bounded 120-second polling of loopback readiness and the exact approved release identity.
- Add regression coverage for stopped-project recovery, ambiguity protection, bounded polling, and removal of the brittle `--wait` path.

## Production evidence
Production deploy #49 attempt 1 failed when the backend exited during the initial Compose wait, then recovered and served exact release `c6cb490f6300ff37cdfcc63a0088774f828b7898`. Attempt 2 failed because the wrapper only searched running frontend containers. Physical iPad verification confirmed `/readiness` was `ready` on the exact release.

## Safety
All existing protected environment, evidence, host, repository, immutable checkout, backup, TLS, smoke, and exact-release gates remain in place. No production action is performed by this PR.