### PR TITLE
Issue 316: apply chat invoice intake review fixes

### DIFF
--- a/backend/app/services/chat_invoice_intake.py
+++ b/backend/app/services/chat_invoice_intake.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from fastapi import HTTPException
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models.finance import CustomerInvoice
@@ -15,8 +16,7 @@ from app.schemas.chat_invoice_intake import (
     ChatInvoiceIntakeResponse,
 )
 from app.schemas.finance import CustomerInvoiceCreate
-from app.schemas.project import ProjectCreate
-from app.services import customer_invoices, projects
+from app.services import customer_invoices
 from app.services.auth import AuthenticatedUser
 from app.services.finance import require_management
 
@@ -43,9 +43,17 @@ def _import_record(
     user: AuthenticatedUser,
 ) -> ChatInvoiceIntakeItemResult:
     invoice_number = record.invoice.invoice_number
+
+    # Check idempotency before resolving or creating a project so retries cannot
+    # create project side effects before discovering an existing invoice.
+    existing = _find_invoice(db, invoice_number)
+    if existing is not None:
+        return _existing_invoice_result(existing, record.invoice)
+
     try:
         project, project_created = _resolve_project(db, record)
     except HTTPException as exc:
+        db.rollback()
         return ChatInvoiceIntakeItemResult(
             invoice_number=invoice_number,
             status="error" if exc.status_code != 409 else "conflict",
@@ -55,43 +63,68 @@ def _import_record(
     linked_payload = record.invoice.model_copy(
         update={"project_id": project.id if project is not None else record.invoice.project_id}
     )
-    existing = db.scalar(
-        select(CustomerInvoice).where(CustomerInvoice.invoice_number == invoice_number)
-    )
-    if existing is not None:
-        if _invoice_matches(existing, linked_payload):
-            return ChatInvoiceIntakeItemResult(
-                invoice_number=invoice_number,
-                status="reused",
-                project_id=existing.project_id,
-                project_created=project_created,
-                invoice=customer_invoices._read(existing),
-                detail="Invoice already exists with identical intake data.",
-            )
-        return ChatInvoiceIntakeItemResult(
-            invoice_number=invoice_number,
-            status="conflict",
-            project_id=project.id if project is not None else existing.project_id,
-            project_created=project_created,
-            detail="Invoice number already exists with different data.",
-        )
+    values = customer_invoices._calculated_values(linked_payload)
+    invoice_row = CustomerInvoice(**values, status="draft", created_by=user.email)
+    db.add(invoice_row)
 
     try:
-        invoice = customer_invoices.create_invoice(db, linked_payload, user)
-    except HTTPException as exc:
+        # Project creation and invoice creation commit together. If a concurrent
+        # request wins the unique invoice-number race, both are rolled back here.
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        existing = _find_invoice(db, invoice_number)
+        if existing is not None:
+            return _existing_invoice_result(existing, record.invoice)
         return ChatInvoiceIntakeItemResult(
             invoice_number=invoice_number,
-            status="error" if exc.status_code != 409 else "conflict",
-            project_id=project.id if project is not None else None,
-            project_created=project_created,
-            detail=str(exc.detail),
+            status="error",
+            detail="Invoice intake conflicted with another database write. Retry safely.",
         )
+
+    db.refresh(invoice_row)
+    invoice = customer_invoices._read(invoice_row)
     return ChatInvoiceIntakeItemResult(
         invoice_number=invoice_number,
         status="created",
         project_id=project.id if project is not None else invoice.project_id,
         project_created=project_created,
         invoice=invoice,
+    )
+
+
+def _find_invoice(db: Session, invoice_number: str) -> CustomerInvoice | None:
+    return db.scalar(
+        select(CustomerInvoice).where(CustomerInvoice.invoice_number == invoice_number)
+    )
+
+
+def _existing_invoice_result(
+    existing: CustomerInvoice,
+    payload: CustomerInvoiceCreate,
+) -> ChatInvoiceIntakeItemResult:
+    # When no explicit project ID was supplied, compare against the project that
+    # is already linked to the existing invoice. This makes a retry of an intake
+    # that originally created its project idempotent without creating a new one.
+    comparison_payload = payload
+    if payload.project_id is None:
+        comparison_payload = payload.model_copy(update={"project_id": existing.project_id})
+
+    if _invoice_matches(existing, comparison_payload):
+        return ChatInvoiceIntakeItemResult(
+            invoice_number=existing.invoice_number,
+            status="reused",
+            project_id=existing.project_id,
+            project_created=False,
+            invoice=customer_invoices._read(existing),
+            detail="Invoice already exists with identical intake data.",
+        )
+    return ChatInvoiceIntakeItemResult(
+        invoice_number=existing.invoice_number,
+        status="conflict",
+        project_id=existing.project_id,
+        project_created=False,
+        detail="Invoice number already exists with different data.",
     )
 
 
@@ -106,14 +139,14 @@ def _resolve_project(
             raise HTTPException(status_code=404, detail="Project not found")
         return project, False
 
+    project_name = payload.project_name.strip()
+    site_address = payload.site_address.strip() if payload.site_address else None
     statement = select(Project).where(
         Project.deleted_at.is_(None),
-        func.lower(Project.name) == payload.project_name.strip().lower(),
+        func.lower(Project.name) == project_name.lower(),
     )
-    if payload.site_address:
-        statement = statement.where(
-            func.lower(Project.project_address) == payload.site_address.strip().lower()
-        )
+    if site_address:
+        statement = statement.where(func.lower(Project.project_address) == site_address.lower())
     matches = list(db.scalars(statement).all())
     if len(matches) > 1:
         raise HTTPException(
@@ -125,17 +158,17 @@ def _resolve_project(
     if not record.create_project_if_missing:
         return None, False
 
-    created = projects.create_project(
-        db,
-        ProjectCreate(
-            name=payload.project_name,
-            client_owner=payload.customer_name,
-            project_address=payload.site_address,
-            status=record.project_status,
-            notes="Created from management chat invoice intake.",
-        ),
+    created = Project(
+        name=project_name,
+        client_owner=payload.customer_name.strip(),
+        project_address=site_address,
+        status=record.project_status.value,
+        notes="Created from management chat invoice intake.",
+        metadata_json={},
     )
-    return db.get(Project, created.id), True
+    db.add(created)
+    db.flush()
+    return created, True
 
 
 def _invoice_matches(existing: CustomerInvoice, payload: CustomerInvoiceCreate) -> bool:

--- a/backend/tests/test_chat_invoice_intake.py
+++ b/backend/tests/test_chat_invoice_intake.py
@@ -3,7 +3,9 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy import func, select
 
+from app.models.project import Project
 from app.schemas.chat_invoice_intake import (
     ChatInvoiceIntakeRecord,
     ChatInvoiceIntakeRequest,
@@ -68,33 +70,41 @@ def test_chat_invoice_intake_is_idempotent_for_identical_retry(db_session) -> No
     payload = ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())])
 
     first = import_chat_invoices(db_session, payload, _user())
+    project_count_after_first = db_session.scalar(select(func.count()).select_from(Project))
     second = import_chat_invoices(db_session, payload, _user())
+    project_count_after_second = db_session.scalar(select(func.count()).select_from(Project))
 
     assert first.items[0].status == "created"
     assert second.items[0].status == "reused"
     assert second.reused_count == 1
     assert second.items[0].project_created is False
     assert second.items[0].project_id == first.items[0].project_id
+    assert project_count_after_second == project_count_after_first
 
 
-def test_chat_invoice_intake_reports_conflicting_invoice_number(db_session) -> None:
+def test_chat_invoice_intake_reports_conflicting_invoice_without_project_side_effect(db_session) -> None:
     import_chat_invoices(
         db_session,
         ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=_invoice())]),
         _user(),
     )
+    project_count_before_conflict = db_session.scalar(select(func.count()).select_from(Project))
 
+    conflicting = _invoice(unit_price="106.00").model_copy(
+        update={"project_name": "Different Project", "site_address": "999 Other Road"}
+    )
     result = import_chat_invoices(
         db_session,
-        ChatInvoiceIntakeRequest(
-            items=[ChatInvoiceIntakeRecord(invoice=_invoice(unit_price="106.00"))]
-        ),
+        ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=conflicting)]),
         _user(),
     )
