### PR TITLE
Issue #324: harden protected awarded-invoice import

### DIFF
--- a/.github/workflows/production-awarded-invoice-import.yml
+++ b/.github/workflows/production-awarded-invoice-import.yml
@@ -8,12 +8,14 @@ on:
       - "ops/scripts/production_awarded_invoice_import.py"
       - "ops/scripts/tests/test_production_awarded_invoice_import.py"
       - "ops/production-awarded-invoice-imports/*.json"
-  push:
-    branches: [main]
-    paths:
-      - "ops/production-awarded-invoice-imports/*.json"
+      - "ops/digitalocean/production-awarded-invoice-import-wrapper.sh"
+      - "ops/digitalocean/cutover.sh"
   workflow_dispatch:
     inputs:
+      release_sha:
+        description: "Exact approved release SHA currently deployed to production"
+        required: true
+        type: string
       import_file:
         description: "Approved bundle under ops/production-awarded-invoice-imports/"
         required: true
@@ -30,17 +32,19 @@ concurrency:
 jobs:
   validate:
     name: Validate awarded-job import bundle
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          ref: ${{ inputs.release_sha || github.sha }}
           persist-credentials: false
       - name: Run disposable validation
         run: |
           set -euo pipefail
           python3 -m unittest ops.scripts.tests.test_production_awarded_invoice_import -v
