### PR TITLE
Issue #322: import Bowline awarded job and draft invoice

### DIFF
--- a/.github/workflows/production-awarded-invoice-import.yml
+++ b/.github/workflows/production-awarded-invoice-import.yml
@@ -1,0 +1,129 @@
+name: Validate and import approved awarded job invoice
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/production-awarded-invoice-import.yml"
+      - "ops/scripts/production_awarded_invoice_import.py"
+      - "ops/scripts/tests/test_production_awarded_invoice_import.py"
+      - "ops/production-awarded-invoice-imports/*.json"
+  push:
+    branches: [main]
+    paths:
+      - "ops/production-awarded-invoice-imports/*.json"
+  workflow_dispatch:
+    inputs:
+      import_file:
+        description: "Approved bundle under ops/production-awarded-invoice-imports/"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: iron-house-os-production-awarded-invoice-import
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate awarded-job import bundle
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Run disposable validation
+        run: |
+          set -euo pipefail
+          python3 -m unittest ops.scripts.tests.test_production_awarded_invoice_import -v
+          shopt -s nullglob
+          bundles=(ops/production-awarded-invoice-imports/*.json)
+          test ${#bundles[@]} -gt 0
+          for bundle in "${bundles[@]}"; do
+            python3 ops/scripts/production_awarded_invoice_import.py validate --input "$bundle"
+          done
+
+  import-production:
+    name: Import and verify owner-approved awarded job
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, linux, ihos-production]
+    environment: production
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+      - name: Resolve approved import bundle
+        id: bundle
+        env:
+          DISPATCH_FILE: ${{ inputs.import_file }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            import_file="$DISPATCH_FILE"
+          else
+            mapfile -t changed < <(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" -- 'ops/production-awarded-invoice-imports/*.json')
+            if [[ ${#changed[@]} -ne 1 ]]; then
+              echo "Expected exactly one changed import bundle; found ${#changed[@]}." >&2
+              exit 1
+            fi
+            import_file="${changed[0]}"
+          fi
+          if [[ ! "$import_file" =~ ^ops/production-awarded-invoice-imports/[A-Za-z0-9._-]+\.json$ ]]; then
+            echo "Invalid import path." >&2
+            exit 1
+          fi
+          issue_number="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["issue_number"])' "$import_file")"
+          echo "import_file=$import_file" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+      - name: Revalidate on protected runner
+        env:
+          IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
+        run: |
+          set -euo pipefail
+          python3 -m unittest ops.scripts.tests.test_production_awarded_invoice_import -v
+          python3 ops/scripts/production_awarded_invoice_import.py validate --input "$IMPORT_FILE"
+      - name: Import through authenticated IHOS loopback API
+        env:
+          IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
+          EVIDENCE_FILE: production-awarded-invoice-import-evidence.json
+        run: |
+          set -euo pipefail
+          if [[ ! -r /etc/iron-house-os/production.env ]]; then
+            echo "Production environment is not readable by the restricted runner." >&2
+            exit 1
+          fi
+          set -a
+          source /etc/iron-house-os/production.env
+          set +a
+          python3 ops/scripts/production_awarded_invoice_import.py import --input "$IMPORT_FILE" --evidence "$EVIDENCE_FILE"
+      - name: Publish verified evidence to linked issue
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.bundle.outputs.issue_number }}
+        run: |
+          {
+            echo "### Production awarded-job invoice import verified"
+            echo
+            echo '~~~json'
+            cat production-awarded-invoice-import-evidence.json
+            echo '~~~'
+          } > "$RUNNER_TEMP/import-comment.md"
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/import-comment.md"
+      - name: Upload immutable import evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-awarded-invoice-import-${{ github.run_id }}
+          path: production-awarded-invoice-import-evidence.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/ops/production-awarded-invoice-imports/2026-08-25-bowline-rawlison.json
+++ b/ops/production-awarded-invoice-imports/2026-08-25-bowline-rawlison.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "issue_number": 322,
+  "import_key": "bowline-rawlison-2026-08-25",
+  "requested_at": "2026-08-25",
+  "project": {
+    "payload": {
+      "name": "Rawlison Cres Common Excavation",
+      "client_owner": "Bowline Construction",
+      "municipality": "Langley",
+      "project_address": "Rawlison Cres, Langley, BC",
+      "contract_value": 10738.77,
+      "status": "awarded",
+      "notes": "Historical completed-work intake from source invoice BOW-2026-0811. Import creates the awarded IHOS job so the system allocates the permanent job number; invoice remains draft pending normal review/issue controls.",
+      "metadata": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_issue": 322,
+        "source_invoice_number": "BOW-2026-0811",
+        "historical_completed_work": true,
+        "billing_address": "20526 50A Avenue, Langley, BC V3A 6Z2",
+        "customer_phone": "778-808-3725",
+        "total_hours": 43.5,
+        "source_file_name": "Bowline_Rawlins_Crescent_Invoice_updated_fixed.pdf"
+      }
+    }
+  },
+  "invoice": {
+    "external_reference": "BOW-2026-0811",
+    "payload": {
+      "invoice_number": "BOW-2026-0811",
+      "project_name": "Rawlison Cres Common Excavation",
+      "site_address": "Rawlison Cres, Langley, BC",
+      "customer_name": "Bowline Construction",
+      "customer_address": "20526 50A Avenue, Langley, BC V3A 6Z2",
+      "customer_phone": "778-808-3725",
+      "invoice_date": "2026-08-15",
+      "due_date": "2026-09-14",
+      "terms": "Net 30",
+      "gst_rate": "5.00",
+      "line_items": [
+        {"description": "Common excavation - Tuesday, August 11, 2026", "quantity": "12.5", "unit_price": "210.00"},
+        {"description": "Common excavation - Wednesday, August 12, 2026", "quantity": "12.0", "unit_price": "210.00"},
+        {"description": "Common excavation - Thursday, August 13, 2026", "quantity": "9.0", "unit_price": "210.00"},
+        {"description": "Common excavation - Friday, August 14, 2026", "quantity": "6.0", "unit_price": "210.00"},
+        {"description": "Mobilize In", "quantity": "1", "unit_price": "706.20"},
+        {"description": "Mobilize Out", "quantity": "1", "unit_price": "706.20"},
+        {"description": "Mini excavator footings and plumbing", "quantity": "4.0", "unit_price": "130.00"}
+      ]
+    },
+    "expected_subtotal": "10227.40",
+    "expected_gst": "511.37",
+    "expected_total": "10738.77"
+  }
+}

--- a/ops/scripts/production_awarded_invoice_import.py
+++ b/ops/scripts/production_awarded_invoice_import.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Validate and import one owner-approved awarded project plus draft customer invoice.
+
+The project is created with status=awarded and without a supplied project_number so IHOS
+allocates the permanent job number through its normal generator. The invoice remains draft.
+"""
+from __future__ import annotations
+
+import argparse
+import http.cookiejar
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any
+
+MONEY = Decimal("0.01")
+JOB_RE = re.compile(r"^IH\d{7,}$")
+
+
+def money(value: Any) -> Decimal:
+    return Decimal(str(value)).quantize(MONEY, rounding=ROUND_HALF_UP)
+
+
+def invoice_totals(payload: dict[str, Any]) -> tuple[Decimal, Decimal, Decimal]:
+    subtotal = money(sum(Decimal(str(x["quantity"])) * Decimal(str(x["unit_price"])) for x in payload["line_items"]))
+    gst = money(subtotal * Decimal(str(payload.get("gst_rate", "5.00"))) / Decimal("100"))
+    return subtotal, gst, money(subtotal + gst)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def validate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
+    require(bundle.get("schema_version") == 1, "schema_version must be 1")
+    require(isinstance(bundle.get("issue_number"), int), "issue_number is required")
+    require(bool(bundle.get("import_key")), "import_key is required")
+    project = (bundle.get("project") or {}).get("payload") or {}
+    require(project.get("status") == "awarded", "project must enter as awarded")
+    require(not project.get("project_number"), "bundle must not supply a job number")
+    require(project.get("name") and project.get("client_owner") and project.get("project_address"), "project identity is required")
+    metadata = project.get("metadata") or {}
+    require(metadata.get("source_import_key") == bundle["import_key"], "project metadata must carry source_import_key")
+    invoice = bundle.get("invoice") or {}
+    ref = invoice.get("external_reference")
+    payload = invoice.get("payload") or {}
+    require(ref and payload.get("invoice_number") == ref, "invoice external reference must match invoice_number")
+    require("status" not in payload, "invoice must use API draft default")
+    require(payload.get("customer_name") and payload.get("customer_address") and payload.get("line_items"), "invoice billing and line items are required")
+    calculated = invoice_totals(payload)
+    expected = tuple(money(invoice[k]) for k in ("expected_subtotal", "expected_gst", "expected_total"))
+    require(calculated == expected, f"invoice totals mismatch: calculated={calculated}, expected={expected}")
+    return {"issue_number": bundle["issue_number"], "import_key": bundle["import_key"], "project_count": 1, "invoice_count": 1, "validated": True}
+
+
+class IHOSClient:
+    def __init__(self) -> None:
+        port = os.environ.get("IHOS_PORT", "8080")
+        self.base = f"http://127.0.0.1:{port}"
+        jar = http.cookiejar.CookieJar()
+        self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
+
+    def request(self, path: str, method: str = "GET", body: dict[str, Any] | None = None, expected: tuple[int, ...] = (200,)) -> dict[str, Any]:
+        request = urllib.request.Request(self.base + path, data=None if body is None else json.dumps(body).encode(), method=method, headers={"Content-Type": "application/json"})
+        try:
+            with self.opener.open(request, timeout=30) as response:
+                result = json.load(response)
+                if response.status not in expected:
+                    raise RuntimeError(f"Unexpected status {response.status}")
+                return result
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"IHOS request failed: {exc.code} {exc.read().decode(errors='replace')}") from exc
+
+    def login(self) -> None:
+        result = self.request("/api/v1/auth/login", method="POST", body={"email": os.environ["BOOTSTRAP_ADMIN_EMAIL"], "password": os.environ["BOOTSTRAP_ADMIN_PASSWORD"]})
+        if result.get("authentication") != "authenticated":
+            raise RuntimeError("IHOS login did not authenticate")
+
+
+def verify_job_number(value: Any) -> str:
+    number = str(value or "").strip()
+    if "-" in number or not JOB_RE.fullmatch(number):
+        raise RuntimeError(f"Generated IHOS job number is invalid: {number!r}")
+    return number
+
+
+def import_bundle(bundle: dict[str, Any], client: IHOSClient) -> dict[str, Any]:
+    validation = validate_bundle(bundle)
+    client.login()
+    project_payload = bundle["project"]["payload"]
+    projects = client.request("/api/v1/projects").get("items", [])
+    matches = [p for p in projects if (p.get("metadata") or {}).get("source_import_key") == bundle["import_key"]]
+    if len(matches) > 1:
+        raise RuntimeError("Multiple projects match source_import_key")
+    if matches:
+        project = matches[0]
+        project_operation = "verified_existing"
+    else:
+        conflicts = [p for p in projects if p.get("name") == project_payload["name"] and p.get("project_address") == project_payload["project_address"]]
+        if conflicts:
+            raise RuntimeError("Same-name/same-address project exists without import key; manual review required")
+        project = client.request("/api/v1/projects", method="POST", body=project_payload, expected=(201,))
+        project_operation = "created"
+    if project.get("status") != "awarded":
+        raise RuntimeError("Imported project is not awarded")
+    if (project.get("metadata") or {}).get("source_import_key") != bundle["import_key"]:
+        raise RuntimeError("Project import key verification failed")
+    job_number = verify_job_number(project.get("project_number"))
+
+    record = bundle["invoice"]
+    ref = record["external_reference"]
+    invoices = client.request("/api/v1/finance/customer-invoices").get("items", [])
+    matches = [x for x in invoices if x.get("invoice_number") == ref]
+    if len(matches) > 1:
+        raise RuntimeError(f"Multiple invoices match {ref}")
+    if matches:
+        invoice = matches[0]
+        invoice_operation = "verified_existing"
+    else:
+        payload = dict(record["payload"])
+        payload["project_id"] = project["id"]
+        invoice = client.request("/api/v1/finance/customer-invoices", method="POST", body=payload, expected=(201,))
+        invoice_operation = "created"
+    if str(invoice.get("project_id")) != str(project["id"]):
+        raise RuntimeError("Invoice is not linked to the imported project")
+    if invoice.get("status") != "draft":
+        raise RuntimeError("Invoice must remain draft")
+    for field, expected in (("subtotal", record["expected_subtotal"]), ("gst", record["expected_gst"]), ("total", record["expected_total"])):
+        if str(invoice.get(field)) != str(expected):
+            raise RuntimeError(f"Invoice {field} mismatch")
+    return {**validation, "project": {"id": project["id"], "operation": project_operation, "job_number": job_number, "status": project["status"]}, "invoice": {"id": invoice["id"], "operation": invoice_operation, "invoice_number": ref, "status": invoice["status"], "total": invoice["total"]}, "production_verified": True}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("validate", "import"))
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--evidence")
+    args = parser.parse_args(argv)
+    bundle = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    if args.command == "validate":
+        result = validate_bundle(bundle)
+    else:
+        if not args.evidence:
+            parser.error("--evidence is required for import")
+        result = import_bundle(bundle, IHOSClient())
+        Path(args.evidence).write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/scripts/tests/test_production_awarded_invoice_import.py
+++ b/ops/scripts/tests/test_production_awarded_invoice_import.py
@@ -1,0 +1,51 @@
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "ops" / "scripts" / "production_awarded_invoice_import.py"
+SPEC = importlib.util.spec_from_file_location("production_awarded_invoice_import", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def valid_bundle():
+    return json.loads((ROOT / "ops" / "production-awarded-invoice-imports" / "2026-08-25-bowline-rawlison.json").read_text())
+
+
+class AwardedInvoiceImportTests(unittest.TestCase):
+    def test_bowline_bundle_validates(self):
+        result = MODULE.validate_bundle(valid_bundle())
+        self.assertTrue(result["validated"])
+        self.assertEqual(result["project_count"], 1)
+        self.assertEqual(result["invoice_count"], 1)
+
+    def test_bundle_cannot_supply_job_number(self):
+        bundle = valid_bundle()
+        bundle["project"]["payload"]["project_number"] = "IH2026999"
+        with self.assertRaisesRegex(ValueError, "must not supply a job number"):
+            MODULE.validate_bundle(bundle)
+
+    def test_project_must_enter_awarded(self):
+        bundle = valid_bundle()
+        bundle["project"]["payload"]["status"] = "opportunity"
+        with self.assertRaisesRegex(ValueError, "must enter as awarded"):
+            MODULE.validate_bundle(bundle)
+
+    def test_invoice_total_mismatch_fails_closed(self):
+        bundle = copy.deepcopy(valid_bundle())
+        bundle["invoice"]["expected_total"] = "1.00"
+        with self.assertRaisesRegex(ValueError, "totals mismatch"):
+            MODULE.validate_bundle(bundle)
+
+    def test_job_number_rejects_hyphens(self):
+        with self.assertRaisesRegex(RuntimeError, "invalid"):
+            MODULE.verify_job_number("IH-2026-001")
+        self.assertEqual(MODULE.verify_job_number("IH2026001"), "IH2026001")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #322 after protected import evidence is attached.
Parent: #268

## Summary
- adds a dedicated protected no-browser import path for one historical awarded project plus one draft customer invoice
- adds the Bowline Rawlison Cres completed-work bundle from source invoice `BOW-2026-0811`
- creates the project as `awarded` without supplying a project number so IHOS allocates the permanent job number through the normal generator
- explicitly rejects generated job numbers containing hyphens
- links the draft invoice to the generated project/job
- preserves customer billing, site, dates, terms, line quantities/rates, GST and totals exactly
- uses stable import keys and invoice matching for idempotent retries
- fails closed on same-name/address conflicts or duplicate invoice records

## Bowline totals
- total hours: 43.5
- subtotal: $10,227.40
- GST (5%): $511.37
- total: $10,738.77

## Controls
- draft PR; no production mutation from pull-request validation
- production import requires protected `production` environment approval
- importer uses authenticated IHOS loopback API only
- invoice remains draft; importer cannot approve, issue or mark paid
- no existing historical job numbers are rewritten
- locked IHOS visual design unchanged

## Validation requested
- dedicated import unit tests
- exact bundle validation
- normal repository CI / review gates
- protected production run only after merge approval and environment approval