### PR TITLE
Wait safely for both cutover backup locks

### DIFF
--- a/docs/operations/production-deploy-agent.md
+++ b/docs/operations/production-deploy-agent.md
@@ -17,9 +17,9 @@ DigitalOcean web console.
   clean recreation of that pinned Compose project. It removes service containers
   and orphans without removing named volumes, retries transient stale-container
   cleanup once, and then fails closed with Compose diagnostics.
-- Scheduled backups remain nonblocking by default. The mandatory post-cutover
-  recovery backup is the only cutover call that waits for an overlapping backup,
-  with a five-minute maximum; timeout remains a deployment failure.
+- Scheduled backups remain nonblocking by default. Both mandatory cutover
+  recovery backups wait for an overlapping backup, with a five-minute maximum;
+  timeout remains a deployment failure before or after cutover.
 - The runner account has passwordless sudo access only to the validated
   production deployment wrapper.
 - Before cutover, the workflow verifies that the installed wrapper is owned by

--- a/ops/digitalocean/cutover.sh
+++ b/ops/digitalocean/cutover.sh
@@ -188,6 +188,7 @@ if not ports or any(port.get("host_ip") != "127.0.0.1" for port in ports):
 stamp=$(date -u +%Y%m%dT%H%M%SZ)
 IHOS_BACKUP_ROOT=/var/backups/iron-house-os \
 IHOS_BACKUP_NAME="pre-cutover-$stamp" \
+IHOS_BACKUP_LOCK_WAIT_SECONDS=300 \
 scripts/scheduled_backup.sh
 certbot certonly \
   --webroot \

--- a/tests/backend/test_live_cutover_config.py
+++ b/tests/backend/test_live_cutover_config.py
@@ -139,7 +139,7 @@ def test_scheduled_backup_supports_only_a_bounded_lock_wait() -> None:
     assert "after waiting ${backup_lock_wait_seconds}s" in backup
 
 
-def test_cutover_waits_for_post_cutover_backup_only() -> None:
+def test_cutover_waits_for_both_mandatory_recovery_backups() -> None:
     cutover = (ROOT / "ops/digitalocean/cutover.sh").read_text()
 
     pre_start = cutover.index("IHOS_BACKUP_NAME=\"pre-cutover-$stamp\"")
@@ -150,9 +150,11 @@ def test_cutover_waits_for_post_cutover_backup_only() -> None:
     pre_backup = cutover[pre_start:maintenance_start]
     post_backup = cutover[post_start:wrappers_start]
 
-    assert "IHOS_BACKUP_LOCK_WAIT_SECONDS" not in pre_backup
+    assert "IHOS_BACKUP_LOCK_WAIT_SECONDS=300" in pre_backup
+    assert "scripts/scheduled_backup.sh" in pre_backup
     assert "IHOS_BACKUP_LOCK_WAIT_SECONDS=300" in post_backup
     assert "scripts/scheduled_backup.sh" in post_backup
+    assert cutover.count("IHOS_BACKUP_LOCK_WAIT_SECONDS=300") == 2
 
 
 def test_production_workflow_pins_actions_and_verifies_exact_release() -> None:


### PR DESCRIPTION
Closes #330

## Summary
- keep ordinary scheduled backups nonblocking by default
- make the mandatory pre-cutover backup wait up to 300 seconds, matching the existing post-cutover recovery backup
- preserve the validated 0–600 second bound and hard fail-closed timeout
- add regression coverage proving both cutover backups wait
- update production operations documentation

## Verified incident
Production deploy #61, run `32907338048`, stopped before maintenance or container changes because the pre-cutover backup overlapped another backup and used the default zero-second wait. Final public verification was skipped. This PR does not claim or alter production state.

## Tests
- CI #986, run `32907751822`: **success**
- Release Readiness #468, run `32907751778`, attempt 2: **success**
- Production-deploy PR policy validation #62, run `32907751809`: **success**
- focused regression proves both mandatory cutover backups use the bounded 300-second wait while the backup script default remains zero

The first Release Readiness attempt encountered an unrelated timing-sensitive MVP workflow frontend assertion. CI passed that frontend suite on the same commit, and the isolated Release Readiness retry passed every gate.

## Controls
No changes to backup contents, retention, named volumes, secrets, data, DNS, certificates, or the protected production approval boundary. Another production attempt requires merge, post-merge CI and Release Readiness evidence, and Jeremie’s protected-environment approval.