### PR TITLE
Wait safely for post-cutover backup lock

### DIFF
--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -17,6 +17,9 @@ DigitalOcean web console.
   clean recreation of that pinned Compose project. It removes service containers
   and orphans without removing named volumes, retries transient stale-container
   cleanup once, and then fails closed with Compose diagnostics.
+- Scheduled backups remain nonblocking by default. The mandatory post-cutover
+  recovery backup is the only cutover call that waits for an overlapping backup,
+  with a five-minute maximum; timeout remains a deployment failure.
 - The runner account has passwordless sudo access only to the validated
   production deployment wrapper.
 - Before cutover, the workflow verifies that the installed wrapper is owned by

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -269,6 +269,7 @@ python scripts/release_smoke.py \
   --full
 IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
 IHOS_BACKUP_NAME="post-cutover-$stamp" \
+IHOS_BACKUP_LOCK_WAIT_SECONDS=300 \
 scripts/scheduled_backup.sh
 install_production_business_import_wrapper
 install_production_awarded_invoice_import_wrapper

--- a/scripts/scheduled_backup.sh
+++ b/scripts/scheduled_backup.sh
@@ -7,6 +7,13 @@ backup_name=${IHOS_BACKUP_NAME:-$(date -u +%Y%m%dT%H%M%SZ)}
 retention_days=${IHOS_BACKUP_RETENTION_DAYS:-30}
 keep_minimum=${IHOS_BACKUP_KEEP_MINIMUM:-7}
 maximum_bundles=${IHOS_BACKUP_MAXIMUM_BUNDLES:-60}
