### PR TITLE
Recover production cutover from stale Compose containers

### DIFF
--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -13,6 +13,10 @@ DigitalOcean web console.
   checkout, missing evidence, and commits not present on `origin/main`.
 - The wrapper discovers and pins the running production Docker Compose project
   name before cutover, preventing a parallel stack from being created.
+- After the pre-cutover backup and maintenance gate, the cutover performs a
+  clean recreation of that pinned Compose project. It removes service containers
+  and orphans without removing named volumes, retries transient stale-container
+  cleanup once, and then fails closed with Compose diagnostics.
 - The runner account has passwordless sudo access only to the validated
   production deployment wrapper.
 - Before cutover, the workflow verifies that the installed wrapper is owned by

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -157,6 +157,26 @@ fi
 scripts/verify_s3_targets.sh "$IHOS_STORAGE_S3_BUCKET" "$IHOS_BACKUP_S3_BUCKET"
 compose=(docker compose --env-file "$environment_file" -f docker-compose.production.yml)
 "${compose[@]}" config --quiet
+
+recreate_production_stack() {
+  local attempt
+
+  for attempt in 1 2; do
+    if "${compose[@]}" down --remove-orphans --timeout 30; then
+      "${compose[@]}" up -d --no-build --remove-orphans
+      return
+    fi
+    if ((attempt == 1)); then
+      echo "Docker Compose cleanup hit transient container state; retrying once." >&2
+      sleep 2
+    fi
+  done
+
+  echo "Docker Compose cleanup failed after two attempts; refusing to recreate production." >&2
+  "${compose[@]}" ps --all >&2 || true
+  return 1
+}
+
 "${compose[@]}" config --format json | python -c '
 import json, sys
 project = json.load(sys.stdin)
@@ -207,7 +227,7 @@ gateway_mutated=1
 install -m 0644 ops/digitalocean/nginx-maintenance.conf /etc/nginx/sites-available/iron-house-os
 nginx -t
 systemctl reload nginx
-"${compose[@]}" up -d --no-build
+recreate_production_stack
 
 readiness_url="http://127.0.0.1:${IHOS_PORT:-8080}/readiness"
 readiness_file=$(mktemp)

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -112,11 +112,11 @@ def test_cutover_recreates_compose_stack_without_removing_volumes() -> None:
     cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
 
     start = cutover.index("recreate_production_stack()")
-    end = cutover.index('\n"\${compose[@]}" config --format json', start)
+    end = cutover.index('\n"${compose[@]}" config --format json', start)
     recreate = cutover[start:end]
 
-    compose_down = '"\${compose[@]}" down --remove-orphans --timeout 30'
-    compose_up = '"\${compose[@]}" up -d --no-build --remove-orphans'
+    compose_down = '"${compose[@]}" down --remove-orphans --timeout 30'
+    compose_up = '"${compose[@]}" up -d --no-build --remove-orphans'
 
     assert "for attempt in 1 2" in recreate
     assert compose_down in recreate

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -94,19 +94,39 @@ def test_cutover_installs_failure_recovery_before_maintenance_mutation() -> None
         "/etc/nginx/sites-available/iron-house-os"
     )
     compose_build = '"${compose[@]}" build'
-    compose_up = '"${compose[@]}" up -d --no-build'
+    compose_recreate = "\nrecreate_production_stack\n\nreadiness_url="
 
     assert "previous_gateway=$(mktemp)" in cutover
     assert "application_ready=0" in cutover
     assert cutover.index(trap) < cutover.rindex(maintenance)
     assert cutover.index(compose_build) < cutover.rindex(maintenance)
-    assert cutover.rindex(maintenance) < cutover.index(compose_up)
+    assert cutover.rindex(maintenance) < cutover.rindex(compose_recreate)
     assert "release_id != expected" in cutover
     assert "for attempt in $(seq 1 24)" in cutover
     assert "--connect-timeout 5 --max-time 10" in cutover
     assert "within 120 seconds" in cutover
     assert 'up -d --no-build --wait' not in cutover
 
+
+def test_cutover_recreates_compose_stack_without_removing_volumes() -> None:
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+
+    start = cutover.index("recreate_production_stack()")
+    end = cutover.index('\n"\${compose[@]}" config --format json', start)
+    recreate = cutover[start:end]
+
+    compose_down = '"\${compose[@]}" down --remove-orphans --timeout 30'
+    compose_up = '"\${compose[@]}" up -d --no-build --remove-orphans'
+
+    assert "for attempt in 1 2" in recreate
+    assert compose_down in recreate
+    assert compose_up in recreate
+    assert recreate.index(compose_down) < recreate.index(compose_up)
+    assert "retrying once" in recreate
+    assert "failed after two attempts" in recreate
+    assert "return 1" in recreate
+    assert "--volumes" not in recreate
+    assert " down -v" not in recreate
 
 def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:
     workflow = (ROOT / ".github/workflows/production-deploy.yml").read_text()


### PR DESCRIPTION
Closes #326

## Summary
- recreate the pinned production Compose project after the pre-cutover backup and maintenance gate
- remove service containers and orphans without removing named volumes
- retry a transient stale-container cleanup once, then fail closed with Compose diagnostics
- retain exact-release readiness, smoke, backup, and protected-environment controls
- document the recovery behavior

## Production incident
Production deploy #54, run `32884504867`, failed while Compose stopped a disappeared replacement backend container. The workflow did not reach public exact-release verification. This PR does not rerun or alter production.

## Tests
- CI #981, run `32885321358`: **success**
- Release Readiness #463, run `32885321329`: **success**
- Production-deploy PR policy validation #55, run `32885321268`: **success**
- focused regression coverage proves cleanup precedes recreation, orphan cleanup is enabled, retry is bounded, failure remains fatal, and no Compose volume-removal flag is used

## Security and production gates
- no secret, environment, DNS, certificate, backup, data, or infrastructure mutation
- no direct production access
- production deployment remains manual and protected by Jeremie’s approval
- no automatic retry of failed deploy #54

## Rollback
Revert this PR to restore the previous direct `docker compose up` cutover behavior.