### PR TITLE
Align documented job and PO number formats

### DIFF
--- a/Documentation/PURCHASE_ORDER_AND_RECEIPT_STANDARD.md
+++ b/Documentation/PURCHASE_ORDER_AND_RECEIPT_STANDARD.md
@@ -18,9 +18,17 @@ The employee, operator, foreman, cardholder, or other purchaser is responsible f
 
 ## PO format
 
-IHOS PO numbers contain the job number so accounting and receipt processing can identify the project automatically. Example:
+New IHOS PO numbers use `PO########-IHYYYYNNN`.
 
-`PO-000127-26-014`
+- `PO########` is the generated PO prefix and sequence.
+- `IHYYYYNNN` is the hyphen-free IHOS job number.
+- The PO number contains exactly one hyphen, separating the PO sequence from the job number.
+
+Example:
+
+`PO12345678-IH2026001`
+
+Existing legacy PO or job values remain read-compatible and are not rewritten automatically. External/source identifiers, including supplier invoice numbers, may retain their original punctuation.
 
 ## Exceptions
 

--- a/docs/customer-quote-to-job.md
+++ b/docs/customer-quote-to-job.md
@@ -11,7 +11,7 @@ Customer Quotes closes the gap between verbal customer information and the award
 3. Draft and sent quotes remain non-binding and have no job number.
 4. A generated IHOS PDF can be opened for review or delivery through an approved company communication method. Marking a quote sent records status only; IHOS does not send it automatically.
 5. Only an administrator or operations manager can use `Accept / award`. They must record the source of acceptance.
-6. In one database transaction, IHOS records acceptance, awards the linked project, allocates the permanent `IH-YYYY-NNN` job number, and provisions the Project Workspace and job-start checklist.
+6. In one database transaction, IHOS records acceptance, awards the linked project, allocates the permanent no-hyphen `IHYYYYNNN` job number, and provisions the Project Workspace and job-start checklist.
 7. Repeating the acceptance request returns the same job; it does not allocate another number.
 
 ## Controls
@@ -22,3 +22,4 @@ Customer Quotes closes the gap between verbal customer information and the award
 - Customer Quotes is available to management and estimators, but acceptance is management-only.
 - A draft, PDF, or sent status is not an award, contract acceptance, purchase order, or authorization to start work.
 - This workflow does not send email, alter production, or perform external submissions.
+- Preserved legacy IHOS job numbers and external source identifiers may retain their original punctuation; new IHOS job numbers do not.

--- a/docs/project-job-numbering.md
+++ b/docs/project-job-numbering.md
@@ -4,8 +4,9 @@ IHOS assigns a permanent job number when a project first becomes `awarded`.
 
 ## Number format
 
-- Default: `IH-YYYY-NNN`
-- Example: `IH-2026-001`
+- Canonical new format: `IHYYYYNNN`
+- Example: `IH2026001`
+- Newly generated IHOS job numbers contain no hyphens.
 - The three-digit sequence restarts for each award year using the Iron House BC business date and expands beyond three digits when required.
 
 ## Allocation rules
@@ -18,4 +19,4 @@ IHOS assigns a permanent job number when a project first becomes `awarded`.
 6. The database uniqueness constraint and allocation retry prevent two awarded projects from retaining the same number.
 7. After the permanent number is assigned, IHOS prepares one stable awarded-project workspace manifest using that number.
 
-Existing legacy projects are not renumbered automatically. Any controlled legacy cleanup must be reviewed separately before changing company records.
+Existing legacy projects are not renumbered automatically. IHOS may read preserved legacy values such as `IH-YYYY-NNN`, but it never generates that format for a new job. External or source identifiers, including customer invoice numbers, may retain their original punctuation. Any controlled legacy cleanup must be reviewed separately before changing company records.

--- a/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
+++ b/frontend/src/pages/PurchaseOrderRequestPage.test.tsx
@@ -105,6 +105,10 @@ describe("PurchaseOrderRequestPage", () => {
         job_number: "IH-2026-030",
       }),
     })));
+    const createdPo = vi.mocked(fieldOperationsApi.createRecord).mock.calls[0]?.[0] as { details?: Record<string, unknown> } | undefined;
+    const poNumber = String(createdPo?.details?.po_number ?? "");
+    expect(poNumber.match(/-/g)).toHaveLength(1);
+    expect(poNumber.split("-")[1]).toMatch(/^IH\d{7}$/);
     expect(await screen.findByText("Created PO12345678-IH2026030 and sent for approval.")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- documents canonical no-hyphen IHOS job numbers as `IHYYYYNNN`
- documents canonical PO numbers as `PO########-IHYYYYNNN` with exactly one hyphen
- preserves read compatibility for existing legacy company records and punctuation in external/source identifiers
- changes no runtime behavior, permissions, visual design, infrastructure, or production data

## Verification

- existing backend job-number allocation tests cover newly generated `IHYYYYNNN`
- existing Purchase Order Request test asserts `PO12345678-IH2026030` and a hyphen-free job code
- GitHub CI and Release Readiness required

Fixes #333