### PR TITLE
Add role-aware Help Centre foundation

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { legacyOperatorTarget } from "./App";
+import { buildHelpPath } from "./components/AppLayout";
 import { workforceEntryRole } from "./contexts/AuthContext";
 import { modules } from "./modules";
 
@@ -15,5 +16,12 @@ describe("Iron House OS frontend scaffold", () => {
     expect(legacyOperatorTarget()).toBe("/employee-portal/operator");
     expect(legacyOperatorTarget("inspections")).toBe("/employee-portal/operator/inspections");
     expect(legacyOperatorTarget("schedule")).toBe("/employee-portal/schedule");
+  });
+
+  it("opens Help with the current page and active project context", () => {
+    expect(buildHelpPath("/estimating", "job-1", "Bennett Civil")).toBe(
+      "/help?from=%2Festimating&projectId=job-1&projectName=Bennett+Civil",
+    );
+    expect(buildHelpPath("/help", null, null)).toBe("/help");
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { LoginPage } from "./pages/LoginPage";
 import { IronHouseChatPage } from "./pages/IronHouseChatPage";
 import { MeetingMinutesPage } from "./pages/MeetingMinutesPage";
 import { GoogleCalendarPage } from "./pages/GoogleCalendarPage";
+import { HelpCenterPage } from "./pages/HelpCenterPage";
 import { PasswordRecoveryPage } from "./pages/PasswordRecoveryPage";
 import { ProjectOperationsPage } from "./pages/ProjectOperationsPage";
 import { ProjectScopedLauncherPage } from "./pages/ProjectScopedLauncherPage";
@@ -94,7 +95,7 @@ function AuthenticatedApp() {
     const root = isForeman ? "/foreman-portal" : "/employee-portal";
     const sections = isForeman ? ["time", "backups", "receipts", "schedule", "production", "loads", "forms", "safety", "milestones", "small-equipment", "records"] : ["time", "backups", "receipts", "journal", "schedule", "safety", "milestones", "small-equipment", "profile", "records"];
     const Page = isForeman ? ForemanPortalPage : EmployeePortalPage;
-    return <AppLayout><Routes><Route path={root} element={<Page />} /><Route path="/request-po" element={<PurchaseOrderRequestPage />} /><Route path={`${root}/request-po`} element={<PurchaseOrderRequestPage />} /><Route path="/backups" element={<BackupsPage />} /><Route path="/equipment/field/:equipmentId" element={<EquipmentFieldPage />} />{sections.map((section) => <Route key={section} path={`${root}/${section}`} element={<Page section={section} />} />)}{!isForeman ? <><Route path="/employee-portal/operator" element={<EmployeePortalPage section="operator" />} /><Route path="/employee-portal/operator/:operatorSection" element={<EmployeeOperatorRoute />} /><Route path="/operator" element={<LegacyOperatorRoute />} /><Route path="/operator/:section" element={<LegacyOperatorRoute />} /><Route path="/operator-portal" element={<LegacyOperatorRoute />} /><Route path="/operator-portal/:section" element={<LegacyOperatorRoute />} /></> : null}<Route path="*" element={<Navigate to={root} replace />} /></Routes></AppLayout>;
+    return <AppLayout><Routes><Route path={root} element={<Page />} /><Route path="/help" element={<HelpCenterPage />} /><Route path="/request-po" element={<PurchaseOrderRequestPage />} /><Route path={`${root}/request-po`} element={<PurchaseOrderRequestPage />} /><Route path="/backups" element={<BackupsPage />} /><Route path="/equipment/field/:equipmentId" element={<EquipmentFieldPage />} />{sections.map((section) => <Route key={section} path={`${root}/${section}`} element={<Page section={section} />} />)}{!isForeman ? <><Route path="/employee-portal/operator" element={<EmployeePortalPage section="operator" />} /><Route path="/employee-portal/operator/:operatorSection" element={<EmployeeOperatorRoute />} /><Route path="/operator" element={<LegacyOperatorRoute />} /><Route path="/operator/:section" element={<LegacyOperatorRoute />} /><Route path="/operator-portal" element={<LegacyOperatorRoute />} /><Route path="/operator-portal/:section" element={<LegacyOperatorRoute />} /></> : null}<Route path="*" element={<Navigate to={root} replace />} /></Routes></AppLayout>;
   }
 
   return (
@@ -102,6 +103,7 @@ function AuthenticatedApp() {
       <Routes>
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/help" element={<HelpCenterPage />} />
         <Route path="/request-po" element={<PurchaseOrderRequestPage />} />
         <Route path="/backups" element={<BackupsPage />} />
         <Route path="/employee-portal" element={<EmployeePortalPage />} />

--- a/frontend/src/components/AppLayout.test.tsx
+++ b/frontend/src/components/AppLayout.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { AppLayout } from "./AppLayout";
+
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { display_name: "Operations User", role: "operations_manager" },
+    portalRole: "management",
+    logout: vi.fn(),
+  }),
+}));
+
+describe("AppLayout Help access", () => {
+  it("keeps Help one tap away and carries the current page and project", () => {
+    render(
+      <MemoryRouter initialEntries={["/estimating?projectId=job-1&projectName=Bennett"]}>
+        <AppLayout><div>Current page</div></AppLayout>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Open Help Centre" })).toHaveAttribute(
+      "href",
+      "/help?from=%2Festimating&projectId=job-1&projectName=Bennett",
+    );
+  });
+});

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { LogOut, Menu, ShoppingCart } from "lucide-react";
+import { CircleHelp, LogOut, Menu, ShoppingCart } from "lucide-react";
 import { PropsWithChildren, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 
@@ -6,11 +6,21 @@ import { modules } from "../modules";
 import { useAuth } from "../contexts/AuthContext";
 import { modulePathWithProjectContext, readEffectiveProjectContext } from "../utils/projectContext";
 
+export function buildHelpPath(pathname: string, projectId: string | null, projectName: string | null): string {
+  const params = new URLSearchParams();
+  if (pathname !== "/help") params.set("from", pathname);
+  if (projectId) params.set("projectId", projectId);
+  if (projectName) params.set("projectName", projectName);
+  const search = params.toString();
+  return search ? `/help?${search}` : "/help";
+}
+
 export function AppLayout({ children }: PropsWithChildren) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { user, portalRole, logout } = useAuth();
   const location = useLocation();
   const activeProject = readEffectiveProjectContext(location.search);
+  const helpPath = buildHelpPath(location.pathname, activeProject.projectId, activeProject.projectName);
   const accessLabel =
     user?.role === "viewer"
       ? "Read-only access"
@@ -85,6 +95,15 @@ export function AppLayout({ children }: PropsWithChildren) {
           <div className="hidden text-sm font-medium text-iron-700 lg:block">{user ? `Signed in as ${user.display_name}` : "Signed out"}</div>
           <div className="flex items-center gap-3">
             <div className="hidden text-xs font-medium text-iron-500 sm:block">{accessLabel}</div>
+            <NavLink
+              to={helpPath}
+              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-brand-gold/50 px-3 text-sm font-semibold text-iron-800 transition hover:bg-brand-gold/10"
+              aria-label="Open Help Centre"
+              title="Help Centre"
+            >
+              <CircleHelp className="h-5 w-5" aria-hidden="true" />
+              <span className="hidden sm:inline">Help</span>
+            </NavLink>
             <div className="rounded-md bg-brand-gold px-3 py-1 text-xs font-semibold capitalize text-brand-black">{user?.role.replace("_", " ")}</div>
             <button type="button" onClick={() => void logout()} className="rounded-md border border-iron-100 p-2 text-iron-700 transition hover:border-brand-gold hover:bg-brand-gold/10" aria-label="Sign out" title="Sign out">
               <LogOut className="h-4 w-4" />

--- a/frontend/src/helpArticles.test.ts
+++ b/frontend/src/helpArticles.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contextualHelpArticle,
+  helpArticlesForUser,
+  searchHelpArticles,
+} from "./helpArticles";
+import { modules } from "./modules";
+
+describe("role-aware help registry", () => {
+  it("keeps every guide short enough for field use", () => {
+    const articles = helpArticlesForUser("operations_manager", "management");
+    expect(articles.every((article) => article.steps.length > 0 && article.steps.length <= 5)).toBe(true);
+  });
+
+  it("covers every module shown in the management navigation", () => {
+    const articles = helpArticlesForUser("operations_manager", "management");
+    for (const module of modules) {
+      expect(articles.some((article) => article.kind === "module" && article.path === module.path)).toBe(true);
+    }
+  });
+
+  it("shows employees field instructions without management-only modules", () => {
+    const articles = helpArticlesForUser("viewer", "employee");
+    expect(articles.some((article) => article.id === "employee-enter-time")).toBe(true);
+    expect(articles.some((article) => article.id === "field-complete-flha")).toBe(true);
+    expect(articles.some((article) => article.path === "/finance")).toBe(false);
+    expect(articles.some((article) => article.id === "management-verbal-quote")).toBe(false);
+  });
+
+  it("gives foremen crew guidance without employee-only time guidance", () => {
+    const articles = helpArticlesForUser("viewer", "foreman");
+    expect(articles.some((article) => article.id === "foreman-crew-time")).toBe(true);
+    expect(articles.some((article) => article.id === "foreman-record-production")).toBe(true);
+    expect(articles.some((article) => article.id === "employee-enter-time")).toBe(false);
+  });
+
+  it("selects the most specific guide for the page the user came from", () => {
+    const articles = helpArticlesForUser("viewer", "employee");
+    expect(contextualHelpArticle("/employee-portal/receipts", articles)?.id).toBe("employee-submit-receipt");
+    expect(contextualHelpArticle("/employee-portal", articles)?.id).toBe("module-employee-portal-workforce");
+  });
+
+  it.each([
+    ["PO", "field-request-po"],
+    ["FLHA", "field-complete-flha"],
+    ["receipt reimbursement", "employee-submit-receipt"],
+    ["small equipment damage", "field-inspect-equipment"],
+  ])("finds common field language: %s", (query, expectedId) => {
+    const articles = helpArticlesForUser("viewer", "employee");
+    expect(searchHelpArticles(articles, query).some((article) => article.id === expectedId)).toBe(true);
+  });
+});

--- a/frontend/src/helpArticles.ts
+++ b/frontend/src/helpArticles.ts
@@ -1,0 +1,433 @@
+import type { AuthUser } from "./api/auth";
+import type { PortalRole } from "./contexts/AuthContext";
+import { modules } from "./modules";
+
+export type HelpAudience = AuthUser["role"];
+
+export type HelpArticle = {
+  id: string;
+  title: string;
+  task: string;
+  summary: string;
+  path: string;
+  contextPaths: string[];
+  roles: HelpAudience[];
+  portalRoles?: Array<"employee" | "foreman">;
+  keywords: string[];
+  steps: string[];
+  expectedResult: string;
+  approvalNote?: string;
+  featured?: boolean;
+  kind: "task" | "module";
+};
+
+const managementRoles: HelpAudience[] = ["admin", "operations_manager", "estimator"];
+const operationsRoles: HelpAudience[] = ["admin", "operations_manager"];
+
+const taskArticles: HelpArticle[] = [
+  {
+    id: "employee-enter-time",
+    title: "Enter my time",
+    task: "Record the hours I worked",
+    summary: "Add your hours to the correct day and job, then review them before saving.",
+    path: "/employee-portal/time",
+    contextPaths: ["/employee-portal/time"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["employee"],
+    keywords: ["time", "hours", "timesheet", "shift", "job"],
+    steps: [
+      "Open Time in the Employee Portal.",
+      "Choose the work date and the correct project.",
+      "Enter your hours and the work details requested on the page.",
+      "Review the date, project and total hours.",
+      "Save or submit the entry.",
+    ],
+    expectedResult: "Your time entry is saved for supervisor or management review.",
+    approvalNote: "A saved entry is not the same as payroll approval.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "employee-submit-receipt",
+    title: "Submit a receipt",
+    task: "Send a purchase receipt to Financial Control",
+    summary: "Upload a clear photo, check the extracted details and submit it for review.",
+    path: "/employee-portal/receipts",
+    contextPaths: ["/employee-portal/receipts", "/foreman-portal/receipts"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["employee", "foreman"],
+    keywords: ["receipt", "expense", "reimbursement", "company card", "photo"],
+    steps: [
+      "Open Receipts in your portal.",
+      "Take or select a clear photo of every receipt page.",
+      "Check the vendor, date, payment method, taxes and total.",
+      "Add the project or coding details you know.",
+      "Submit the receipt for review.",
+    ],
+    expectedResult: "The receipt is queued for Financial Control review; it is not posted automatically.",
+    approvalNote: "Financial Control reviews coding, totals and duplicates before approval or export.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "employee-check-schedule",
+    title: "Check my schedule",
+    task: "See where and when I am scheduled",
+    summary: "Open the schedule assigned to your portal and review the job details.",
+    path: "/employee-portal/schedule",
+    contextPaths: ["/employee-portal/schedule", "/foreman-portal/schedule"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["employee", "foreman"],
+    keywords: ["schedule", "shift", "crew", "tomorrow", "where", "when"],
+    steps: [
+      "Open Schedule in your portal.",
+      "Find the correct date.",
+      "Review the project, start information and notes.",
+      "Contact your supervisor if anything is missing or incorrect.",
+    ],
+    expectedResult: "You know the current assignment shown in Iron House OS.",
+    approvalNote: "If field instructions conflict with the schedule, confirm with your supervisor.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "field-complete-flha",
+    title: "Complete the daily FLHA",
+    task: "Record today’s tasks, hazards and controls",
+    summary: "Verify actual site conditions, review every control and post the FLHA to the job folder.",
+    path: "/employee-portal/safety",
+    contextPaths: ["/employee-portal/safety", "/foreman-portal/safety"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["employee", "foreman"],
+    keywords: ["flha", "safety", "hazard", "control", "assessment", "field level"],
+    steps: [
+      "Open Safety and select the correct project or job.",
+      "Complete the rapid hazard screening for actual site conditions.",
+      "Add each task, hazard, control and responsible person.",
+      "Resolve every critical-hazard blocker and review the emergency details.",
+      "Review the FLHA, then post it for crew acknowledgement and supervisor release.",
+    ],
+    expectedResult: "A versioned FLHA is saved in the job folder for acknowledgement and release.",
+    approvalNote: "Help or AI suggestions never declare work safe. Stop work and contact the supervisor whenever conditions are unsafe or unclear.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "field-request-po",
+    title: "Request a purchase order",
+    task: "Ask for approval before a purchase",
+    summary: "Send the purchase details to the designated approver and wait for the approved PO number.",
+    path: "/request-po",
+    contextPaths: ["/request-po", "/employee-portal/request-po", "/foreman-portal/request-po"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["employee", "foreman"],
+    keywords: ["po", "purchase order", "buy", "supplier", "approval", "material"],
+    steps: [
+      "Open Request PO.",
+      "Select the correct project and supplier when known.",
+      "Describe what is needed, the reason and the expected amount.",
+      "Review the request and submit it.",
+      "Wait for the approver’s decision and PO number before purchasing.",
+    ],
+    expectedResult: "A traceable PO request is sent for approval.",
+    approvalNote: "Submitting a request does not authorize a purchase.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "field-inspect-equipment",
+    title: "Inspect small equipment",
+    task: "Record an equipment condition before use",
+    summary: "Check the item, record its condition and flag anything unsafe or needing repair.",
+    path: "/employee-portal/small-equipment",
+    contextPaths: ["/employee-portal/small-equipment", "/foreman-portal/small-equipment", "/equipment/field"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["employee", "foreman"],
+    keywords: ["equipment", "inspection", "tool", "repair", "damage", "unsafe"],
+    steps: [
+      "Open Small Equipment and choose the employee and project.",
+      "Identify the equipment type and asset.",
+      "Check guards, controls, cords or hoses, leaks and damage.",
+      "Choose the condition and add clear comments or photos.",
+      "Review and submit the inspection.",
+    ],
+    expectedResult: "The condition is recorded and flagged items are visible to management.",
+    approvalNote: "Remove unsafe equipment from service and notify the supervisor immediately.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "foreman-crew-time",
+    title: "Enter crew time",
+    task: "Prepare the foreman daily timesheet",
+    summary: "Record crew hours against the correct project and review the daily sheet.",
+    path: "/foreman-portal/time",
+    contextPaths: ["/foreman-portal/time"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["foreman"],
+    keywords: ["crew time", "foreman", "daily timesheet", "hours", "labour"],
+    steps: [
+      "Open Time in the Foreman Portal.",
+      "Choose the work date and project.",
+      "Add each crew member and their hours.",
+      "Check the crew total and work details.",
+      "Save or submit the daily sheet for review.",
+    ],
+    expectedResult: "The daily crew timesheet is saved for management review.",
+    approvalNote: "Review does not replace payroll approval.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "foreman-record-production",
+    title: "Record daily production",
+    task: "Capture completed quantities and field progress",
+    summary: "Save the day’s production against the correct job with supporting notes or photos.",
+    path: "/foreman-portal/production",
+    contextPaths: ["/foreman-portal/production", "/foreman-portal/loads"],
+    roles: ["viewer", ...managementRoles],
+    portalRoles: ["foreman"],
+    keywords: ["production", "quantity", "loads", "progress", "foreman", "daily"],
+    steps: [
+      "Open Production or Loads in the Foreman Portal.",
+      "Select the correct date and project.",
+      "Enter the activity, quantity, unit and supporting details.",
+      "Attach clear evidence when it is available.",
+      "Review and save the record.",
+    ],
+    expectedResult: "A traceable daily production record is attached to the job.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "management-verbal-quote",
+    title: "Start a verbal quote",
+    task: "Turn a customer request into a controlled quote record",
+    summary: "Capture the customer, scope and assumptions before preparing or issuing a quote.",
+    path: "/customer-quotes",
+    contextPaths: ["/customer-quotes"],
+    roles: managementRoles,
+    keywords: ["verbal quote", "customer", "scope", "price", "acceptance", "award"],
+    steps: [
+      "Open Customer Quotes and start a new verbal quote.",
+      "Record the customer, contact, site and scope requested.",
+      "Add pricing, assumptions, exclusions and validity details.",
+      "Review the draft before it is issued.",
+      "Record customer acceptance only when evidence is available.",
+    ],
+    expectedResult: "A controlled quote record is ready for review, issue and eventual award handoff.",
+    approvalNote: "Quote acceptance and project award remain explicit management actions.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "management-create-project",
+    title: "Create or open a project",
+    task: "Set up the central project workspace",
+    summary: "Create the project once, then use its workspace to reach documents, RFQs, estimating and readiness.",
+    path: "/projects",
+    contextPaths: ["/projects", "/p"],
+    roles: managementRoles,
+    keywords: ["project", "job", "workspace", "awarded", "setup", "job number"],
+    steps: [
+      "Open Projects and search before creating a new record.",
+      "Open the existing project, or choose the correct stage for a new one.",
+      "Enter the required customer, name and project details.",
+      "Save the project and keep it selected as the active project.",
+      "Use the project workspace for the next task.",
+    ],
+    expectedResult: "One central project record is available to the connected OS functions.",
+    approvalNote: "Do not create a duplicate project when a matching job already exists.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "management-build-estimate",
+    title: "Build an estimate",
+    task: "Prepare production costs, markups and risk",
+    summary: "Build the estimate within the active project and review its assumptions before export.",
+    path: "/estimating",
+    contextPaths: ["/estimating"],
+    roles: managementRoles,
+    keywords: ["estimate", "cost", "markup", "production rate", "risk", "workbook"],
+    steps: [
+      "Open Estimating with the correct active project.",
+      "Add the work items, quantities, production rates and costs.",
+      "Add markups, risk and estimate notes.",
+      "Review the summary and unresolved assumptions.",
+      "Save the workspace or export the workbook for review.",
+    ],
+    expectedResult: "A saved, project-linked estimate is ready for internal review.",
+    approvalNote: "Exporting an estimate does not approve a bid or customer price.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "management-upload-document",
+    title: "Add a project document",
+    task: "Store a drawing, specification, addendum or other file",
+    summary: "Upload the source file once, label it clearly and keep its revision traceable.",
+    path: "/document-operations",
+    contextPaths: ["/document-operations", "/documents"],
+    roles: managementRoles,
+    keywords: ["document", "upload", "drawing", "specification", "addendum", "revision", "file"],
+    steps: [
+      "Open Document Operations with the correct active project.",
+      "Choose the file and the correct document type.",
+      "Enter a clear title, date and revision information.",
+      "Review the project and metadata.",
+      "Upload the document and confirm it appears in the project record.",
+    ],
+    expectedResult: "A traceable project document is available to connected workflows.",
+    approvalNote: "Preserve source documents; do not replace an old revision without recording the new one.",
+    featured: true,
+    kind: "task",
+  },
+  {
+    id: "management-build-rfq",
+    title: "Build an RFQ package",
+    task: "Prepare supplier pricing requests",
+    summary: "Select suppliers and controlled project documents, then review package readiness.",
+    path: "/rfq-builder",
+    contextPaths: ["/rfq-builder", "/rfq-automation", "/bid-package"],
+    roles: managementRoles,
+    keywords: ["rfq", "supplier", "quote", "package", "attachments", "bid"],
+    steps: [
+      "Open RFQ Builder with the correct active project.",
+      "Define the requested scope and response date.",
+      "Select the intended suppliers.",
+      "Add only the correct controlled documents and revisions.",
+      "Resolve readiness warnings before issuing anything.",
+    ],
+    expectedResult: "A project-linked RFQ package is ready for controlled review or issue.",
+    approvalNote: "Readiness does not authorize sending or committing the company.",
+    kind: "task",
+  },
+  {
+    id: "operations-onboard-employee",
+    title: "Onboard a new employee",
+    task: "Create, review and activate a new-hire record",
+    summary: "Use the controlled invitation and review process; restricted information stays restricted.",
+    path: "/employee-onboarding",
+    contextPaths: ["/employee-onboarding", "/worker-orientations"],
+    roles: operationsRoles,
+    keywords: ["employee", "onboarding", "new hire", "invitation", "orientation", "activate"],
+    steps: [
+      "Open Employee Onboarding and create the new-hire record.",
+      "Generate and deliver the secure invitation.",
+      "Review the returned package and request corrections if needed.",
+      "Approve the package and complete required orientation evidence.",
+      "Activate access only after deployment readiness passes.",
+    ],
+    expectedResult: "The employee has a reviewed onboarding record and appropriately controlled OS access.",
+    approvalNote: "Activation is a management-controlled action; invitation completion alone is not approval.",
+    kind: "task",
+  },
+];
+
+const moduleArticles: HelpArticle[] = modules.map((module) => ({
+  id: `module-${module.path.slice(1).replaceAll("/", "-") || "home"}`,
+  title: module.label,
+  task: `Learn what ${module.label} is for`,
+  summary: module.description,
+  path: module.path,
+  contextPaths: [module.path],
+  roles: managementRoles,
+  keywords: [module.label, module.description, "module", "page"],
+  steps: [
+    `Open ${module.label} from the main menu.`,
+    "Confirm you are working in the correct project when a project is shown.",
+    "Read the page heading and any status or readiness message.",
+    "Use the task controls available for your role.",
+    "Return to Help before continuing if the result or approval is unclear.",
+  ],
+  expectedResult: `You can identify the purpose and current status of ${module.label}.`,
+  kind: "module" as const,
+}));
+
+const workforceModuleArticles: HelpArticle[] = [
+  {
+    id: "module-employee-portal-workforce",
+    title: "Employee Portal",
+    task: "Find employee field tasks",
+    summary: "Time, receipts, schedule, safety, equipment, records and personal details in one place.",
+    path: "/employee-portal",
+    contextPaths: ["/employee-portal"],
+    roles: ["viewer"],
+    portalRoles: ["employee"],
+    keywords: ["employee", "portal", "field", "home"],
+    steps: [
+      "Open Employee Portal from the menu.",
+      "Choose the task card that matches what you need to do.",
+      "Complete one workspace at a time.",
+      "Review the result message before leaving the page.",
+    ],
+    expectedResult: "You are in the correct employee workspace for the task.",
+    kind: "module",
+  },
+  {
+    id: "module-foreman-portal-workforce",
+    title: "Foreman Portal",
+    task: "Find crew and field-record tasks",
+    summary: "Crew time, production, loads, forms, safety, photos and records in one place.",
+    path: "/foreman-portal",
+    contextPaths: ["/foreman-portal"],
+    roles: ["viewer"],
+    portalRoles: ["foreman"],
+    keywords: ["foreman", "crew", "portal", "field", "home"],
+    steps: [
+      "Open Foreman Portal from the menu.",
+      "Choose the crew or field-record task you need.",
+      "Confirm the date and project before entering information.",
+      "Review the result message before leaving the page.",
+    ],
+    expectedResult: "You are in the correct foreman workspace for the task.",
+    kind: "module",
+  },
+];
+
+export const helpArticles: HelpArticle[] = [...taskArticles, ...moduleArticles, ...workforceModuleArticles];
+
+function normalizedPortalRole(portalRole: PortalRole): "employee" | "foreman" {
+  return portalRole === "foreman" ? "foreman" : "employee";
+}
+
+export function helpArticlesForUser(role: HelpAudience, portalRole: PortalRole): HelpArticle[] {
+  return helpArticles.filter((article) => {
+    if (!article.roles.includes(role)) return false;
+    if (role !== "viewer" || !article.portalRoles) return true;
+    return article.portalRoles.includes(normalizedPortalRole(portalRole));
+  });
+}
+
+function pathMatchLength(pathname: string, contextPath: string): number {
+  if (pathname === contextPath || pathname.startsWith(`${contextPath}/`)) return contextPath.length;
+  return -1;
+}
+
+export function contextualHelpArticle(pathname: string, articles: HelpArticle[]): HelpArticle | null {
+  if (!pathname) return null;
+  let best: { article: HelpArticle; length: number } | null = null;
+  for (const article of articles) {
+    for (const contextPath of article.contextPaths) {
+      const length = pathMatchLength(pathname, contextPath);
+      if (length > (best?.length ?? -1)) best = { article, length };
+    }
+  }
+  return best?.article ?? null;
+}
+
+function searchableText(article: HelpArticle): string {
+  return [article.title, article.task, article.summary, article.expectedResult, ...article.keywords, ...article.steps]
+    .join(" ")
+    .toLowerCase();
+}
+
+export function searchHelpArticles(articles: HelpArticle[], query: string): HelpArticle[] {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (!terms.length) return articles;
+  return articles.filter((article) => {
+    const text = searchableText(article);
+    return terms.every((term) => text.includes(term));
+  });
+}

--- a/frontend/src/pages/HelpCenterPage.test.tsx
+++ b/frontend/src/pages/HelpCenterPage.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { HelpCenterPage } from "./HelpCenterPage";
+
+const auth = vi.hoisted(() => ({ role: "viewer" as "viewer" | "operations_manager", portalRole: "employee" as "employee" | "foreman" | "management" }));
+
+vi.mock("../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { role: auth.role },
+    portalRole: auth.portalRole,
+  }),
+}));
+
+describe("Help Centre", () => {
+  it("shows page-specific, employee-safe guidance", () => {
+    auth.role = "viewer";
+    auth.portalRole = "employee";
+    render(
+      <MemoryRouter initialEntries={["/help?from=/employee-portal/time&projectId=job-1&projectName=Bennett"]}>
+        <HelpCenterPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "What do you need to do?" })).toBeInTheDocument();
+    expect(screen.getByText("Help with the page you were on")).toBeInTheDocument();
+    expect(screen.getAllByText("Enter my time").length).toBeGreaterThan(0);
+    expect(screen.getByText("Active project: Bennett")).toBeInTheDocument();
+    expect(screen.queryByText("Financial Control")).not.toBeInTheDocument();
+  });
+
+  it("searches with everyday terms", () => {
+    auth.role = "viewer";
+    auth.portalRole = "employee";
+    render(
+      <MemoryRouter initialEntries={["/help"]}>
+        <HelpCenterPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "What are you trying to do?" }), { target: { value: "FLHA" } });
+    expect(screen.getByRole("heading", { name: "Search results" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Complete the daily FLHA" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Enter my time" })).not.toBeInTheDocument();
+  });
+
+  it("makes module guides available to management", () => {
+    auth.role = "operations_manager";
+    auth.portalRole = "management";
+    render(
+      <MemoryRouter initialEntries={["/help"]}>
+        <HelpCenterPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "Financial Control" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Customer Quotes" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/HelpCenterPage.tsx
+++ b/frontend/src/pages/HelpCenterPage.tsx
@@ -1,0 +1,200 @@
+import { ArrowUpRight, CheckCircle2, CircleHelp, Search, ShieldCheck } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+
+import { useAuth } from "../contexts/AuthContext";
+import {
+  contextualHelpArticle,
+  helpArticlesForUser,
+  searchHelpArticles,
+  type HelpArticle,
+} from "../helpArticles";
+import { modulePathWithProjectContext, readEffectiveProjectContext } from "../utils/projectContext";
+
+function ArticleInstructions({ article }: { article: HelpArticle }) {
+  return (
+    <div className="mt-4 border-t border-iron-100 pt-4">
+      <ol className="space-y-3">
+        {article.steps.map((step, index) => (
+          <li key={step} className="flex gap-3 text-sm leading-6 text-iron-700">
+            <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-brand-gold font-semibold text-brand-black">
+              {index + 1}
+            </span>
+            <span>{step}</span>
+          </li>
+        ))}
+      </ol>
+      <div className="mt-4 rounded-lg bg-emerald-50 p-3 text-sm leading-6 text-emerald-900">
+        <CheckCircle2 className="mr-2 inline h-4 w-4" aria-hidden="true" />
+        <strong>What happens next:</strong> {article.expectedResult}
+      </div>
+      {article.approvalNote ? (
+        <div className="mt-3 rounded-lg bg-amber-50 p-3 text-sm leading-6 text-amber-950">
+          <ShieldCheck className="mr-2 inline h-4 w-4" aria-hidden="true" />
+          <strong>Important:</strong> {article.approvalNote}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ArticleCard({ article, destination }: { article: HelpArticle; destination: string }) {
+  return (
+    <article className="rounded-xl border border-iron-100 bg-white p-4 shadow-sm sm:p-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">
+            {article.kind === "task" ? "How to" : "Module guide"}
+          </div>
+          <h3 className="mt-1 text-lg font-semibold text-iron-950">{article.title}</h3>
+          <p className="mt-2 text-sm leading-6 text-iron-600">{article.summary}</p>
+        </div>
+        <Link
+          to={destination}
+          className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-md border border-brand-gold px-4 text-sm font-semibold text-iron-900 transition hover:bg-brand-gold/10"
+        >
+          Open page <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+        </Link>
+      </div>
+      <details className="group mt-4">
+        <summary className="flex min-h-11 cursor-pointer list-none items-center rounded-md bg-iron-50 px-4 text-sm font-semibold text-iron-900 transition hover:bg-brand-gold/10">
+          <span className="group-open:hidden">Show simple instructions</span>
+          <span className="hidden group-open:inline">Hide instructions</span>
+        </summary>
+        <ArticleInstructions article={article} />
+      </details>
+    </article>
+  );
+}
+
+export function HelpCenterPage() {
+  const { user, portalRole } = useAuth();
+  const location = useLocation();
+  const [query, setQuery] = useState("");
+  const projectContext = readEffectiveProjectContext(location.search);
+  const sourcePath = new URLSearchParams(location.search).get("from") ?? "";
+  const articles = useMemo(
+    () => (user ? helpArticlesForUser(user.role, portalRole) : []),
+    [portalRole, user],
+  );
+  const contextArticle = useMemo(
+    () => contextualHelpArticle(sourcePath, articles),
+    [articles, sourcePath],
+  );
+  const results = useMemo(() => searchHelpArticles(articles, query), [articles, query]);
+  const featured = articles.filter((article) => article.featured).slice(0, 6);
+  const projectName = projectContext.projectName;
+
+  return (
+    <div className="space-y-6">
+      <section className="ihos-brand-surface overflow-hidden rounded-xl border border-brand-gold/30 px-5 py-6 text-white shadow-brand sm:px-7">
+        <div className="flex items-start gap-4">
+          <div className="grid h-12 w-12 shrink-0 place-items-center rounded-xl border border-brand-gold/40 bg-white/10 text-brand-gold">
+            <CircleHelp className="h-7 w-7" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-gold">Iron House Help</div>
+            <h1 className="mt-2 text-3xl font-semibold text-brand-silver">What do you need to do?</h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-100">
+              Find simple, role-appropriate instructions. Each guide explains the steps, the result and whether another person must approve it.
+            </p>
+            {projectName ? (
+              <div className="mt-3 inline-flex rounded-full border border-brand-gold/40 bg-white/10 px-3 py-1 text-xs font-semibold text-brand-silver">
+                Active project: {projectName}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      {contextArticle ? (
+        <section className="rounded-xl border-2 border-brand-gold bg-white p-4 shadow-sm sm:p-6" aria-labelledby="current-page-help">
+          <div className="text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">Help with the page you were on</div>
+          <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 id="current-page-help" className="text-xl font-semibold text-iron-950">{contextArticle.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-iron-600">{contextArticle.summary}</p>
+            </div>
+            <Link
+              to={modulePathWithProjectContext(contextArticle.path, projectContext)}
+              className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-md bg-brand-gold px-4 text-sm font-semibold text-brand-black transition hover:bg-brand-gold-light"
+            >
+              Return to task <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+          <ArticleInstructions article={contextArticle} />
+        </section>
+      ) : null}
+
+      <section className="rounded-xl border border-iron-100 bg-white p-4 shadow-sm sm:p-6" aria-labelledby="help-search-heading">
+        <h2 id="help-search-heading" className="text-xl font-semibold text-iron-950">Search Help</h2>
+        <p className="mt-1 text-sm text-iron-500">Use everyday words such as “time,” “receipt,” “FLHA,” “PO,” “quote” or “equipment.”</p>
+        <label className="relative mt-4 block">
+          <span className="sr-only">What are you trying to do?</span>
+          <Search className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-iron-400" aria-hidden="true" />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="What are you trying to do?"
+            className="min-h-12 w-full rounded-lg border border-iron-200 bg-iron-50 py-3 pl-12 pr-4 text-base text-iron-950 outline-none transition placeholder:text-iron-400 focus:border-brand-gold focus:ring-2 focus:ring-brand-gold/30"
+          />
+        </label>
+      </section>
+
+      {!query && featured.length ? (
+        <section aria-labelledby="quick-start-heading">
+          <h2 id="quick-start-heading" className="text-xl font-semibold text-iron-950">Common tasks</h2>
+          <p className="mt-1 text-sm text-iron-500">Choose what you are trying to do.</p>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {featured.map((article) => (
+              <button
+                key={article.id}
+                type="button"
+                onClick={() => setQuery(article.title)}
+                className="min-h-20 rounded-xl border border-brand-gold/40 bg-white p-4 text-left shadow-sm transition hover:border-brand-gold hover:bg-brand-gold/10"
+              >
+                <span className="font-semibold text-iron-950">{article.title}</span>
+                <span className="mt-1 block text-sm text-iron-500">{article.task}</span>
+              </button>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section aria-live="polite" aria-labelledby="help-results-heading">
+        <div className="flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <h2 id="help-results-heading" className="text-xl font-semibold text-iron-950">
+              {query ? "Search results" : "All instructions"}
+            </h2>
+            <p className="mt-1 text-sm text-iron-500">
+              {results.length} {results.length === 1 ? "guide" : "guides"} available for your access level.
+            </p>
+          </div>
+          {query ? (
+            <button type="button" onClick={() => setQuery("")} className="min-h-11 rounded-md px-3 text-sm font-semibold text-iron-700 underline">
+              Clear search
+            </button>
+          ) : null}
+        </div>
+        {results.length ? (
+          <div className="mt-4 grid gap-4 lg:grid-cols-2">
+            {results.map((article) => (
+              <ArticleCard
+                key={article.id}
+                article={article}
+                destination={modulePathWithProjectContext(article.path, projectContext)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 rounded-xl border border-dashed border-iron-200 bg-white p-6 text-center">
+            <div className="font-semibold text-iron-950">No guide matched those words.</div>
+            <p className="mt-2 text-sm text-iron-500">Try a shorter search or ask your supervisor. Help does not replace a required approval.</p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/visual-design-lock.json
+++ b/frontend/visual-design-lock.json
@@ -1,7 +1,7 @@
 {
   "approved_by": "Jeremie Peters",
-  "baseline_commit": "c24ecec8f7ee7f4b25e4a926759a933cc80000c2",
-  "baseline_date": "2026-08-07",
+  "baseline_commit": "00e9bad73463acc706bba0fb444098ff3842ea85",
+  "baseline_date": "2026-08-26",
   "files": {
     "frontend/public/apple-touch-icon.png": "61238cf4edb72a94ae0bdb0c762db8aaf5bf0e022fc521db8edea033080951de",
     "frontend/public/favicon-32x32.png": "c7c83909f9026f4910f05406fe7d9404904b3dedb81f09aa836b4a909e938423",
@@ -15,7 +15,7 @@
     "frontend/src/pages/LoginPage.tsx": "8cc96693579ea7e18e3fa34b456f259ad47b8479230df8c04bf7de50e3b510fe",
     "frontend/src/styles.css": "d0ed7ee59b1690db07d4d70193cfbf1f3f80d6a5084edfedad786817de4ce58d",
     "frontend/tailwind.config.ts": "3c9eae349df550797ad4590c8cfc905e031639f3eadf883844d4386d037be7e2",
-    "frontend/src/components/AppLayout.tsx": "2f519acb014792ffc11a7b55d810bcbe6ee03739cf2a2cd2a75783676faecf26"
+    "frontend/src/components/AppLayout.tsx": "05b18f6d6b8637a7ae1a094728ce03b4e803678b42925599bbd881ea5f531d80"
   },
   "policy": "docs/visual-design-lock.md",
   "schema_version": 1


### PR DESCRIPTION
Closes #337
Part of #336

## Summary
- adds a persistent one-tap Help control for every authenticated role
- carries the current route and active-project context into Help
- adds a task-first, searchable Help Centre with five steps or fewer per guide
- separates Employee, Foreman, and management guidance
- explains expected results, approval boundaries, and safety stop-work boundaries
- covers every top-level management module and tailored core field/estimating/project tasks
- keeps Phase 1 static: no backend writes, AI key, production data, or deployment change

## Verification
- 39 frontend test files passed (126 tests)
- focused Help/AppLayout tests passed
- TypeScript `tsc --noEmit` passed
- production frontend build passed
- React Router RSC boundary check passed
- `git diff --check` passed

## Follow-on (not in this PR)
The read-only AI Coach remains Phase 2 of #336. It should reuse the existing server-owned Responses API loop, retrieve only from an approved employee-safe Help corpus, cite the source guide, and never expose the management Project Brain or perform writes.