+    project_count_after_conflict = db_session.scalar(select(func.count()).select_from(Project))
 
     assert result.conflict_count == 1
     assert result.items[0].status == "conflict"
+    assert result.items[0].project_created is False
     assert "different data" in (result.items[0].detail or "")
+    assert project_count_after_conflict == project_count_before_conflict
 
 
 def test_chat_invoice_intake_reuses_matching_project_for_new_invoice(db_session) -> None:
@@ -114,6 +124,28 @@ def test_chat_invoice_intake_reuses_matching_project_for_new_invoice(db_session)
     assert second.items[0].status == "created"
     assert second.items[0].project_created is False
     assert second.items[0].project_id == first.items[0].project_id
+
+
+def test_chat_invoice_intake_strips_project_creation_fields(db_session) -> None:
+    spaced = _invoice().model_copy(
+        update={
+            "project_name": "  Aria  ",
+            "site_address": "  13575 Commerce Parkway, Richmond, BC V6V 2L1  ",
+            "customer_name": "  Universal Construction  ",
+        }
+    )
+
+    result = import_chat_invoices(
+        db_session,
+        ChatInvoiceIntakeRequest(items=[ChatInvoiceIntakeRecord(invoice=spaced)]),
+        _user(),
+    )
+    project = db_session.get(Project, result.items[0].project_id)
+
+    assert project is not None
+    assert project.name == "Aria"
+    assert project.project_address == "13575 Commerce Parkway, Richmond, BC V6V 2L1"
+    assert project.client_owner == "Universal Construction"
 
 
 def test_chat_invoice_intake_requires_management(db_session) -> None:


### PR DESCRIPTION
Follow-up to merged PR #317. Applies Copilot review fixes that landed on the old branch after merge:

- check duplicate invoice numbers before project resolution/creation to avoid side-effect projects;
- make project + invoice creation atomic within one transaction;
- handle concurrent unique invoice-number races by rolling back and reclassifying as reused/conflict when possible;
- strip project name, site address, and client owner before project creation;
- add regression tests for duplicate idempotency, no project side effects on conflicts, and whitespace normalization.

No production data changes. No deployment. CI and release readiness must pass before merge.