### PR TITLE
Harden recoverable release-smoke cleanup

### DIFF
--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -160,31 +160,47 @@ describe("ProjectWorkspacePage", () => {
     expect(screen.getByText("7")).toBeInTheDocument();
   });
 
-  it("filters projects by searchable fields and the smoke/test cleanup control", async () => {
+  it("filters only exact release-smoke records with matching SMOKE job numbers", async () => {
     const smokeProject: Project = {
       ...project,
       id: "33333333-3333-4333-8333-333333333333",
       name: "Release smoke 20260823-100046",
       project_number: "SMOKE-20260823-100046",
     };
-    mockProjectApiWithProjects([project, smokeProject]);
+    const legitimateSmokeProject: Project = {
+      ...project,
+      id: "44444444-4444-4444-8444-444444444444",
+      name: "Smoke Test Pump Station Upgrade",
+      project_number: "IH2026002",
+    };
+    const mismatchedReleaseSmoke: Project = {
+      ...project,
+      id: "55555555-5555-4555-8555-555555555555",
+      name: "Release smoke 20260823-131404",
+      project_number: "SMOKE-20260823-131405",
+    };
+    mockProjectApiWithProjects([project, smokeProject, legitimateSmokeProject, mismatchedReleaseSmoke]);
     const user = userEvent.setup();
     renderWorkspace("/projects");
 
     expect(await screen.findByText(project.name)).toBeInTheDocument();
     expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
+    expect(screen.getByText(legitimateSmokeProject.name)).toBeInTheDocument();
+    expect(screen.getByText(mismatchedReleaseSmoke.name)).toBeInTheDocument();
 
     await user.type(screen.getByRole("searchbox", { name: "Search projects" }), "100046");
     expect(screen.queryByText(project.name)).not.toBeInTheDocument();
     expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
 
     await user.clear(screen.getByRole("searchbox", { name: "Search projects" }));
-    await user.click(screen.getByRole("checkbox", { name: "Smoke/test projects only" }));
+    await user.click(screen.getByRole("checkbox", { name: "Release smoke projects only" }));
     expect(screen.queryByText(project.name)).not.toBeInTheDocument();
     expect(screen.getByText(smokeProject.name)).toBeInTheDocument();
+    expect(screen.queryByText(legitimateSmokeProject.name)).not.toBeInTheDocument();
+    expect(screen.queryByText(mismatchedReleaseSmoke.name)).not.toBeInTheDocument();
   });
 
-  it("moves only the filtered smoke/test projects to recoverable trash after confirmation", async () => {
+  it("moves only the filtered release smoke projects to recoverable trash after confirmation", async () => {
     const smokeProjects: Project[] = [
       { ...project, id: "33333333-3333-4333-8333-333333333333", name: "Release smoke 20260823-100046", project_number: "SMOKE-20260823-100046" },
       { ...project, id: "44444444-4444-4444-8444-444444444444", name: "Release smoke 20260823-131404", project_number: "SMOKE-20260823-131404" },
@@ -195,16 +211,73 @@ describe("ProjectWorkspacePage", () => {
     renderWorkspace("/projects");
 
     await screen.findByText(project.name);
-    await user.click(screen.getByRole("checkbox", { name: "Smoke/test projects only" }));
-    await user.click(screen.getByRole("button", { name: "Move 2 filtered smoke/test projects to Trash" }));
+    await user.click(screen.getByRole("checkbox", { name: "Release smoke projects only" }));
+    await user.click(screen.getByRole("button", { name: "Move 2 release smoke projects to Trash" }));
 
-    await screen.findByText("2 smoke/test projects moved to Trash. They can be restored by an administrator.");
+    await screen.findByText("2 release smoke projects moved to Trash. They can be restored by an administrator.");
     const deletes = fetchMock.mock.calls.filter(([, options]) => options?.method === "DELETE");
     expect(deletes).toHaveLength(2);
     expect(deletes.map(([, options]) => JSON.parse(String(options?.body)).confirmation_name)).toEqual(
       smokeProjects.map((item) => item.name),
     );
     expect(screen.queryByText(project.name)).not.toBeInTheDocument();
+  });
+
+  it("re-reads the active release-smoke set before confirmation so retries skip already-trashed records", async () => {
+    const staleSmokeProject: Project = {
+      ...project,
+      id: "33333333-3333-4333-8333-333333333333",
+      name: "Release smoke 20260823-100046",
+      project_number: "SMOKE-20260823-100046",
+    };
+    const currentSmokeProject: Project = {
+      ...project,
+      id: "44444444-4444-4444-8444-444444444444",
+      name: "Release smoke 20260823-131404",
+      project_number: "SMOKE-20260823-131404",
+    };
+    const fetchMock = mockProjectApiWithProjects([project, staleSmokeProject, currentSmokeProject], {
+      activeProjectsBeforeConfirmation: [project, currentSmokeProject],
+    });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWorkspace("/projects");
+
+    await screen.findByText(project.name);
+    await user.click(screen.getByRole("checkbox", { name: "Release smoke projects only" }));
+    expect(screen.getByRole("button", { name: "Move 2 release smoke projects to Trash" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Move 2 release smoke projects to Trash" }));
+
+    await screen.findByText("1 release smoke project moved to Trash. They can be restored by an administrator.");
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining("Move 1 filtered release smoke project"));
+    const deletes = fetchMock.mock.calls.filter(([, options]) => options?.method === "DELETE");
+    expect(deletes).toHaveLength(1);
+    expect(JSON.parse(String(deletes[0][1]?.body)).confirmation_name).toBe(currentSmokeProject.name);
+  });
+
+  it("preserves partial progress and the exact failing record after a cleanup request fails", async () => {
+    const smokeProjects: Project[] = [
+      { ...project, id: "33333333-3333-4333-8333-333333333333", name: "Release smoke 20260823-100046", project_number: "SMOKE-20260823-100046" },
+      { ...project, id: "44444444-4444-4444-8444-444444444444", name: "Release smoke 20260823-131404", project_number: "SMOKE-20260823-131404" },
+      { ...project, id: "55555555-5555-4555-8555-555555555555", name: "Release smoke 20260823-140000", project_number: "SMOKE-20260823-140000" },
+    ];
+    const fetchMock = mockProjectApiWithProjects([project, ...smokeProjects], { failDeleteAt: 2 });
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    const user = userEvent.setup();
+    renderWorkspace("/projects");
+
+    await screen.findByText(project.name);
+    await user.click(screen.getByRole("checkbox", { name: "Release smoke projects only" }));
+    await user.click(screen.getByRole("button", { name: "Move 3 release smoke projects to Trash" }));
+
+    expect(
+      await screen.findByText(
+        "1 release smoke project moved to Trash before cleanup stopped at Release smoke 20260823-131404 (SMOKE-20260823-131404). Request failed with 500",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Move 2 release smoke projects to Trash" })).toBeInTheDocument();
+    const deletes = fetchMock.mock.calls.filter(([, options]) => options?.method === "DELETE");
+    expect(deletes).toHaveLength(2);
   });
 
   it("creates an awarded project and delegates job-number generation to IHOS", async () => {
@@ -518,17 +591,30 @@ function mockProjectApi(
   return fetchMock;
 }
 
-function mockProjectApiWithProjects(initialProjects: Project[]) {
+function mockProjectApiWithProjects(
+  initialProjects: Project[],
+  mockOptions: { failDeleteAt?: number; activeProjectsBeforeConfirmation?: Project[] } = {},
+) {
   let projects = initialProjects;
-  const fetchMock = vi.fn(async (input: RequestInfo | URL, options?: RequestInit) => {
+  let deleteCalls = 0;
+  let listCalls = 0;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, requestOptions?: RequestInit) => {
     const url = input.toString();
-    if (options?.method === "DELETE") {
+    if (requestOptions?.method === "DELETE") {
+      deleteCalls += 1;
+      if (deleteCalls === mockOptions.failDeleteAt) return jsonResponse({ detail: "Cleanup failed" }, 500);
       const deleted = projects.find((item) => url.endsWith(`/projects/${item.id}`));
       if (!deleted) return jsonResponse({ detail: "Not found" }, 404);
       projects = projects.filter((item) => item.id !== deleted.id);
       return jsonResponse({ ...deleted, deleted_at: "2026-08-23T15:00:00Z" });
     }
-    if (url.endsWith("/projects")) return jsonResponse({ items: projects, total: projects.length });
+    if (url.endsWith("/projects")) {
+      listCalls += 1;
+      if (listCalls === 2 && mockOptions.activeProjectsBeforeConfirmation) {
+        projects = mockOptions.activeProjectsBeforeConfirmation;
+      }
+      return jsonResponse({ items: projects, total: projects.length });
+    }
     const dashboardProject = projects.find((item) => url.endsWith(`/projects/${item.id}/dashboard`));
     if (dashboardProject) return jsonResponse({ ...dashboard, project_id: dashboardProject.id });
     throw new Error(`Unhandled request: ${url}`);

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -31,6 +31,27 @@ const tabs = [
   "Activity",
 ];
 
+const releaseSmokeNamePattern = /^Release smoke (\d{8}-\d{6})$/;
+const releaseSmokeProjectNumberPattern = /^SMOKE-(\d{8}-\d{6})$/;
+
+function isReleaseSmokeProject(project: Project) {
+  const nameMatch = releaseSmokeNamePattern.exec(project.name);
+  const projectNumberMatch = releaseSmokeProjectNumberPattern.exec(project.project_number ?? "");
+  return Boolean(nameMatch && projectNumberMatch && nameMatch[1] === projectNumberMatch[1]);
+}
+
+function filterProjects(projects: Project[], normalizedSearch: string, releaseSmokeOnly: boolean) {
+  return projects.filter((project) => {
+    const searchable = [project.project_number, project.name, project.municipality, label(project.status)]
+      .filter(Boolean)
+      .join(" ")
+      .toLocaleLowerCase();
+    const matchesSearch = !normalizedSearch || searchable.includes(normalizedSearch);
+    const matchesReleaseSmoke = !releaseSmokeOnly || isReleaseSmokeProject(project);
+    return matchesSearch && matchesReleaseSmoke;
+  });
+}
+
 export function ProjectWorkspacePage() {
   const { projectId } = useParams();
   const navigate = useNavigate();
@@ -152,30 +173,48 @@ export function ProjectWorkspacePage() {
     await refresh();
   }
 
-  async function moveFilteredSmokeTestsToTrash(filteredProjects: Project[]) {
-    if (!isAdmin || bulkDeleting || filteredProjects.length === 0) return;
-    const confirmed = window.confirm(
-      `Move all ${filteredProjects.length} filtered smoke/test projects to recoverable Trash?\n\nNo other projects will be changed.`,
-    );
-    if (!confirmed) return;
+  async function moveFilteredReleaseSmokeProjectsToTrash() {
+    if (!isAdmin || bulkDeleting) return;
     setBulkDeleting(true);
     setBulkDeleteResult(null);
     setError(null);
     let moved = 0;
+    let failingProject: Project | null = null;
     try {
-      for (const project of filteredProjects) {
+      const currentList = await projectsApi.list(statusFilter, false);
+      const currentProjects = currentList.items.filter((project) => !project.deleted_at);
+      const currentCandidates = filterProjects(currentProjects, normalizedSearch, true);
+      setProjects(currentProjects);
+
+      if (currentCandidates.length === 0) {
+        setBulkDeleteResult("No active release smoke projects remain in the current filter.");
+        return;
+      }
+
+      const confirmed = window.confirm(
+        `Move ${currentCandidates.length} filtered release smoke ${currentCandidates.length === 1 ? "project" : "projects"} to recoverable Trash?\n\nOnly exact Release smoke records with matching SMOKE job numbers will be changed.`,
+      );
+      if (!confirmed) return;
+
+      for (const project of currentCandidates) {
+        failingProject = project;
         await projectsApi.delete(project.id, project.name);
         moved += 1;
       }
-      setBulkDeleteResult(`${moved} smoke/test projects moved to Trash. They can be restored by an administrator.`);
+      await refresh();
+      setBulkDeleteResult(
+        `${moved} release smoke ${moved === 1 ? "project" : "projects"} moved to Trash. They can be restored by an administrator.`,
+      );
     } catch (currentError) {
+      await refresh();
       setError(
-        `${moved} projects moved to Trash before cleanup stopped. ${
+        `${moved} release smoke ${moved === 1 ? "project" : "projects"} moved to Trash before cleanup stopped${
+          failingProject ? ` at ${failingProject.name} (${failingProject.project_number ?? "no project number"})` : ""
+        }. ${
           currentError instanceof Error ? currentError.message : "Unable to complete smoke/test cleanup."
         }`,
       );
     } finally {
-      await refresh();
       setBulkDeleting(false);
     }
   }
@@ -206,16 +245,7 @@ export function ProjectWorkspacePage() {
   }
 
   const normalizedSearch = searchFilter.trim().toLocaleLowerCase();
-  const smokeTestMarker = /(?:^|[^a-z0-9])(smoke|test)(?:[^a-z0-9]|$)/i;
-  const filteredProjects = projects.filter((project) => {
-    const searchable = [project.project_number, project.name, project.municipality, label(project.status)]
-      .filter(Boolean)
-      .join(" ")
-      .toLocaleLowerCase();
-    const matchesSearch = !normalizedSearch || searchable.includes(normalizedSearch);
-    const matchesSmokeTest = !smokeTestOnly || smokeTestMarker.test(`${project.project_number ?? ""} ${project.name}`);
-    return matchesSearch && matchesSmokeTest;
-  });
+  const filteredProjects = filterProjects(projects, normalizedSearch, smokeTestOnly);
 
   return (
     <section className="space-y-6">
@@ -269,13 +299,13 @@ export function ProjectWorkspacePage() {
             <button
               type="button"
               disabled={bulkDeleting}
-              onClick={() => void moveFilteredSmokeTestsToTrash(filteredProjects)}
+              onClick={() => void moveFilteredReleaseSmokeProjectsToTrash()}
               className="inline-flex min-h-11 items-center gap-2 rounded-md border border-red-200 bg-white px-3 py-2 text-sm font-semibold text-red-700 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Trash2 className="h-4 w-4" />
               {bulkDeleting
-                ? "Moving smoke/test projects to Trash..."
-                : `Move ${filteredProjects.length} filtered smoke/test projects to Trash`}
+                ? "Moving release smoke projects to Trash..."
+                : `Move ${filteredProjects.length} release smoke projects to Trash`}
             </button>
           ) : null}
           {isAdmin ? (
@@ -369,7 +399,7 @@ function ProjectFilters({
           onChange={(event) => onSmokeTestOnlyChange(event.target.checked)}
           className="h-4 w-4 rounded border-iron-200"
         />
-        Smoke/test projects only
+        Release smoke projects only
       </label>
     </div>
   );


### PR DESCRIPTION
Closes #305

## Summary
- replace the broad `smoke|test` marker with the exact release-smoke pair `Release smoke YYYYMMDD-HHMMSS` + `SMOKE-YYYYMMDD-HHMMSS`, requiring matching timestamps
- re-read the current active project set before confirmation so retries skip records already in recoverable Trash
- refresh the list before setting completion/failure notices so partial progress is not cleared
- show the exact failing project name, job number, completed count, and request error after an interrupted cleanup
- clarify the administrator control copy without changing the locked layout or styling

## Safety and production gates
- administrator-only visibility and action guard remain unchanged
- deletion remains sequential, exact-name confirmed, and recoverable through Trash
- legitimate projects containing the words `smoke` or `test` are excluded
- no backend endpoint, production data, deployment workflow, environment, credential, or infrastructure change
- this draft PR does not authorize a deployment or another production cleanup; exact inventory and Jeremie’s explicit confirmation remain required

## Validation
- `npm test -- --run src/pages/ProjectWorkspacePage.test.tsx` — 15/15 passed
- `./node_modules/.bin/tsc --noEmit` — passed
- `npm run build` — passed
- `npm test -- --run src/pages/MVPWorkflowPage.test.tsx` — 5/5 passed in isolation
- full `npm test` — 114/115 passed; the untouched `MVPWorkflowPage` bounded-summary timing assertion failed twice under the local parallel suite (2 fallbacks observed before the assertion instead of 5), while its isolated file passed
- `git diff --check` — passed

## Behaviour evidence
- focused tests prove exact-pattern filtering, legitimate-name exclusion, matched name/job timestamps, refreshed retry inventory, two-item successful cleanup, and HTTP 500 partial-progress preservation

## Risk and rollback
- risk is limited to the administrator project cleanup filter and status messaging
- rollback: revert commit `dc1e7516186d68f7fca22a9f21c321c4d7b72974`; any records already moved remain recoverable in Trash