### PR TITLE
Issue #314: harden protected production business import

### DIFF
--- a/.github/workflows/production-business-import.yml
+++ b/.github/workflows/production-business-import.yml
@@ -8,12 +8,14 @@ on:
       - "ops/scripts/production_business_import.py"
       - "ops/scripts/tests/test_production_business_import.py"
       - "ops/production-business-imports/*.json"
-  push:
-    branches: [main]
-    paths:
-      - "ops/production-business-imports/*.json"
+      - "ops/digitalocean/production-business-import-wrapper.sh"
+      - "ops/digitalocean/cutover.sh"
   workflow_dispatch:
     inputs:
+      release_sha:
+        description: "Exact approved release SHA currently deployed to production"
+        required: true
+        type: string
       import_file:
         description: "Approved bundle under ops/production-business-imports/"
         required: true
@@ -30,19 +32,21 @@ concurrency:
 jobs:
   validate:
     name: Validate import controls and bundle
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out proposed change without credentials
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          ref: ${{ inputs.release_sha || github.sha }}
           persist-credentials: false
 
       - name: Run disposable validation suite
         run: |
           set -euo pipefail
           python3 -m unittest discover -s ops/scripts/tests -p 'test_*.py' -v
+          bash -n ops/digitalocean/production-business-import-wrapper.sh ops/digitalocean/cutover.sh
           shopt -s nullglob
           bundles=(ops/production-business-imports/*.json)
           if [[ ${#bundles[@]} -eq 0 ]]; then
@@ -55,7 +59,8 @@ jobs:
 
   import-production:
     name: Import and verify owner-approved draft records
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: validate
     runs-on: [self-hosted, linux, ihos-production]
     environment: production
     timeout-minutes: 15
@@ -63,28 +68,22 @@ jobs:
       - name: Check out approved main revision without credentials
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          ref: ${{ inputs.release_sha }}
           persist-credentials: false
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Resolve the single approved import bundle
         id: bundle
         env:
           DISPATCH_FILE: ${{ inputs.import_file }}
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            import_file="$DISPATCH_FILE"
-          else
-            mapfile -t changed < <(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" -- 'ops/production-business-imports/*.json')
-            if [[ ${#changed[@]} -ne 1 ]]; then
-              echo "Expected exactly one changed production import bundle; found ${#changed[@]}." >&2
-              printf '%s\n' "${changed[@]}" >&2
-              exit 1
-            fi
-            import_file="${changed[0]}"
-          fi
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]
+          git fetch --quiet origin main
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
+          import_file="$DISPATCH_FILE"
           if [[ ! "$import_file" =~ ^ops/production-business-imports/[A-Za-z0-9._-]+\.json$ ]]; then
             echo "Import file must be a direct JSON child of ops/production-business-imports/." >&2
             exit 1
@@ -93,6 +92,7 @@ jobs:
           issue_number="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["issue_number"])' "$import_file")"
           echo "import_file=$import_file" >> "$GITHUB_OUTPUT"
           echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Re-run validation on the protected runner
         env:
@@ -102,21 +102,24 @@ jobs:
           python3 -m unittest discover -s ops/scripts/tests -p 'test_*.py' -v
           python3 ops/scripts/production_business_import.py validate --input "$IMPORT_FILE"
 
-      - name: Import through the authenticated IHOS loopback API
-        env:
-          IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
-          EVIDENCE_FILE: production-business-import-evidence.json
+      - name: Verify the installed least-privilege import wrapper
         run: |
           set -euo pipefail
-          if [[ ! -r /etc/iron-house-os/production.env ]]; then
-            echo "Production environment is not readable by the restricted runner." >&2
-            exit 1
-          fi
-          set -a
-          source /etc/iron-house-os/production.env
-          set +a
-          python3 ops/scripts/production_business_import.py import \
-            --input "$IMPORT_FILE" \
+          installed=/usr/local/sbin/ihos-production-business-import
+          trusted="$GITHUB_WORKSPACE/ops/digitalocean/production-business-import-wrapper.sh"
+          [[ "$(stat -c '%U:%G:%a' "$installed")" == "root:root:755" ]]
+          cmp --silent "$trusted" "$installed"
+
+      - name: Import through the restricted root wrapper and IHOS loopback API
+        env:
+          IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
+          RELEASE_SHA: ${{ steps.bundle.outputs.release_sha }}
+          EVIDENCE_FILE: ${{ runner.temp }}/production-business-import-evidence.json
+        run: |
+          set -euo pipefail
+          sudo -n /usr/local/sbin/ihos-production-business-import \
+            --release "$RELEASE_SHA" \
+            --bundle "$IMPORT_FILE" \
             --evidence "$EVIDENCE_FILE"
 
       - name: Publish verified evidence to the linked issue
@@ -129,7 +132,7 @@ jobs:
             echo "### Production business-record import verified"
             echo
             echo '~~~json'
-            cat production-business-import-evidence.json
+            cat "${{ runner.temp }}/production-business-import-evidence.json"
             echo '~~~'
           } > "$RUNNER_TEMP/production-business-import-comment.md"
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/production-business-import-comment.md"
@@ -139,6 +142,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: production-business-import-${{ github.run_id }}
-          path: production-business-import-evidence.json
+          path: ${{ runner.temp }}/production-business-import-evidence.json
           if-no-files-found: warn
           retention-days: 90

--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -49,3 +49,18 @@ validates its narrow sudoers rule, and exits without registering, restarting,
 or reconfiguring the runner service. Treat the refresh as a production
 infrastructure change: obtain explicit approval and record the exact source
 commit before running it.
+
+## Protected business-import launcher
+
+Approved production cutovers also install
+`/usr/local/sbin/ihos-production-business-import` as `root:root 0755` and a dedicated,
+validated sudoers rule for `ihos-runner`. The launcher is intentionally separate from the
+deployment launcher. It accepts only an exact deployed main SHA, a direct JSON child of
+`ops/production-business-imports/`, and an evidence path inside the restricted runner temporary
+directory. It verifies live readiness reports the same release SHA before sourcing the protected
+environment and passes only IHOS port plus bootstrap credentials to the importer.
+
+Do not grant the runner read access to `/etc/iron-house-os/production.env` and do not add generic
+sudo, shell, Docker, or file-copy privileges. Production imports remain manual and require a second
+protected `production` environment approval after the release deployment.
+

--- a/docs/production-business-record-import.md
+++ b/docs/production-business-record-import.md
@@ -7,9 +7,12 @@ customer quotes and customer invoices.
 
 - Work starts from a linked issue and a draft pull request.
 - Pull requests run the disposable validation suite only; they cannot reach production.
-- A bundle merged to `main` starts a protected `production` environment job. The job cannot
-  continue until the configured production reviewer approves it.
-- The production runner talks only to the authenticated IHOS loopback API.
+- Production import is manual-only and requires the exact SHA already deployed to production.
+- The protected `production` environment job cannot continue until the configured reviewer approves it.
+- A root-owned launcher verifies the deployed release, approved bundle, live readiness identity,
+  evidence destination and least-privilege environment before calling the IHOS loopback API.
+- The runner cannot read `production.env`; only the narrow launcher can source the three values
+  required for authenticated import.
 - Projects enter as `opportunity`; no project/job number is allocated.
 - Customer quotes and invoices use the API's `draft` defaults. The importer cannot issue,
   approve, accept or award them.
@@ -23,9 +26,12 @@ customer quotes and customer invoices.
 2. Run `python3 -m unittest discover -s ops/scripts/tests -p 'test_*.py' -v`.
 3. Run `python3 ops/scripts/production_business_import.py validate --input <bundle>`.
 4. Open an issue-linked draft pull request and complete normal review/CI.
-5. Merge only with owner authorization.
-6. Approve the protected production environment job after checking the exact bundle totals,
-   customer identity and draft-only state.
+5. Merge only with owner authorization, complete Release Readiness, and deploy that exact SHA
+   through the normal protected production deployment workflow.
+6. Dispatch `Validate and import approved business records` with that deployed SHA and the exact
+   bundle path.
+7. Approve the protected production import after checking the bundle totals, customer identity,
+   deployed release SHA and draft-only state.
 
 Rollback is intentionally manual: records are never deleted automatically. If a created draft is
 wrong, void/archive it through the normal IHOS authorization workflow and retain the import evidence.

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -53,6 +53,30 @@ if [[ "$environment_mode" != "600" && "$environment_mode" != "400" ]]; then
   exit 1
 fi
 
+install_production_business_import_wrapper() {
+  local wrapper_source="$repo_root/ops/digitalocean/production-business-import-wrapper.sh"
+  local wrapper_target=/usr/local/sbin/ihos-production-business-import
+  local sudoers_target=/etc/sudoers.d/iron-house-os-production-business-import
+  local sudoers_candidate
+
+  if [[ ! -f "$wrapper_source" ]]; then
+    echo "Approved release is missing the production business import wrapper." >&2
+    return 1
+  fi
+  bash -n "$wrapper_source"
+  sudoers_candidate=$(mktemp)
+  printf '%s\n' \
+    "ihos-runner ALL=(root) NOPASSWD: $wrapper_target *" \
+    >"$sudoers_candidate"
+  chmod 0440 "$sudoers_candidate"
+  visudo -cf "$sudoers_candidate" >/dev/null
+  install -o root -g root -m 0755 "$wrapper_source" "$wrapper_target"
+  install -o root -g root -m 0440 "$sudoers_candidate" "$sudoers_target"
+  rm -f "$sudoers_candidate"
+  visudo -cf "$sudoers_target" >/dev/null
+}
+
+
 cd "$repo_root"
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "Refusing cutover from a dirty working tree." >&2
@@ -203,6 +227,7 @@ python scripts/release_smoke.py \
 IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
 IHOS_BACKUP_NAME="post-cutover-$stamp" \
 scripts/scheduled_backup.sh
+install_production_business_import_wrapper
 
 acceptance=/var/lib/iron-house-os/operator-acceptance-$stamp.md
 cat >"$acceptance" <<EOF
@@ -231,3 +256,4 @@ rm -f "$previous_gateway"
 trap - EXIT
 echo "Release $release_sha live cutover passed: https://$domain"
 echo "Operator acceptance: $acceptance"
+

--- a/ops/digitalocean/production-business-import-wrapper.sh
+++ b/ops/digitalocean/production-business-import-wrapper.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+release_sha=
+bundle_file=
+evidence_file=
+
+usage() {
+  echo "Usage: ihos-production-business-import --release 40_HEX_SHA --bundle ops/production-business-imports/FILE.json --evidence FILE" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --release)
+      release_sha=${2:-}
+      shift 2
+      ;;
+    --bundle)
+      bundle_file=${2:-}
+      shift 2
+      ;;
+    --evidence)
+      evidence_file=${2:-}
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ((EUID != 0)) ||
+  [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]] ||
+  [[ ! "$bundle_file" =~ ^ops/production-business-imports/[A-Za-z0-9._-]+\.json$ ]] ||
+  [[ -z "$evidence_file" ]]; then
+  usage
+  exit 2
+fi
+if [[ "$(hostname)" != "iron-house-os-prod-1" ]]; then
+  echo "Refusing production import on unexpected host." >&2
+  exit 1
+fi
+
+release_root="/opt/iron-house-os-releases/$release_sha"
+if [[ ! -d "$release_root/.git" ]]; then
+  echo "The requested release has not been installed through the approved production deployment workflow." >&2
+  exit 1
+fi
+git_release() {
+  git -c "safe.directory=$release_root" -C "$release_root" "$@"
+}
+if [[ "$(git_release rev-parse HEAD)" != "$release_sha" ]] || [[ -n "$(git_release status --porcelain)" ]]; then
+  echo "Immutable production release checkout is missing, dirty, or has the wrong SHA." >&2
+  exit 1
+fi
+remote_url=$(git_release remote get-url origin)
+case "$remote_url" in
+  https://github.com/iron-house-os/iron-house-os|https://github.com/iron-house-os/iron-house-os.git|git@github.com:iron-house-os/iron-house-os.git)
+    ;;
+  *)
+    echo "Unexpected repository remote: $remote_url" >&2
+    exit 1
+    ;;
+esac
+git_release fetch --quiet origin main
+if ! git_release merge-base --is-ancestor "$release_sha" origin/main; then
+  echo "Requested release is not present on origin/main." >&2
+  exit 1
+fi
+
+bundle_path="$release_root/$bundle_file"
+importer_path="$release_root/ops/scripts/production_business_import.py"
+if [[ ! -f "$bundle_path" || ! -f "$importer_path" ]]; then
+  echo "Approved release is missing the import bundle or importer." >&2
+  exit 1
+fi
+resolved_bundle=$(realpath "$bundle_path")
+if [[ "$resolved_bundle" != "$release_root/ops/production-business-imports/"*.json ]]; then
+  echo "Import bundle escaped the approved release directory." >&2
+  exit 1
+fi
+if ! git_release diff --quiet HEAD -- "$bundle_file" "ops/scripts/production_business_import.py"; then
+  echo "Import bundle or importer differs from the approved release." >&2
+  exit 1
+fi
+
+evidence_parent=$(cd "$(dirname "$evidence_file")" && pwd -P)
+evidence_name=$(basename "$evidence_file")
+if [[ "$evidence_parent" != "/opt/iron-house-os-actions-runner/_work/_temp" &&
+      "$evidence_parent" != /opt/iron-house-os-actions-runner/_work/_temp/* ]] ||
+  [[ ! "$evidence_name" =~ ^[A-Za-z0-9._-]+\.json$ ]]; then
+  echo "Evidence output must be a JSON file in the restricted runner temporary directory." >&2
+  exit 1
+fi
+evidence_file="$evidence_parent/$evidence_name"
+
+environment_file=/etc/iron-house-os/production.env
+if [[ "$(stat -c '%U:%G:%a' "$environment_file" 2>/dev/null || true)" != "root:root:600" &&
+      "$(stat -c '%U:%G:%a' "$environment_file" 2>/dev/null || true)" != "root:root:400" ]]; then
+  echo "Protected production environment ownership or permissions are invalid." >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+source "$environment_file"
+set +a
+: "${BOOTSTRAP_ADMIN_EMAIL:?BOOTSTRAP_ADMIN_EMAIL is required}"
+: "${BOOTSTRAP_ADMIN_PASSWORD:?BOOTSTRAP_ADMIN_PASSWORD is required}"
+IHOS_PORT=${IHOS_PORT:-8080}
+
+readiness_url="http://127.0.0.1:${IHOS_PORT}/readiness"
+curl --fail --silent --show-error --connect-timeout 5 --max-time 30 "$readiness_url" |
+  EXPECTED_RELEASE="$release_sha" python3 -c '
+import json, os, sys
+payload = json.load(sys.stdin)
+expected = os.environ["EXPECTED_RELEASE"]
+release_id = payload.get("checks", {}).get("release_id")
+if payload.get("status") != "ready" or release_id != expected:
+    raise SystemExit(
+        "Production release mismatch: status={}, release_id={}, expected={}".format(
+            payload.get("status"), release_id, expected
+        )
+    )
+'
+
+temporary_evidence=$(mktemp "$evidence_parent/.production-business-import.XXXXXX")
+trap 'rm -f "$temporary_evidence"' EXIT
+env -i \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  IHOS_PORT="$IHOS_PORT" \
+  BOOTSTRAP_ADMIN_EMAIL="$BOOTSTRAP_ADMIN_EMAIL" \
+  BOOTSTRAP_ADMIN_PASSWORD="$BOOTSTRAP_ADMIN_PASSWORD" \
+  python3 "$importer_path" import \
+    --input "$resolved_bundle" \
+    --evidence "$temporary_evidence"
+
+python3 -m json.tool "$temporary_evidence" >/dev/null
+install -o ihos-runner -g ihos-runner -m 0640 "$temporary_evidence" "$evidence_file"
+trap - EXIT
+rm -f "$temporary_evidence"
+echo "Production business import verified for release $release_sha."

--- a/ops/scripts/production_business_import.py
+++ b/ops/scripts/production_business_import.py
@@ -29,7 +29,7 @@ def money(value: Any) -> Decimal:
 
 def quote_totals(payload: dict[str, Any]) -> tuple[Decimal, Decimal, Decimal]:
     subtotal = sum(
-        (Decimal(str(item["quantity"])) * Decimal(str(item["unit_price"])))
+        money(Decimal(str(item["quantity"])) * Decimal(str(item["unit_price"])))
         for item in payload["line_items"]
     )
     subtotal = money(subtotal)
@@ -39,7 +39,7 @@ def quote_totals(payload: dict[str, Any]) -> tuple[Decimal, Decimal, Decimal]:
 
 def invoice_totals(payload: dict[str, Any]) -> tuple[Decimal, Decimal, Decimal]:
     subtotal = sum(
-        (Decimal(str(item["quantity"])) * Decimal(str(item["unit_price"])))
+        money(Decimal(str(item["quantity"])) * Decimal(str(item["unit_price"])))
         for item in payload["line_items"]
     )
     subtotal = money(subtotal)
@@ -83,6 +83,9 @@ def validate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
         _require("status" not in payload and "issue_status" not in payload, f"{ref} must use API draft defaults")
         _require(payload.get("project_name") and payload.get("customer_name"), f"{ref} is missing customer/project data")
         _require(payload.get("scope_summary") and payload.get("line_items"), f"{ref} is missing scope or line items")
+        _require(payload.get("quote_date"), f"{ref} quote_date is required before import")
+        _require(payload.get("valid_until"), f"{ref} valid_until is required before import")
+        _require(payload.get("gst_rate") is not None, f"{ref} gst_rate is required before import")
         _require(all(Decimal(str(item["quantity"])) > 0 for item in payload["line_items"]), f"{ref} quantities must be positive")
         marker = f"[{IMPORT_MARKER}:{ref}]"
         _require(marker in (payload.get("notes") or ""), f"{ref} notes must contain {marker}")
@@ -99,6 +102,9 @@ def validate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
         _require(payload.get("invoice_number") == ref, f"{ref} must match invoice_number")
         _require(payload.get("customer_name") and payload.get("customer_address"), f"{ref} client billing data is required")
         _require(payload.get("line_items"), f"{ref} line items are required")
+        _require(payload.get("project_name") and payload.get("site_address"), f"{ref} project/site data is required")
+        _require(payload.get("invoice_date") and payload.get("due_date"), f"{ref} invoice and due dates are required")
+        _require(payload.get("terms") and payload.get("gst_rate") is not None, f"{ref} terms and gst_rate are required")
         _validate_expected(record, invoice_totals(payload), ref)
 
     return {

--- a/ops/scripts/tests/test_production_business_import.py
+++ b/ops/scripts/tests/test_production_business_import.py
@@ -53,6 +53,109 @@ class BundleValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "totals mismatch"):
             MODULE.validate_bundle(bundle)
 
+    def test_line_amounts_are_rounded_before_subtotal(self):
+        payload = {
+            "gst_rate": "5.00",
+            "line_items": [
+                {"quantity": "0.333", "unit_price": "1.00"},
+                {"quantity": "0.333", "unit_price": "1.00"},
+                {"quantity": "0.333", "unit_price": "1.00"},
+            ],
+        }
+        subtotal, gst, total = MODULE.quote_totals(payload)
+        self.assertEqual(str(subtotal), "0.99")
+        self.assertEqual(str(gst), "0.05")
+        self.assertEqual(str(total), "1.04")
+
+    def test_dates_required_before_any_import_write(self):
+        bundle = valid_bundle()
+        del bundle["quotes"][0]["payload"]["quote_date"]
+        with self.assertRaisesRegex(ValueError, "quote_date is required"):
+            MODULE.validate_bundle(bundle)
+
+
+class FakeClient:
+    def __init__(self):
+        self.projects = []
+        self.quotes = []
+        self.invoices = []
+        self.logged_in = 0
+        self.post_count = 0
+
+    def login(self):
+        self.logged_in += 1
+
+    def request(self, path, method="GET", body=None, expected=(200,)):
+        if method == "GET":
+            if path == "/api/v1/projects":
+                return {"items": copy.deepcopy(self.projects)}
+            if path == "/api/v1/customer-quotes":
+                return {"items": copy.deepcopy(self.quotes)}
+            if path == "/api/v1/finance/customer-invoices":
+                return {"items": copy.deepcopy(self.invoices)}
+            raise AssertionError(path)
+
+        self.post_count += 1
+        if path == "/api/v1/projects":
+            record = copy.deepcopy(body)
+            record.update({"id": "project-1", "project_number": None})
+            self.projects.append(record)
+            return copy.deepcopy(record)
+        if path == "/api/v1/customer-quotes":
+            subtotal, gst, total = MODULE.quote_totals(body)
+            record = copy.deepcopy(body)
+            record.update({
+                "id": f"quote-{len(self.quotes) + 1}",
+                "quote_number": f"Q-2026-{len(self.quotes) + 1:03d}",
+                "subtotal": str(subtotal),
+                "gst": str(gst),
+                "total": str(total),
+                "status": "draft",
+                "issue_status": "draft",
+            })
+            self.quotes.append(record)
+            return copy.deepcopy(record)
+        if path == "/api/v1/finance/customer-invoices":
+            subtotal, gst, total = MODULE.invoice_totals(body)
+            record = copy.deepcopy(body)
+            record.update({
+                "id": f"invoice-{len(self.invoices) + 1}",
+                "subtotal": str(subtotal),
+                "gst": str(gst),
+                "total": str(total),
+                "status": "draft",
+            })
+            self.invoices.append(record)
+            return copy.deepcopy(record)
+        raise AssertionError(path)
+
+
+class ImportExecutionTests(unittest.TestCase):
+    def test_import_is_idempotent_with_api_verification(self):
+        client = FakeClient()
+        first = MODULE.import_bundle(valid_bundle(), client)
+        self.assertEqual(first["project"]["operation"], "created")
+        self.assertTrue(all(item["operation"] == "created" for item in first["quotes"]))
+        self.assertEqual(first["invoices"][0]["operation"], "created")
+        self.assertEqual(client.post_count, 5)
+
+        second = MODULE.import_bundle(valid_bundle(), client)
+        self.assertEqual(second["project"]["operation"], "verified_existing")
+        self.assertTrue(all(item["operation"] == "verified_existing" for item in second["quotes"]))
+        self.assertEqual(second["invoices"][0]["operation"], "verified_existing")
+        self.assertEqual(client.post_count, 5)
+        self.assertEqual(client.logged_in, 2)
+
+    def test_same_name_address_without_key_fails_before_write(self):
+        client = FakeClient()
+        project = copy.deepcopy(valid_bundle()["project"]["payload"])
+        project["id"] = "conflict"
+        project["metadata"] = {}
+        client.projects.append(project)
+        with self.assertRaisesRegex(RuntimeError, "manual review required"):
+            MODULE.import_bundle(valid_bundle(), client)
+        self.assertEqual(client.post_count, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tracks #314.

## Root cause
Protected run 32859478918 validated the COHO/Blueberry bundle but failed before the importer started because the restricted runner correctly could not read `/etc/iron-house-os/production.env`. No IHOS records were written.

## Changes
- Adds a root-owned, least-privilege `ihos-production-business-import` launcher.
- Installs that launcher and a dedicated validated sudoers rule only during an approved production cutover.
- Keeps `production.env` at root-only 0600/0400; the runner never receives read access.
- Passes only IHOS port and bootstrap credentials into the importer.
- Requires an exact main SHA already installed through the protected production deployment workflow.
- Verifies live readiness reports that exact release before import.
- Restricts bundle paths and evidence output paths.
- Changes the import workflow from automatic push execution to manual-only dispatch after deployment.
- Runs disposable validation before the production approval gate.
- Matches IHOS per-line monetary rounding.
- Requires quote/invoice dates, terms and GST before any write.
- Adds fake-client coverage for create, API verification, idempotent retry and same-name/address fail-closed behaviour.
- Documents the two protected approvals: release deployment, then draft-record import.

## Local verification
```text
python3 -m unittest discover -s ops/scripts/tests -p 'test_*.py' -v
# Ran 9 tests — OK

python3 ops/scripts/production_business_import.py validate \
  --input ops/production-business-imports/2026-08-25-coho-blueberry-vale.json
# validated=true; 1 project, 3 quotes, 1 invoice

python3 -m py_compile ops/scripts/production_business_import.py \
  ops/scripts/tests/test_production_business_import.py
bash -n ops/digitalocean/production-business-import-wrapper.sh \
  ops/digitalocean/cutover.sh
PyYAML safe_load(.github/workflows/production-business-import.yml)
visudo -cf <candidate dedicated sudoers rule>
# parsed OK
```

## Security / production boundary
- This PR does not deploy, alter production secrets, change production data, or grant generic sudo/Docker/shell access.
- Production remains unchanged.
- Merge requires normal review.
- The launcher is not installed until the exact release passes Release Readiness and Jeremie approves the protected production deployment.
- The import then requires a second protected production approval.
- Quotes/invoice remain draft; project remains opportunity with no job number.

## Rollback
Revert the release before deployment to prevent installation. After deployment, a later approved cutover can remove the launcher and dedicated sudoers file. Imported records are never automatically deleted; any correction remains within the normal IHOS archive/void controls and evidence trail.