### PR TITLE
Issue 316: add ChatGPT invoice intake workflow

### DIFF
--- a/backend/app/api/v1/routes/finance.py
+++ b/backend/app/api/v1/routes/finance.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies.auth import CurrentUser
 from app.db.session import get_db
 from app.schemas.backups import BackupsIntakeList, BackupsReviewDestination
+from app.schemas.chat_invoice_intake import ChatInvoiceIntakeRequest, ChatInvoiceIntakeResponse
 from app.schemas.receipt import (
     ReceiptAction, ReceiptCreate, ReceiptExtractionRequest, ReceiptExtractionResponse,
     ReceiptList, ReceiptRead, ReceiptUpdate,
@@ -27,7 +28,14 @@ from app.schemas.finance import (
     StartupExpenseSummary,
     StartupExpenseUpdate,
 )
-from app.services import backups, customer_invoices, finance, receipt_extraction, receipts
+from app.services import (
+    backups,
+    chat_invoice_intake,
+    customer_invoices,
+    finance,
+    receipt_extraction,
+    receipts,
+)
 from app.services.customer_invoice_pdf import render_customer_invoice_pdf
 
 router = APIRouter()
@@ -37,6 +45,15 @@ DBSession = Annotated[Session, Depends(get_db)]
 @router.post("/customer-invoices", response_model=CustomerInvoiceRead, status_code=status.HTTP_201_CREATED)
 def create_customer_invoice(payload: CustomerInvoiceCreate, db: DBSession, user: CurrentUser) -> CustomerInvoiceRead:
     return customer_invoices.create_invoice(db, payload, user)
+
+
+@router.post("/customer-invoices/chat-intake", response_model=ChatInvoiceIntakeResponse)
+def chat_customer_invoice_intake(
+    payload: ChatInvoiceIntakeRequest,
+    db: DBSession,
+    user: CurrentUser,
+) -> ChatInvoiceIntakeResponse:
+    return chat_invoice_intake.import_chat_invoices(db, payload, user)
 
 
 @router.get("/customer-invoices", response_model=CustomerInvoiceList)

--- a/backend/app/schemas/chat_invoice_intake.py
+++ b/backend/app/schemas/chat_invoice_intake.py
@@ -1,0 +1,37 @@
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from app.schemas.finance import CustomerInvoiceCreate, CustomerInvoiceRead
+from app.schemas.project import ProjectStatus
+
+
+class ChatInvoiceIntakeRecord(BaseModel):
+    invoice: CustomerInvoiceCreate
+    create_project_if_missing: bool = True
+    project_status: ProjectStatus = ProjectStatus.construction
+
+
+class ChatInvoiceIntakeRequest(BaseModel):
+    items: list[ChatInvoiceIntakeRecord] = Field(min_length=1, max_length=50)
+
+
+ChatInvoiceIntakeStatus = Literal["created", "reused", "conflict", "error"]
+
+
+class ChatInvoiceIntakeItemResult(BaseModel):
+    invoice_number: str
+    status: ChatInvoiceIntakeStatus
+    project_id: UUID | None = None
+    project_created: bool = False
+    invoice: CustomerInvoiceRead | None = None
+    detail: str | None = None
+
+
+class ChatInvoiceIntakeResponse(BaseModel):
+    items: list[ChatInvoiceIntakeItemResult]
+    created_count: int
+    reused_count: int
+    conflict_count: int
+    error_count: int

--- a/backend/app/services/chat_invoice_intake.py
+++ b/backend/app/services/chat_invoice_intake.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.finance import CustomerInvoice
+from app.models.project import Project
+from app.schemas.chat_invoice_intake import (
+    ChatInvoiceIntakeItemResult,
+    ChatInvoiceIntakeRecord,
+    ChatInvoiceIntakeRequest,
+    ChatInvoiceIntakeResponse,
+)
+from app.schemas.finance import CustomerInvoiceCreate
+from app.schemas.project import ProjectCreate
+from app.services import customer_invoices, projects
+from app.services.auth import AuthenticatedUser
+from app.services.finance import require_management
+
+
+def import_chat_invoices(
+    db: Session,
+    payload: ChatInvoiceIntakeRequest,
+    user: AuthenticatedUser,
+) -> ChatInvoiceIntakeResponse:
+    require_management(user)
+    results = [_import_record(db, record, user) for record in payload.items]
+    return ChatInvoiceIntakeResponse(
+        items=results,
+        created_count=sum(item.status == "created" for item in results),
+        reused_count=sum(item.status == "reused" for item in results),
+        conflict_count=sum(item.status == "conflict" for item in results),
+        error_count=sum(item.status == "error" for item in results),
+    )
+
+
+def _import_record(
+    db: Session,
+    record: ChatInvoiceIntakeRecord,
+    user: AuthenticatedUser,
+) -> ChatInvoiceIntakeItemResult:
+    invoice_number = record.invoice.invoice_number
+    try:
+        project, project_created = _resolve_project(db, record)
+    except HTTPException as exc:
+        return ChatInvoiceIntakeItemResult(
+            invoice_number=invoice_number,
+            status="error" if exc.status_code != 409 else "conflict",
+            detail=str(exc.detail),
+        )
+
+    linked_payload = record.invoice.model_copy(
+        update={"project_id": project.id if project is not None else record.invoice.project_id}
+    )
+    existing = db.scalar(
+        select(CustomerInvoice).where(CustomerInvoice.invoice_number == invoice_number)
+    )
+    if existing is not None:
+        if _invoice_matches(existing, linked_payload):
+            return ChatInvoiceIntakeItemResult(
+                invoice_number=invoice_number,
+                status="reused",
+                project_id=existing.project_id,
+                project_created=project_created,
+                invoice=customer_invoices._read(existing),
+                detail="Invoice already exists with identical intake data.",
+            )
+        return ChatInvoiceIntakeItemResult(
+            invoice_number=invoice_number,
+            status="conflict",
+            project_id=project.id if project is not None else existing.project_id,
+            project_created=project_created,
+            detail="Invoice number already exists with different data.",
+        )
+
+    try:
+        invoice = customer_invoices.create_invoice(db, linked_payload, user)
+    except HTTPException as exc:
+        return ChatInvoiceIntakeItemResult(
+            invoice_number=invoice_number,
+            status="error" if exc.status_code != 409 else "conflict",
+            project_id=project.id if project is not None else None,
+            project_created=project_created,
+            detail=str(exc.detail),
+        )
+    return ChatInvoiceIntakeItemResult(
+        invoice_number=invoice_number,
+        status="created",
+        project_id=project.id if project is not None else invoice.project_id,
+        project_created=project_created,
+        invoice=invoice,
+    )
+
+
+def _resolve_project(
+    db: Session,
+    record: ChatInvoiceIntakeRecord,
+) -> tuple[Project | None, bool]:
+    payload = record.invoice
+    if payload.project_id is not None:
+        project = db.get(Project, payload.project_id)
+        if project is None or project.deleted_at is not None:
+            raise HTTPException(status_code=404, detail="Project not found")
+        return project, False
+
+    statement = select(Project).where(
+        Project.deleted_at.is_(None),
+        func.lower(Project.name) == payload.project_name.strip().lower(),
+    )
+    if payload.site_address:
+        statement = statement.where(
+            func.lower(Project.project_address) == payload.site_address.strip().lower()
+        )
+    matches = list(db.scalars(statement).all())
+    if len(matches) > 1:
+        raise HTTPException(
+            status_code=409,
+            detail="Multiple projects match the supplied project name/site address.",
+        )
+    if matches:
+        return matches[0], False
+    if not record.create_project_if_missing:
+        return None, False
+
+    created = projects.create_project(
+        db,
+        ProjectCreate(
+            name=payload.project_name,
+            client_owner=payload.customer_name,
+            project_address=payload.site_address,
+            status=record.project_status,
+            notes="Created from management chat invoice intake.",
+        ),
+    )
+    return db.get(Project, created.id), True
+
+
+def _invoice_matches(existing: CustomerInvoice, payload: CustomerInvoiceCreate) -> bool:
+    calculated = customer_invoices._calculated_values(payload)
+    return all(
+        (
+            existing.project_id == calculated.get("project_id"),
+            existing.project_name == calculated.get("project_name"),
+            existing.site_address == calculated.get("site_address"),
+            existing.customer_name == calculated.get("customer_name"),
+            existing.customer_address == calculated.get("customer_address"),
+            existing.customer_phone == calculated.get("customer_phone"),
+            existing.invoice_date == calculated.get("invoice_date"),
+            existing.due_date == calculated.get("due_date"),
+            existing.terms == calculated.get("terms"),
+            existing.line_items_json == calculated.get("line_items_json"),
+            Decimal(existing.gst_rate) == Decimal(calculated.get("gst_rate")),
+            Decimal(existing.subtotal) == Decimal(calculated.get("subtotal")),
+            Decimal(existing.gst) == Decimal(calculated.get("gst")),
+            Decimal(existing.total) == Decimal(calculated.get("total")),
+        )
+    )

--- a/backend/tests/test_chat_invoice_intake.py
+++ b/backend/tests/test_chat_invoice_intake.py
@@ -1,0 +1,127 @@
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.chat_invoice_intake import (
+    ChatInvoiceIntakeRecord,
+    ChatInvoiceIntakeRequest,
+)
+from app.schemas.finance import CustomerInvoiceCreate
+from app.services.auth import AuthenticatedUser
+from app.services.chat_invoice_intake import import_chat_invoices
+
+
+def _user(role: str = "admin") -> AuthenticatedUser:
+    return AuthenticatedUser(
+        id=uuid4(),
+        email=f"{role}@ironhousecivil.com",
+        display_name=role,
+        role=role,
+        session_version=1,
+    )
+
+
+def _invoice(invoice_number: str = "CHAT-001", unit_price: str = "105.00") -> CustomerInvoiceCreate:
+    return CustomerInvoiceCreate(
+        invoice_number=invoice_number,
+        project_name="Aria",
+        site_address="13575 Commerce Parkway, Richmond, BC V6V 2L1",
+        customer_name="Universal Construction",
+        customer_address="PO Box 1120, Chilliwack, BC V2R 3N7",
+        customer_phone="604-858-8618",
+        invoice_date=date(2026, 8, 20),
+        due_date=date(2026, 9, 19),
+        line_items=[
+            {
+                "description": "Water testing and water service install",
+                "quantity": "4.19",
+                "unit_price": unit_price,
+            }
+        ],
+    )
+
+
+def test_chat_invoice_intake_creates_project_and_draft_invoice(db_session) -> None:
+    result = import_chat_invoices(
+        db_session,
+        ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())]),
+        _user(),
+    )
+
+    assert result.created_count == 1
+    assert result.reused_count == 0
+    item = result.items[0]
+    assert item.status == "created"
+    assert item.project_created is True
+    assert item.project_id is not None
+    assert item.invoice is not None
+    assert item.invoice.project_id == item.project_id
+    assert item.invoice.status == "draft"
+    assert item.invoice.subtotal == "439.95"
+    assert item.invoice.gst == "22.00"
+    assert item.invoice.total == "461.95"
+
+
+def test_chat_invoice_intake_is_idempotent_for_identical_retry(db_session) -> None:
+    payload = ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())])
+
+    first = import_chat_invoices(db_session, payload, _user())
+    second = import_chat_invoices(db_session, payload, _user())
+
+    assert first.items[0].status == "created"
+    assert second.items[0].status == "reused"
+    assert second.reused_count == 1
+    assert second.items[0].project_created is False
+    assert second.items[0].project_id == first.items[0].project_id
+
+
+def test_chat_invoice_intake_reports_conflicting_invoice_number(db_session) -> None:
+    import_chat_invoices(
+        db_session,
+        ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())]),
+        _user(),
+    )
+
+    result = import_chat_invoices(
+        db_session,
+        ChatInvoiceIntakeRequest(
+            items=[ChatInvoiceIntakeRecord(invoice=_invoice(unit_price="106.00"))]
+        ),
+        _user(),
+    )
+
+    assert result.conflict_count == 1
+    assert result.items[0].status == "conflict"
+    assert "different data" in (result.items[0].detail or "")
+
+
+def test_chat_invoice_intake_reuses_matching_project_for_new_invoice(db_session) -> None:
+    first = import_chat_invoices(
+        db_session,
+        ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())]),
+        _user(),
+    )
+    second = import_chat_invoices(
+        db_session,
+        ChatInvoiceIntakeRequest(
+            items=[ChatInvoiceIntakeRecord(invoice=_invoice(invoice_number="CHAT-002"))]
+        ),
+        _user(),
+    )
+
+    assert second.items[0].status == "created"
+    assert second.items[0].project_created is False
+    assert second.items[0].project_id == first.items[0].project_id
+
+
+def test_chat_invoice_intake_requires_management(db_session) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        import_chat_invoices(
+            db_session,
+            ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())]),
+            _user("estimator"),
+        )
+
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
Closes #316

## Summary
- adds management-only bulk customer-invoice chat intake under `/api/v1/finance/customer-invoices/chat-intake`
- resolves an explicit project ID or exact project name/site address
- optionally creates a project from supplied invoice facts when missing
- creates the linked IHOS customer invoice using existing tax/rounding rules
- makes retries idempotent by invoice number when submitted data is identical
- reports conflicting duplicate invoice numbers without creating a second invoice
- adds service-level coverage for management authorization, project creation/reuse, calculations, retry idempotency, and conflicts

## Guardrails
- no production data changed
- no deployment performed
- existing invoice approval/issue status controls remain unchanged
- invoice intake creates draft invoices only

## Validation
GitHub CI/staging checks requested by this draft PR. Do not merge or deploy until checks pass and owner review is complete.