+backup_lock_wait_seconds=${IHOS_BACKUP_LOCK_WAIT_SECONDS:-0}
+
+if [[ ! "$backup_lock_wait_seconds" =~ ^[0-9]+$ ]] ||
+  ((10#$backup_lock_wait_seconds > 600)); then
+  echo "IHOS_BACKUP_LOCK_WAIT_SECONDS must be an integer from 0 to 600." >&2
+  exit 2
+fi
 
 if [[ ! "$backup_name" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$backup_name" == "." || "$backup_name" == ".." ]]; then
   echo "IHOS_BACKUP_NAME must be a safe single directory name." >&2
@@ -16,8 +23,8 @@ fi
 mkdir -p "$backup_root"
 backup_root=$(cd "$backup_root" && pwd -P)
 exec 9>"$backup_root/.backup.lock"
-if ! flock -n 9; then
-  echo "Another Iron House OS backup is already running." >&2
+if ! flock --wait "$backup_lock_wait_seconds" 9; then
+  echo "Another Iron House OS backup is already running after waiting ${backup_lock_wait_seconds}s." >&2
   exit 1
 fi
 

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -128,6 +128,95 @@ def test_cutover_recreates_compose_stack_without_removing_volumes() -> None:
     assert "--volumes" not in recreate
     assert " down -v" not in recreate
 
+def test_scheduled_backup_supports_only_a_bounded_lock_wait() -> None:
+    backup = (ROOT / "scripts/scheduled_backup.sh").read_text()
+
+    assert "backup_lock_wait_seconds=${IHOS_BACKUP_LOCK_WAIT_SECONDS:-0}" in backup
+    assert '"$backup_lock_wait_seconds" =~ ^[0-9]+    workflow = (ROOT / ".github/workflows/production-deploy.yml").read_text()
+
+    checkout_pin = (
+        "actions/checkout@11d5960a326750d5838078e36cf38b85af677262"
+    )
+
+    assert workflow.count(checkout_pin) == 3
+    assert "actions/checkout@v4" not in workflow
+    assert "persist-credentials: false" in workflow
+    assert "Verify public production endpoints and release identity" in workflow
+    assert 'release_id = payload.get("checks", {}).get("release_id")' in workflow
+    assert "release_id != expected" in workflow
+    assert workflow.count("--connect-timeout 5 --max-time 30") == 3
+
+
+def test_awarded_invoice_import_is_manual_and_exact_release_only() -> None:
+    workflow = (
+        ROOT / ".github/workflows/production-awarded-invoice-import.yml"
+    ).read_text()
+
+    assert "  push:" not in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "release_sha:" in workflow
+    assert "github.event_name == 'workflow_dispatch'" in workflow
+    assert "needs: validate" in workflow
+    assert "ref: ${{ inputs.release_sha }}" in workflow
+    assert '[[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]' in workflow
+    assert '[[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]' in workflow
+    assert 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' in workflow
+    assert "/etc/iron-house-os/production.env" not in workflow
+    assert (
+        "sudo -n /usr/local/sbin/ihos-production-awarded-invoice-import"
+        in workflow
+    )
+
+
+def test_cutover_installs_restricted_awarded_invoice_import_wrapper() -> None:
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+    wrapper = (
+        ROOT / "ops/digitalocean/production-awarded-invoice-import-wrapper.sh"
+    ).read_text()
+
+    assert "install_production_awarded_invoice_import_wrapper" in cutover
+    assert (
+        "wrapper_target=/usr/local/sbin/ihos-production-awarded-invoice-import"
+        in cutover
+    )
+    assert (
+        "sudoers_target=/etc/sudoers.d/iron-house-os-production-awarded-invoice-import"
+        in cutover
+    )
+    assert "if ((EUID != 0))" in wrapper
+    assert 'hostname)" != "iron-house-os-prod-1"' in wrapper
+    assert "ops/production-awarded-invoice-imports/" in wrapper
+    assert "ops/scripts/production_awarded_invoice_import.py" in wrapper
+    assert 'release_root="/opt/iron-house-os-releases/$release_sha"' in wrapper
+    assert 'release_id != expected' in wrapper
+    assert 'environment_file=/etc/iron-house-os/production.env' in wrapper
+    assert "env -i" in wrapper
+    assert (
+        "/opt/iron-house-os-actions-runner/_work/_temp" in wrapper
+    )
+ in backup
+    assert "10#$backup_lock_wait_seconds > 600" in backup
+    assert 'flock --wait "$backup_lock_wait_seconds" 9' in backup
+    assert "IHOS_BACKUP_LOCK_WAIT_SECONDS must be an integer from 0 to 600." in backup
+    assert "after waiting ${backup_lock_wait_seconds}s" in backup
+
+
+def test_cutover_waits_for_post_cutover_backup_only() -> None:
+    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
+
+    pre_start = cutover.index("IHOS_BACKUP_NAME=\"pre-cutover-$stamp\"")
+    maintenance_start = cutover.index("gateway_config=")
+    post_start = cutover.index("IHOS_BACKUP_NAME=\"post-cutover-$stamp\"")
+    wrappers_start = cutover.index("install_production_business_import_wrapper", post_start)
+
+    pre_backup = cutover[pre_start:maintenance_start]
+    post_backup = cutover[post_start:wrappers_start]
+
+    assert "IHOS_BACKUP_LOCK_WAIT_SECONDS" not in pre_backup
+    assert "IHOS_BACKUP_LOCK_WAIT_SECONDS=300" in post_backup
+    assert "scripts/scheduled_backup.sh" in post_backup
+
+
 def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:
     workflow = (ROOT / ".github/workflows/production-deploy.yml").read_text()
 

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -132,69 +132,7 @@ def test_scheduled_backup_supports_only_a_bounded_lock_wait() -> None:
     backup = (ROOT / "scripts/scheduled_backup.sh").read_text()
 
     assert "backup_lock_wait_seconds=${IHOS_BACKUP_LOCK_WAIT_SECONDS:-0}" in backup
-    assert '"$backup_lock_wait_seconds" =~ ^[0-9]+    workflow = (ROOT / ".github/workflows/production-deploy.yml").read_text()
-
-    checkout_pin = (
-        "actions/checkout@11d5960a326750d5838078e36cf38b85af677262"
-    )
-
-    assert workflow.count(checkout_pin) == 3
-    assert "actions/checkout@v4" not in workflow
-    assert "persist-credentials: false" in workflow
-    assert "Verify public production endpoints and release identity" in workflow
-    assert 'release_id = payload.get("checks", {}).get("release_id")' in workflow
-    assert "release_id != expected" in workflow
-    assert workflow.count("--connect-timeout 5 --max-time 30") == 3
-
-
-def test_awarded_invoice_import_is_manual_and_exact_release_only() -> None:
-    workflow = (
-        ROOT / ".github/workflows/production-awarded-invoice-import.yml"
-    ).read_text()
-
-    assert "  push:" not in workflow
-    assert "workflow_dispatch:" in workflow
-    assert "release_sha:" in workflow
-    assert "github.event_name == 'workflow_dispatch'" in workflow
-    assert "needs: validate" in workflow
-    assert "ref: ${{ inputs.release_sha }}" in workflow
-    assert '[[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]' in workflow
-    assert '[[ "$(git rev-parse HEAD)" == "$RELEASE_SHA" ]]' in workflow
-    assert 'git merge-base --is-ancestor "$RELEASE_SHA" origin/main' in workflow
-    assert "/etc/iron-house-os/production.env" not in workflow
-    assert (
-        "sudo -n /usr/local/sbin/ihos-production-awarded-invoice-import"
-        in workflow
-    )
-
-
-def test_cutover_installs_restricted_awarded_invoice_import_wrapper() -> None:
-    cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
-    wrapper = (
-        ROOT / "ops/digitalocean/production-awarded-invoice-import-wrapper.sh"
-    ).read_text()
-
-    assert "install_production_awarded_invoice_import_wrapper" in cutover
-    assert (
-        "wrapper_target=/usr/local/sbin/ihos-production-awarded-invoice-import"
-        in cutover
-    )
-    assert (
-        "sudoers_target=/etc/sudoers.d/iron-house-os-production-awarded-invoice-import"
-        in cutover
-    )
-    assert "if ((EUID != 0))" in wrapper
-    assert 'hostname)" != "iron-house-os-prod-1"' in wrapper
-    assert "ops/production-awarded-invoice-imports/" in wrapper
-    assert "ops/scripts/production_awarded_invoice_import.py" in wrapper
-    assert 'release_root="/opt/iron-house-os-releases/$release_sha"' in wrapper
-    assert 'release_id != expected' in wrapper
-    assert 'environment_file=/etc/iron-house-os/production.env' in wrapper
-    assert "env -i" in wrapper
-    assert (
-        "/opt/iron-house-os-actions-runner/_work/_temp" in wrapper
-    )
- in backup
+    assert '"$backup_lock_wait_seconds" =~ ^[0-9]+$' in backup
     assert "10#$backup_lock_wait_seconds > 600" in backup
     assert 'flock --wait "$backup_lock_wait_seconds" 9' in backup
     assert "IHOS_BACKUP_LOCK_WAIT_SECONDS must be an integer from 0 to 600." in backup


### PR DESCRIPTION
Closes #328

## Summary
- keep scheduled backups nonblocking by default
- add a validated backup-lock wait option bounded to 0–600 seconds
- make only the mandatory post-cutover recovery backup wait up to 300 seconds
- fail closed if the lock remains occupied
- add regression coverage and operations documentation

## Production incident
Deploy #57, run `32904283495`, completed clean stack recreation, exact loopback readiness, live gateway activation, and authenticated full public smoke for `07f97b93929260fa45b341b90f7c48f03a2bb86e`. It failed when its post-cutover backup overlapped another backup, so the final public workflow verification was skipped. This PR does not claim or alter production state.

## Tests
- CI #984, run `32905036923`: **success**
- Release Readiness #466, run `32905036995`: **success**
- Production-deploy PR policy validation #59, run `32905036938`: **success**
- focused regression coverage verifies the default zero wait, 600-second validation bound, lock wait command, post-cutover-only 300-second wait, and mandatory backup invocation

## Security and production gates
- the mandatory post-cutover backup is preserved
- no backup contents, retention policy, volumes, secrets, data, DNS, certificates, or protected environments are weakened
- timeout remains a hard deployment failure
- no production deployment or direct host action occurs in this PR

## Rollback
Revert this PR to restore immediate nonblocking lock acquisition for all backup callers.