+          bash -n ops/digitalocean/production-awarded-invoice-import-wrapper.sh ops/digitalocean/cutover.sh
           shopt -s nullglob
           bundles=(ops/production-awarded-invoice-imports/*.json)
           test ${#bundles[@]} -gt 0
@@ -50,40 +54,41 @@ jobs:
 
   import-production:
     name: Import and verify owner-approved awarded job
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: validate
     runs-on: [self-hosted, linux, ihos-production]
     environment: production
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Check out approved main revision without credentials
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
+          ref: ${{ inputs.release_sha }}
           persist-credentials: false
-          fetch-depth: 2
+          fetch-depth: 0
+
       - name: Resolve approved import bundle
         id: bundle
         env:
           DISPATCH_FILE: ${{ inputs.import_file }}
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            import_file="$DISPATCH_FILE"
-          else
-            mapfile -t changed < <(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA" -- 'ops/production-awarded-invoice-imports/*.json')
-            if [[ ${#changed[@]} -ne 1 ]]; then
-              echo "Expected exactly one changed import bundle; found ${#changed[@]}." >&2
-              exit 1
-            fi
-            import_file="${changed[0]}"
-          fi
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]
+          git fetch --quiet origin main
+          git merge-base --is-ancestor "$RELEASE_SHA" origin/main
+          import_file="$DISPATCH_FILE"
           if [[ ! "$import_file" =~ ^ops/production-awarded-invoice-imports/[A-Za-z0-9._-]+\.json$ ]]; then
-            echo "Invalid import path." >&2
+            echo "Import file must be a direct JSON child of ops/production-awarded-invoice-imports/." >&2
             exit 1
           fi
+          test -f "$import_file"
           issue_number="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["issue_number"])' "$import_file")"
           echo "import_file=$import_file" >> "$GITHUB_OUTPUT"
           echo "issue_number=$issue_number" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Revalidate on protected runner
         env:
           IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
@@ -91,20 +96,27 @@ jobs:
           set -euo pipefail
           python3 -m unittest ops.scripts.tests.test_production_awarded_invoice_import -v
           python3 ops/scripts/production_awarded_invoice_import.py validate --input "$IMPORT_FILE"
-      - name: Import through authenticated IHOS loopback API
-        env:
-          IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
-          EVIDENCE_FILE: production-awarded-invoice-import-evidence.json
+
+      - name: Verify the installed least-privilege import wrapper
         run: |
           set -euo pipefail
-          if [[ ! -r /etc/iron-house-os/production.env ]]; then
-            echo "Production environment is not readable by the restricted runner." >&2
-            exit 1
-          fi
-          set -a
-          source /etc/iron-house-os/production.env
-          set +a
-          python3 ops/scripts/production_awarded_invoice_import.py import --input "$IMPORT_FILE" --evidence "$EVIDENCE_FILE"
+          installed=/usr/local/sbin/ihos-production-awarded-invoice-import
+          trusted="$GITHUB_WORKSPACE/ops/digitalocean/production-awarded-invoice-import-wrapper.sh"
+          [[ "$(stat -c '%U:%G:%a' "$installed")" == "root:root:755" ]]
+          cmp --silent "$trusted" "$installed"
+
+      - name: Import through the restricted root wrapper and IHOS loopback API
+        env:
+          IMPORT_FILE: ${{ steps.bundle.outputs.import_file }}
+          RELEASE_SHA: ${{ steps.bundle.outputs.release_sha }}
+          EVIDENCE_FILE: ${{ runner.temp }}/production-awarded-invoice-import-evidence.json
+        run: |
+          set -euo pipefail
+          sudo -n /usr/local/sbin/ihos-production-awarded-invoice-import \
+            --release "$RELEASE_SHA" \
+            --bundle "$IMPORT_FILE" \
+            --evidence "$EVIDENCE_FILE"
+
       - name: Publish verified evidence to linked issue
         if: success()
         env:
@@ -115,15 +127,16 @@ jobs:
             echo "### Production awarded-job invoice import verified"
             echo
             echo '~~~json'
-            cat production-awarded-invoice-import-evidence.json
+            cat "${{ runner.temp }}/production-awarded-invoice-import-evidence.json"
             echo '~~~'
           } > "$RUNNER_TEMP/import-comment.md"
           gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$RUNNER_TEMP/import-comment.md"
+
       - name: Upload immutable import evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: production-awarded-invoice-import-${{ github.run_id }}
-          path: production-awarded-invoice-import-evidence.json
+          path: ${{ runner.temp }}/production-awarded-invoice-import-evidence.json
           if-no-files-found: warn
           retention-days: 90

--- a/docs/production-awarded-invoice-import.md
+++ b/docs/production-awarded-invoice-import.md
@@ -1,0 +1,42 @@
+# Production awarded-job invoice import
+
+This is the supported no-browser path for one owner-approved historical awarded project and its
+draft customer invoice.
+
+## Controls
+
+- Work starts from a linked issue and draft pull request.
+- Pull requests run disposable validation only and cannot reach production.
+- Merging a bundle never starts a production import.
+- Production import is manual-only and requires the exact SHA already deployed to production.
+- The protected `production` environment requires its configured human reviewer.
+- A root-owned launcher verifies the immutable deployed release, approved bundle path, live
+  readiness release identity, repository origin and runner-temporary evidence destination.
+- The restricted runner cannot read `production.env`; only the launcher sources the IHOS port
+  and bootstrap credentials required for authenticated loopback API calls.
+- IHOS generates the awarded project's permanent job number. The bundle cannot supply one, and
+  the importer rejects generated job numbers containing hyphens.
+- The customer invoice remains `draft`; the importer cannot approve, issue or pay it.
+- Stable import keys and invoice numbers make retries idempotent. Identity conflicts fail closed.
+- Verified evidence is attached to the linked issue and retained as a 90-day workflow artifact.
+
+## Approval sequence
+
+1. Review the exact project, billing identity, invoice lines, totals, GST, dates and terms in the
+   issue-linked bundle.
+2. Complete normal draft-PR review, CI and Release Readiness.
+3. Merge only with owner authorization.
+4. Deploy that exact main SHA through the protected production deployment workflow. This is the
+   first protected approval and installs the matching restricted launcher.
+5. Dispatch `Validate and import approved awarded job invoice` with:
+   - the exact deployed 40-character release SHA; and
+   - the exact bundle path under `ops/production-awarded-invoice-imports/`.
+6. At the second protected approval, recheck the SHA and exact record scope before approving.
+7. Verify the issue evidence, generated no-hyphen job number, awarded project, draft invoice,
+   exact totals and public production release identity.
+
+Never rerun a failed pre-hardening push-triggered workflow. It was not bound to a deployed release
+and could not read the protected environment.
+
+Rollback is intentionally manual. Imported records are never deleted automatically. Correct a
+wrong project or invoice through normal IHOS archive/void controls and retain the evidence trail.

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -77,6 +77,29 @@ install_production_business_import_wrapper() {
 }
 
 
+install_production_awarded_invoice_import_wrapper() {
+  local wrapper_source="$repo_root/ops/digitalocean/production-awarded-invoice-import-wrapper.sh"
+  local wrapper_target=/usr/local/sbin/ihos-production-awarded-invoice-import
+  local sudoers_target=/etc/sudoers.d/iron-house-os-production-awarded-invoice-import
+  local sudoers_candidate
+
+  if [[ ! -f "$wrapper_source" ]]; then
+    echo "Approved release is missing the production awarded-invoice import wrapper." >&2
+    return 1
+  fi
+  bash -n "$wrapper_source"
+  sudoers_candidate=$(mktemp)
+  printf '%s\n' \
+    "ihos-runner ALL=(root) NOPASSWD: $wrapper_target *" \
+    >"$sudoers_candidate"
+  chmod 0440 "$sudoers_candidate"
+  visudo -cf "$sudoers_candidate" >/dev/null
+  install -o root -g root -m 0755 "$wrapper_source" "$wrapper_target"
+  install -o root -g root -m 0440 "$sudoers_candidate" "$sudoers_target"
+  rm -f "$sudoers_candidate"
+  visudo -cf "$sudoers_target" >/dev/null
+}
+
 cd "$repo_root"
 if [[ -n "$(git status --porcelain)" ]]; then
   echo "Refusing cutover from a dirty working tree." >&2
@@ -228,6 +251,7 @@ IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
 IHOS_BACKUP_NAME="post-cutover-$stamp" \
 scripts/scheduled_backup.sh
 install_production_business_import_wrapper
+install_production_awarded_invoice_import_wrapper
 
 acceptance=/var/lib/iron-house-os/operator-acceptance-$stamp.md
 cat >"$acceptance" <<EOF

--- a/ops/digitalocean/production-awarded-invoice-import-wrapper.sh
+++ b/ops/digitalocean/production-awarded-invoice-import-wrapper.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+release_sha=
+bundle_file=
+evidence_file=
+
+usage() {
+  echo "Usage: ihos-production-awarded-invoice-import --release 40_HEX_SHA --bundle ops/production-awarded-invoice-imports/FILE.json --evidence FILE" >&2
+}
+
+while (($#)); do
+  case "$1" in
+    --release)
+      release_sha=${2:-}
+      shift 2
+      ;;
+    --bundle)
+      bundle_file=${2:-}
+      shift 2
+      ;;
+    --evidence)
+      evidence_file=${2:-}
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ((EUID != 0)) ||
+  [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]] ||
+  [[ ! "$bundle_file" =~ ^ops/production-awarded-invoice-imports/[A-Za-z0-9._-]+\.json$ ]] ||
+  [[ -z "$evidence_file" ]]; then
+  usage
+  exit 2
+fi
+if [[ "$(hostname)" != "iron-house-os-prod-1" ]]; then
+  echo "Refusing production import on unexpected host." >&2
+  exit 1
+fi
+
+release_root="/opt/iron-house-os-releases/$release_sha"
+if [[ ! -d "$release_root/.git" ]]; then
+  echo "The requested release has not been installed through the approved production deployment workflow." >&2
+  exit 1
+fi
+git_release() {
+  git -c "safe.directory=$release_root" -C "$release_root" "$@"
+}
+if [[ "$(git_release rev-parse HEAD)" != "$release_sha" ]] || [[ -n "$(git_release status --porcelain)" ]]; then
+  echo "Immutable production release checkout is missing, dirty, or has the wrong SHA." >&2
+  exit 1
+fi
+remote_url=$(git_release remote get-url origin)
+case "$remote_url" in
+  https://github.com/iron-house-os/iron-house-os|https://github.com/iron-house-os/iron-house-os.git|git@github.com:iron-house-os/iron-house-os.git)
+    ;;
+  *)
+    echo "Unexpected repository remote: $remote_url" >&2
+    exit 1
+    ;;
+esac
+git_release fetch --quiet origin main
+if ! git_release merge-base --is-ancestor "$release_sha" origin/main; then
+  echo "Requested release is not present on origin/main." >&2
+  exit 1
+fi
+
+bundle_path="$release_root/$bundle_file"
+importer_path="$release_root/ops/scripts/production_awarded_invoice_import.py"
+if [[ ! -f "$bundle_path" || ! -f "$importer_path" ]]; then
+  echo "Approved release is missing the import bundle or importer." >&2
+  exit 1
+fi
+resolved_bundle=$(realpath "$bundle_path")
+if [[ "$resolved_bundle" != "$release_root/ops/production-awarded-invoice-imports/"*.json ]]; then
+  echo "Import bundle escaped the approved release directory." >&2
+  exit 1
+fi
+if ! git_release diff --quiet HEAD -- "$bundle_file" "ops/scripts/production_awarded_invoice_import.py"; then
+  echo "Import bundle or importer differs from the approved release." >&2
+  exit 1
+fi
+
+evidence_parent=$(cd "$(dirname "$evidence_file")" && pwd -P)
+evidence_name=$(basename "$evidence_file")
+if [[ "$evidence_parent" != "/opt/iron-house-os-actions-runner/_work/_temp" &&
+      "$evidence_parent" != /opt/iron-house-os-actions-runner/_work/_temp/* ]] ||
+  [[ ! "$evidence_name" =~ ^[A-Za-z0-9._-]+\.json$ ]]; then
+  echo "Evidence output must be a JSON file in the restricted runner temporary directory." >&2
+  exit 1
+fi
+evidence_file="$evidence_parent/$evidence_name"
+
+environment_file=/etc/iron-house-os/production.env
+if [[ "$(stat -c '%U:%G:%a' "$environment_file" 2>/dev/null || true)" != "root:root:600" &&
+      "$(stat -c '%U:%G:%a' "$environment_file" 2>/dev/null || true)" != "root:root:400" ]]; then
+  echo "Protected production environment ownership or permissions are invalid." >&2
+  exit 1
+fi
+set -a
+# shellcheck disable=SC1090
+source "$environment_file"
+set +a
+: "${BOOTSTRAP_ADMIN_EMAIL:?BOOTSTRAP_ADMIN_EMAIL is required}"
+: "${BOOTSTRAP_ADMIN_PASSWORD:?BOOTSTRAP_ADMIN_PASSWORD is required}"
+IHOS_PORT=${IHOS_PORT:-8080}
+
+readiness_url="http://127.0.0.1:${IHOS_PORT}/readiness"
+curl --fail --silent --show-error --connect-timeout 5 --max-time 30 "$readiness_url" |
+  EXPECTED_RELEASE="$release_sha" python3 -c '
+import json, os, sys
+payload = json.load(sys.stdin)
+expected = os.environ["EXPECTED_RELEASE"]
+release_id = payload.get("checks", {}).get("release_id")
+if payload.get("status") != "ready" or release_id != expected:
+    raise SystemExit(
+        "Production release mismatch: status={}, release_id={}, expected={}".format(
+            payload.get("status"), release_id, expected
+        )
+    )
+'
+
+temporary_evidence=$(mktemp "$evidence_parent/.production-awarded-invoice-import.XXXXXX")
+trap 'rm -f "$temporary_evidence"' EXIT
+env -i \
+  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+  IHOS_PORT="$IHOS_PORT" \
+  BOOTSTRAP_ADMIN_EMAIL="$BOOTSTRAP_ADMIN_EMAIL" \
+  BOOTSTRAP_ADMIN_PASSWORD="$BOOTSTRAP_ADMIN_PASSWORD" \
+  python3 "$importer_path" import \
+    --input "$resolved_bundle" \
+    --evidence "$temporary_evidence"
+
+python3 -m json.tool "$temporary_evidence" >/dev/null
+install -o ihos-runner -g ihos-runner -m 0640 "$temporary_evidence" "$evidence_file"
+trap - EXIT
+rm -f "$temporary_evidence"
+echo "Production awarded-invoice import verified for release $release_sha."

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -122,3 +122,52 @@ def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:
     assert 'release_id = payload.get("checks", {}).get("release_id")' in workflow
     assert "release_id != expected" in workflow
     assert workflow.count("--connect-timeout 5 --max-time 30") == 3
+
+
+def test_awarded_invoice_import_is_manual_and_exact_release_only() -> None:
+    workflow = (
+        ROOT / ".github/workflows/production-awarded-invoice-import.yml"
+    ).read_text()
+
+    assert "  push:" not in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "release_sha:" in workflow
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+    assert "needs: validate" in workflow
+    assert "ref: ${{ inputs.release_sha }}" in workflow
+    assert '[[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]' in workflow
+    assert '[[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]' in workflow
+    assert 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' in workflow
+    assert "/etc/iron-house-os/production.env" not in workflow
+    assert (
+        "sudo -n /usr/local/sbin/ihos-production-awarded-invoice-import"
+        in workflow
+    )
+
+
+def test_cutover_installs_restricted_awarded_invoice_import_wrapper() -> None:
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+    wrapper = (
+        ROOT / "ops/digitalocean/production-awarded-invoice-import-wrapper.sh"
+    ).read_text()
+
+    assert "install_production_awarded_invoice_import_wrapper" in cutover
+    assert (
+        "wrapper_target=/usr/local/sbin/ihos-production-awarded-invoice-import"
+        in cutover
+    )
+    assert (
+        "sudoers_target=/etc/sudoers.d/iron-house-os-production-awarded-invoice-import"
+        in cutover
+    )
+    assert "if ((EUID != 0))" in wrapper
+    assert 'hostname)" != "iron-house-os-prod-1"' in wrapper
+    assert "ops/production-awarded-invoice-imports/" in wrapper
+    assert "ops/scripts/production_awarded_invoice_import.py" in wrapper
+    assert 'release_root="/opt/iron-house-os-releases/$release_sha"' in wrapper
+    assert 'release_id != expected' in wrapper
+    assert 'environment_file=/etc/iron-house-os/production.env' in wrapper
+    assert "env -i" in wrapper
+    assert (
+        "/opt/iron-house-os-actions-runner/_work/_temp" in wrapper
+    )


### PR DESCRIPTION
Closes #324.

## Summary

- removes the automatic production import on `main` pushes;
- requires a manual dispatch with the exact SHA already deployed to production;
- adds a root-owned, least-privilege awarded-invoice import launcher;
- verifies immutable release identity, origin/main ancestry, live readiness identity, bundle containment and evidence destination;
- keeps `production.env` root-only and passes only the IHOS port/bootstrap credentials to the loopback importer;
- installs the launcher and a dedicated validated sudoers rule only during an approved production cutover;
- adds configuration regression tests and a two-approval operating guide.

## Verified root cause

Run [32864559974](https://github.com/iron-house-os/iron-house-os/actions/runs/32864559974) failed before the importer started because the restricted runner could not read `/etc/iron-house-os/production.env`. Bundle validation passed. No Bowline records were written.

## Commands / validation

The draft PR triggers the repository CI and Release Readiness suites. The workflow also runs:

```text
python3 -m unittest ops.scripts.tests.test_production_awarded_invoice_import -v
bash -n ops/digitalocean/production-awarded-invoice-import-wrapper.sh ops/digitalocean/cutover.sh
python3 ops/scripts/production_awarded_invoice_import.py validate --input <each approved bundle>
```

Exact GitHub results will be recorded after completion.

## Security and production boundary

- No production deployment.
- No production data mutation.
- No direct runner access to `production.env`.
- No generic shell, Docker, database, DNS, certificate, backup or secret changes.
- Both a protected exact-release deployment and a separate protected import approval remain required.
- Failed pre-hardening runs must not be rerun.

## Rollback

Revert this PR before deployment to avoid installing the launcher. After deployment, a later approved cutover may remove it. Any imported IHOS records remain subject to normal archive/void controls and are never automatically deleted.


## GitHub verification

- Awarded-invoice import validation #3 — **success**: https://github.com/iron-house-os/iron-house-os/actions/runs/32879320595
- Existing business-import validation #5 — **success**: https://github.com/iron-house-os/iron-house-os/actions/runs/32879320565
- CI #979 attempt 2 — **success**: https://github.com/iron-house-os/iron-house-os/actions/runs/32879320525
- Release Readiness #461 — **success**: https://github.com/iron-house-os/iron-house-os/actions/runs/32879320644

CI attempt 1 had one timing-sensitive MVP Workflow frontend assertion fail while the equivalent Release Readiness frontend suite passed. Only that failed CI job was rerun; attempt 2 passed frontend, backend and browser/mobile/accessibility.
