### PR TITLE
Add role-isolated read-only Help Coach

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -8,6 +8,7 @@ from app.db.session import get_db
 from app.core.config import get_settings
 from app.services.access_control import (
     can_access_employee_receipt_route,
+    can_access_help_coach_route,
     can_access_module,
     required_permission,
 )
@@ -82,6 +83,13 @@ def require_module_access(request: Request, user: CurrentUser) -> AuthenticatedU
         )
     relative_path = path_parts[len(prefix) + 1 :]
     if can_access_employee_receipt_route(
+        user.role,
+        module,
+        request.method,
+        relative_path,
+    ):
+        return user
+    if can_access_help_coach_route(
         user.role,
         module,
         request.method,

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -20,6 +20,7 @@ from app.api.v1.routes import (
     field_operations,
     finance,
     google_calendar,
+    help_coach,
     estimates,
     media,
     municipality,
@@ -77,6 +78,7 @@ protected_router.include_router(equipment.router, prefix="/equipment", tags=["eq
 protected_router.include_router(field_operations.router, prefix="/field-operations", tags=["field-operations"])
 protected_router.include_router(finance.router, prefix="/finance", tags=["finance"])
 protected_router.include_router(media.router, prefix="/media", tags=["media"])
+protected_router.include_router(help_coach.router, prefix="/help-coach", tags=["help-coach"])
 protected_router.include_router(assistant.router, prefix="/iron-house-chat", tags=["iron-house-chat"])
 protected_router.include_router(
     meeting_minutes.router,

--- a/backend/app/api/v1/routes/help_coach.py
+++ b/backend/app/api/v1/routes/help_coach.py
@@ -1,0 +1,96 @@
+from time import perf_counter
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy.orm import Session
+
+from app.api.dependencies.auth import CurrentUser
+from app.core.config import get_settings
+from app.db.session import get_db
+from app.schemas.assistant import HelpCoachPrompt, HelpCoachReply, HelpCoachSource
+from app.services.document_audit import DocumentAuditEvent, emit_document_audit_event
+from app.services.help_coach import (
+    format_help_context,
+    is_restricted_help_message,
+    resolve_help_audience,
+    select_help_articles,
+    static_help_answer,
+)
+from app.services.iron_house_chat import AssistantUnavailable, generate_help_coach_reply
+from app.services.request_context import get_request_audit_context
+
+
+router = APIRouter()
+
+
+@router.post("/messages", response_model=HelpCoachReply)
+def ask_help_coach(
+    payload: HelpCoachPrompt,
+    request: Request,
+    user: CurrentUser,
+    db: Session = Depends(get_db),
+) -> HelpCoachReply:
+    started = perf_counter()
+    audience = resolve_help_audience(db, user)
+    articles = []
+    provider_status = "not_called"
+
+    if is_restricted_help_message(payload.message):
+        answer = (
+            "Do not enter passwords, API keys, SINs, banking, medical, payroll, disciplinary, "
+            "or restricted first-aid information in Help. Contact your supervisor or management "
+            "through the approved private process."
+        )
+        answer_status = "restricted"
+    else:
+        articles = select_help_articles(payload.message, audience, payload.route)
+        if not articles:
+            answer = (
+                "I could not find an approved Help guide for that question. Try a shorter term in "
+                "Search Help below, or ask your supervisor. I cannot guess or change an OS record."
+            )
+            answer_status = "no_match"
+        else:
+            answer = static_help_answer(articles[0])
+            answer_status = "static_fallback"
+            settings = get_settings()
+            if settings.iron_house_chat_enabled and settings.openai_api_key:
+                provider_status = "requested"
+                try:
+                    answer = generate_help_coach_reply(
+                        payload.message,
+                        format_help_context(articles),
+                        route=payload.route,
+                        project_name=payload.project_name,
+                    )
+                    answer_status = "completed"
+                    provider_status = "completed"
+                except AssistantUnavailable:
+                    provider_status = "unavailable"
+
+    sources = [
+        HelpCoachSource(id=article.id, title=article.title, path=article.path)
+        for article in articles
+    ]
+    context = get_request_audit_context(request)
+    emit_document_audit_event(
+        DocumentAuditEvent(
+            action="help_coach_request",
+            outcome=answer_status,
+            actor=user.email,
+            request_id=context.request_id,
+            metadata={
+                "audience": audience,
+                "latency_ms": round((perf_counter() - started) * 1000),
+                "mode": "read-only",
+                "provider_status": provider_status,
+                "route": payload.route,
+                "source_ids": [source.id for source in sources],
+            },
+        )
+    )
+    return HelpCoachReply(
+        answer=answer,
+        status=answer_status,
+        audience=audience,
+        sources=sources,
+    )

--- a/backend/app/schemas/assistant.py
+++ b/backend/app/schemas/assistant.py
@@ -61,3 +61,23 @@ class MemoryImportResult(BaseModel):
     updated: int
     skipped: int
     total_project_memories: int
+
+
+class HelpCoachPrompt(BaseModel):
+    message: str = Field(min_length=1, max_length=1000)
+    route: str = Field(default="", max_length=300, pattern=r"^$|^/[A-Za-z0-9_./:-]*$")
+    project_name: str = Field(default="", max_length=160)
+
+
+class HelpCoachSource(BaseModel):
+    id: str
+    title: str
+    path: str
+
+
+class HelpCoachReply(BaseModel):
+    answer: str
+    status: str
+    audience: str
+    mode: str = "read-only"
+    sources: list[HelpCoachSource]

--- a/backend/app/services/access_control.py
+++ b/backend/app/services/access_control.py
@@ -11,6 +11,7 @@ class ModulePermission(StrEnum):
 
 
 BUSINESS_MODULES = (
+    "help-coach",
     "iron-house-chat",
     "backups",
     "meeting-minutes",
@@ -147,6 +148,21 @@ def can_access_employee_receipt_route(
     if len(relative_path) == 2:
         return normalized_method in {"GET", "PUT"}
     return relative_path[2] == "submit" and normalized_method == "POST"
+
+
+def can_access_help_coach_route(
+    role: str | None,
+    module: str,
+    method: str,
+    relative_path: list[str],
+) -> bool:
+    """Allow every supported signed-in role to ask the strictly read-only Help Coach."""
+    return (
+        normalize_role(role) in {"admin", "operations_manager", "estimator", "viewer"}
+        and module == "help-coach"
+        and method.upper() == "POST"
+        and relative_path == ["messages"]
+    )
 
 
 def describe_role_access(role: str | None) -> dict[str, list[str]]:

--- a/backend/app/services/help_coach.py
+++ b/backend/app/services/help_coach.py
@@ -1,0 +1,433 @@
+from dataclasses import dataclass
+import re
+from typing import Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.user import Employee
+from app.services.auth import AuthenticatedUser
+
+
+HelpAudience = Literal["employee", "foreman", "management"]
+
+
+@dataclass(frozen=True)
+class HelpArticle:
+    id: str
+    title: str
+    path: str
+    audiences: frozenset[HelpAudience]
+    keywords: tuple[str, ...]
+    summary: str
+    steps: tuple[str, ...]
+    expected_result: str
+    approval_note: str | None = None
+
+
+EMPLOYEE_AND_FOREMAN = frozenset({"employee", "foreman"})
+ALL_AUDIENCES = frozenset({"employee", "foreman", "management"})
+
+APPROVED_HELP_ARTICLES: tuple[HelpArticle, ...] = (
+    HelpArticle(
+        id="employee-enter-time",
+        title="Enter my time",
+        path="/employee-portal/time",
+        audiences=frozenset({"employee"}),
+        keywords=("time", "hours", "timesheet", "shift", "job"),
+        summary="Add your hours to the correct day and job, then review them before saving.",
+        steps=(
+            "Open Time in the Employee Portal.",
+            "Choose the work date and the correct project.",
+            "Enter your hours and the work details requested on the page.",
+            "Review the date, project and total hours.",
+            "Save or submit the entry.",
+        ),
+        expected_result="Your time entry is saved for supervisor or management review.",
+        approval_note="A saved entry is not the same as payroll approval.",
+    ),
+    HelpArticle(
+        id="employee-submit-receipt",
+        title="Submit a receipt",
+        path="/employee-portal/receipts",
+        audiences=EMPLOYEE_AND_FOREMAN,
+        keywords=("receipt", "expense", "reimbursement", "company card", "photo"),
+        summary="Upload a clear photo, check the extracted details and submit it for review.",
+        steps=(
+            "Open Receipts in your portal.",
+            "Take or select a clear photo of every receipt page.",
+            "Check the vendor, date, payment method, taxes and total.",
+            "Add the project or coding details you know.",
+            "Submit the receipt for review.",
+        ),
+        expected_result=(
+            "The receipt is queued for Financial Control review; it is not posted automatically."
+        ),
+        approval_note=(
+            "Financial Control reviews coding, totals and duplicates before approval or export."
+        ),
+    ),
+    HelpArticle(
+        id="employee-check-schedule",
+        title="Check my schedule",
+        path="/employee-portal/schedule",
+        audiences=EMPLOYEE_AND_FOREMAN,
+        keywords=("schedule", "shift", "crew", "tomorrow", "where", "when"),
+        summary="Open the schedule assigned to your portal and review the job details.",
+        steps=(
+            "Open Schedule in your portal.",
+            "Find the correct date.",
+            "Review the project, start information and notes.",
+            "Contact your supervisor if anything is missing or incorrect.",
+        ),
+        expected_result="You know the current assignment shown in Iron House OS.",
+        approval_note=(
+            "If field instructions conflict with the schedule, confirm with your supervisor."
+        ),
+    ),
+    HelpArticle(
+        id="field-complete-flha",
+        title="Complete the daily FLHA",
+        path="/employee-portal/safety",
+        audiences=ALL_AUDIENCES,
+        keywords=("flha", "safety", "hazard", "control", "assessment", "field level"),
+        summary=(
+            "Verify actual site conditions, review every control and post the FLHA to the job folder."
+        ),
+        steps=(
+            "Open Safety and select the correct project or job.",
+            "Complete the rapid hazard screening for actual site conditions.",
+            "Add each task, hazard, control and responsible person.",
+            "Resolve every critical-hazard blocker and review the emergency details.",
+            "Review the FLHA, then post it for crew acknowledgement and supervisor release.",
+        ),
+        expected_result=(
+            "A versioned FLHA is saved in the job folder for acknowledgement and release."
+        ),
+        approval_note=(
+            "Help or AI suggestions never declare work safe. Stop work and contact the supervisor "
+            "whenever conditions are unsafe or unclear."
+        ),
+    ),
+    HelpArticle(
+        id="field-request-po",
+        title="Request a purchase order",
+        path="/request-po",
+        audiences=ALL_AUDIENCES,
+        keywords=("po", "purchase order", "buy", "supplier", "approval", "material"),
+        summary=(
+            "Send the purchase details to the designated approver and wait for the approved PO number."
+        ),
+        steps=(
+            "Open Request PO.",
+            "Select the correct project and supplier when known.",
+            "Describe what is needed, the reason and the expected amount.",
+            "Review the request and submit it.",
+            "Wait for the approver's decision and PO number before purchasing.",
+        ),
+        expected_result="A traceable PO request is sent for approval.",
+        approval_note="Submitting a request does not authorize a purchase.",
+    ),
+    HelpArticle(
+        id="field-inspect-equipment",
+        title="Inspect small equipment",
+        path="/employee-portal/small-equipment",
+        audiences=ALL_AUDIENCES,
+        keywords=("equipment", "inspection", "tool", "repair", "damage", "unsafe"),
+        summary=(
+            "Check the item, record its condition and flag anything unsafe or needing repair."
+        ),
+        steps=(
+            "Open Small Equipment and choose the employee and project.",
+            "Identify the equipment type and asset.",
+            "Check guards, controls, cords or hoses, leaks and damage.",
+            "Choose the condition and add clear comments or photos.",
+            "Review and submit the inspection.",
+        ),
+        expected_result=(
+            "The condition is recorded and flagged items are visible to management."
+        ),
+        approval_note="Remove unsafe equipment from service and notify the supervisor immediately.",
+    ),
+    HelpArticle(
+        id="foreman-crew-time",
+        title="Enter crew time",
+        path="/foreman-portal/time",
+        audiences=frozenset({"foreman"}),
+        keywords=("crew time", "foreman", "daily timesheet", "hours", "labour"),
+        summary="Record crew hours against the correct project and review the daily sheet.",
+        steps=(
+            "Open Time in the Foreman Portal.",
+            "Choose the work date and project.",
+            "Add each crew member and their hours.",
+            "Check the crew total and work details.",
+            "Save or submit the daily sheet for review.",
+        ),
+        expected_result="The daily crew timesheet is saved for management review.",
+        approval_note="Review does not replace payroll approval.",
+    ),
+    HelpArticle(
+        id="foreman-record-production",
+        title="Record daily production",
+        path="/foreman-portal/production",
+        audiences=frozenset({"foreman"}),
+        keywords=("production", "quantity", "loads", "progress", "foreman", "daily"),
+        summary=(
+            "Save the day's production against the correct job with supporting notes or photos."
+        ),
+        steps=(
+            "Open Production or Loads in the Foreman Portal.",
+            "Select the correct date and project.",
+            "Enter the activity, quantity, unit and supporting details.",
+            "Attach clear evidence when it is available.",
+            "Review and save the record.",
+        ),
+        expected_result="A traceable daily production record is attached to the job.",
+    ),
+    HelpArticle(
+        id="management-verbal-quote",
+        title="Start a verbal quote",
+        path="/customer-quotes",
+        audiences=frozenset({"management"}),
+        keywords=("verbal quote", "customer", "scope", "price", "acceptance", "award"),
+        summary="Capture the customer, scope and assumptions before preparing or issuing a quote.",
+        steps=(
+            "Open Customer Quotes and start a new verbal quote.",
+            "Record the customer, contact, site and scope requested.",
+            "Add pricing, assumptions, exclusions and validity details.",
+            "Review the draft before it is issued.",
+            "Record customer acceptance only when evidence is available.",
+        ),
+        expected_result=(
+            "A controlled quote record is ready for review, issue and eventual award handoff."
+        ),
+        approval_note="Quote acceptance and project award remain explicit management actions.",
+    ),
+    HelpArticle(
+        id="management-create-project",
+        title="Create or open a project",
+        path="/projects",
+        audiences=frozenset({"management"}),
+        keywords=("project", "job", "workspace", "awarded", "setup", "job number"),
+        summary=(
+            "Create the project once, then use its workspace to reach documents, RFQs, estimating "
+            "and readiness."
+        ),
+        steps=(
+            "Open Projects and search before creating a new record.",
+            "Open the existing project, or choose the correct stage for a new one.",
+            "Enter the required customer, name and project details.",
+            "Save the project and keep it selected as the active project.",
+            "Use the project workspace for the next task.",
+        ),
+        expected_result=(
+            "One central project record is available to the connected OS functions."
+        ),
+        approval_note="Do not create a duplicate project when a matching job already exists.",
+    ),
+    HelpArticle(
+        id="management-build-estimate",
+        title="Build an estimate",
+        path="/estimating",
+        audiences=frozenset({"management"}),
+        keywords=("estimate", "cost", "markup", "production rate", "risk", "workbook"),
+        summary=(
+            "Build the estimate within the active project and review its assumptions before export."
+        ),
+        steps=(
+            "Open Estimating with the correct active project.",
+            "Add the work items, quantities, production rates and costs.",
+            "Add markups, risk and estimate notes.",
+            "Review the summary and unresolved assumptions.",
+            "Save the workspace or export the workbook for review.",
+        ),
+        expected_result="A saved, project-linked estimate is ready for internal review.",
+        approval_note="Exporting an estimate does not approve a bid or customer price.",
+    ),
+    HelpArticle(
+        id="management-upload-document",
+        title="Add a project document",
+        path="/document-operations",
+        audiences=frozenset({"management"}),
+        keywords=("document", "upload", "drawing", "specification", "addendum", "revision"),
+        summary="Upload the source file once, label it clearly and keep its revision traceable.",
+        steps=(
+            "Open Document Operations with the correct active project.",
+            "Choose the file and the correct document type.",
+            "Enter a clear title, date and revision information.",
+            "Review the project and metadata.",
+            "Upload the document and confirm it appears in the project record.",
+        ),
+        expected_result=(
+            "A traceable project document is available to connected workflows."
+        ),
+        approval_note=(
+            "Preserve source documents; do not replace an old revision without recording the new one."
+        ),
+    ),
+    HelpArticle(
+        id="management-build-rfq",
+        title="Build an RFQ package",
+        path="/rfq-builder",
+        audiences=frozenset({"management"}),
+        keywords=("rfq", "supplier", "quote", "package", "attachments", "bid"),
+        summary=(
+            "Select suppliers and controlled project documents, then review package readiness."
+        ),
+        steps=(
+            "Open RFQ Builder with the correct active project.",
+            "Define the requested scope and response date.",
+            "Select the intended suppliers.",
+            "Add only the correct controlled documents and revisions.",
+            "Resolve readiness warnings before issuing anything.",
+        ),
+        expected_result=(
+            "A project-linked RFQ package is ready for controlled review or issue."
+        ),
+        approval_note="Readiness does not authorize sending or committing the company.",
+    ),
+    HelpArticle(
+        id="operations-onboard-employee",
+        title="Onboard a new employee",
+        path="/employee-onboarding",
+        audiences=frozenset({"management"}),
+        keywords=("employee", "onboarding", "new hire", "invitation", "orientation", "activate"),
+        summary=(
+            "Use the controlled invitation and review process; restricted information stays restricted."
+        ),
+        steps=(
+            "Open Employee Onboarding and create the new-hire record.",
+            "Generate and deliver the secure invitation.",
+            "Review the returned package and request corrections if needed.",
+            "Approve the package and complete required orientation evidence.",
+            "Activate access only after deployment readiness passes.",
+        ),
+        expected_result=(
+            "The employee has a reviewed onboarding record and appropriately controlled OS access."
+        ),
+        approval_note=(
+            "Activation is a management-controlled action; invitation completion alone is not approval."
+        ),
+    ),
+)
+
+STOP_WORDS = {
+    "a",
+    "about",
+    "and",
+    "can",
+    "do",
+    "for",
+    "how",
+    "i",
+    "in",
+    "is",
+    "it",
+    "my",
+    "of",
+    "on",
+    "the",
+    "to",
+    "what",
+    "where",
+}
+RESTRICTED_TERMS = (
+    "password",
+    "api key",
+    "secret key",
+    "social insurance",
+    "bank account",
+    "banking",
+    "medical",
+    "payroll",
+    "disciplinary",
+    "first aid",
+)
+
+
+def resolve_help_audience(db: Session, user: AuthenticatedUser) -> HelpAudience:
+    if user.role != "viewer":
+        return "management"
+    employee = db.scalar(
+        select(Employee).where(func.lower(Employee.email) == user.email.strip().lower())
+    )
+    if employee is not None and employee.portal_role == "foreman":
+        return "foreman"
+    return "employee"
+
+
+def _terms(value: str) -> set[str]:
+    return {
+        item
+        for item in re.findall(r"[a-z0-9]+", value.lower())
+        if len(item) > 1 and item not in STOP_WORDS
+    }
+
+
+def _path_matches(route: str, path: str) -> bool:
+    return route == path or route.startswith(f"{path}/")
+
+
+def select_help_articles(
+    message: str,
+    audience: HelpAudience,
+    route: str = "",
+    *,
+    limit: int = 3,
+) -> list[HelpArticle]:
+    normalized_message = f" {message.strip().lower()} "
+    query_terms = _terms(message)
+    ranked: list[tuple[int, str, HelpArticle]] = []
+    for article in APPROVED_HELP_ARTICLES:
+        if audience not in article.audiences:
+            continue
+        keyword_terms = _terms(" ".join(article.keywords))
+        body_terms = _terms(
+            " ".join(
+                (
+                    article.title,
+                    article.summary,
+                    article.expected_result,
+                    *article.steps,
+                )
+            )
+        )
+        score = 3 * len(query_terms & keyword_terms) + len(query_terms & body_terms)
+        score += sum(4 for keyword in article.keywords if f" {keyword.lower()} " in normalized_message)
+        if route and _path_matches(route, article.path):
+            score += 8
+        if score > 0:
+            ranked.append((score, article.id, article))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    return [item[2] for item in ranked[: max(1, limit)]]
+
+
+def is_restricted_help_message(message: str) -> bool:
+    normalized = f" {message.strip().lower()} "
+    return "sin" in _terms(message) or any(term in normalized for term in RESTRICTED_TERMS)
+
+
+def format_help_context(articles: list[HelpArticle]) -> str:
+    sections: list[str] = []
+    for article in articles:
+        details = [
+            f"ARTICLE ID: {article.id}",
+            f"TITLE: {article.title}",
+            f"IHOS PATH: {article.path}",
+            f"SUMMARY: {article.summary}",
+            "STEPS:",
+            *(f"{index}. {step}" for index, step in enumerate(article.steps, start=1)),
+            f"EXPECTED RESULT: {article.expected_result}",
+        ]
+        if article.approval_note:
+            details.append(f"APPROVAL OR SAFETY NOTE: {article.approval_note}")
+        sections.append("\n".join(details))
+    return "\n\n---\n\n".join(sections)
+
+
+def static_help_answer(article: HelpArticle) -> str:
+    lines = [article.summary, "", *(f"{index}. {step}" for index, step in enumerate(article.steps, 1))]
+    lines.extend(("", f"What happens next: {article.expected_result}"))
+    if article.approval_note:
+        lines.extend(("", f"Important: {article.approval_note}"))
+    return "\n".join(lines)

--- a/backend/app/services/iron_house_chat.py
+++ b/backend/app/services/iron_house_chat.py
@@ -13,23 +13,28 @@ for or repeat passwords, API keys, SINs, banking information, medical informatio
 If the answer depends on data you cannot see, say so and identify the exact OS page where it can be
 checked. Distinguish guidance from legal, financial, engineering, and safety approval."""
 
+HELP_COACH_INSTRUCTIONS = """You are the Iron House Help Coach for employees, foremen, and
+management using Iron House OS. Answer only from the APPROVED HELP ARTICLES supplied with the
+request. Use plain construction language, short sentences, and no more than five numbered steps.
+Do not use general knowledge to fill a gap. If the approved articles do not support the answer, say
+that no approved guide covers it and direct the user to their supervisor or the static Help search.
+Never claim to change a record. Never authorize a purchase, approval, schedule, price, payroll item,
+contract decision, or safety release. Never ask for or repeat passwords, API keys, SINs, banking,
+medical, payroll, disciplinary, or restricted first-aid information. For safety questions, never
+declare work safe; tell the user to stop work and contact the supervisor when conditions are unsafe
+or unclear. Mention the supporting article title in the answer."""
+
 
 class AssistantUnavailable(RuntimeError):
     pass
 
 
-def generate_help_reply(messages: list[dict[str, str]], project_context: str = "") -> str:
+def _request_response(payload: dict) -> str:
     settings = get_settings()
     if not settings.openai_api_key:
         raise AssistantUnavailable(
             "Iron House Chat is installed but its separate OpenAI API credential has not been configured."
         )
-    payload = {
-        "model": settings.openai_chat_model,
-        "instructions": f"{SYSTEM_INSTRUCTIONS}\n\nPROJECT BRAIN CONTEXT\n{project_context}",
-        "input": messages,
-        "max_output_tokens": 700,
-    }
     request = Request(
         f"{settings.openai_api_base_url.rstrip('/')}/responses",
         data=json.dumps(payload).encode("utf-8"),
@@ -56,3 +61,40 @@ def generate_help_reply(messages: list[dict[str, str]], project_context: str = "
             if content.get("type") == "output_text" and content.get("text"):
                 return str(content["text"]).strip()
     raise AssistantUnavailable("The AI provider returned no answer.")
+
+
+def generate_help_reply(messages: list[dict[str, str]], project_context: str = "") -> str:
+    settings = get_settings()
+    return _request_response(
+        {
+            "model": settings.openai_chat_model,
+            "instructions": f"{SYSTEM_INSTRUCTIONS}\n\nPROJECT BRAIN CONTEXT\n{project_context}",
+            "input": messages,
+            "max_output_tokens": 700,
+        }
+    )
+
+
+def generate_help_coach_reply(
+    message: str,
+    approved_context: str,
+    *,
+    route: str = "",
+    project_name: str = "",
+) -> str:
+    settings = get_settings()
+    safe_page_context = f"Current IHOS path: {route or 'not supplied'}"
+    if project_name:
+        safe_page_context += f"\nSelected project label: {project_name}"
+    return _request_response(
+        {
+            "model": settings.openai_chat_model,
+            "instructions": (
+                f"{HELP_COACH_INSTRUCTIONS}\n\n"
+                f"SAFE PAGE CONTEXT\n{safe_page_context}\n\n"
+                f"APPROVED HELP ARTICLES\n{approved_context}"
+            ),
+            "input": message,
+            "max_output_tokens": 500,
+        }
+    )

--- a/frontend/src/api/helpCoach.ts
+++ b/frontend/src/api/helpCoach.ts
@@ -1,0 +1,42 @@
+import { apiFetch } from "./client";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+
+export type HelpCoachSource = {
+  id: string;
+  title: string;
+  path: string;
+};
+
+export type HelpCoachReply = {
+  answer: string;
+  status: "completed" | "static_fallback" | "no_match" | "restricted";
+  audience: "employee" | "foreman" | "management";
+  mode: "read-only";
+  sources: HelpCoachSource[];
+};
+
+async function read(response: Response): Promise<HelpCoachReply> {
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(payload?.detail ?? `Help Coach request failed (${response.status})`);
+  }
+  return response.json() as Promise<HelpCoachReply>;
+}
+
+export const helpCoachApi = {
+  send: (
+    message: string,
+    context: { route?: string; projectName?: string },
+    signal?: AbortSignal,
+  ) => apiFetch(`${API_BASE_URL}/help-coach/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      message,
+      route: context.route ?? "",
+      project_name: context.projectName ?? "",
+    }),
+    signal,
+  }).then(read),
+};

--- a/frontend/src/pages/HelpCenterPage.test.tsx
+++ b/frontend/src/pages/HelpCenterPage.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HelpCenterPage } from "./HelpCenterPage";
 
 const auth = vi.hoisted(() => ({ role: "viewer" as "viewer" | "operations_manager", portalRole: "employee" as "employee" | "foreman" | "management" }));
+const coachApi = vi.hoisted(() => ({ send: vi.fn() }));
 
 vi.mock("../contexts/AuthContext", () => ({
   useAuth: () => ({
@@ -13,7 +14,11 @@ vi.mock("../contexts/AuthContext", () => ({
   }),
 }));
 
+vi.mock("../api/helpCoach", () => ({ helpCoachApi: coachApi }));
+
 describe("Help Centre", () => {
+  beforeEach(() => coachApi.send.mockReset());
+
   it("shows page-specific, employee-safe guidance", () => {
     auth.role = "viewer";
     auth.portalRole = "employee";
@@ -56,5 +61,64 @@ describe("Help Centre", () => {
 
     expect(screen.getByRole("heading", { name: "Financial Control" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Customer Quotes" })).toBeInTheDocument();
+  });
+
+  it("asks the role-safe Help Coach and links its approved source", async () => {
+    auth.role = "viewer";
+    auth.portalRole = "employee";
+    coachApi.send.mockResolvedValue({
+      answer: "Open Time and choose the correct date and project.",
+      status: "completed",
+      audience: "employee",
+      mode: "read-only",
+      sources: [{ id: "employee-enter-time", title: "Enter my time", path: "/employee-portal/time" }],
+    });
+    render(
+      <MemoryRouter initialEntries={["/help?from=/employee-portal/time&projectId=job-1&projectName=Bennett"]}>
+        <HelpCenterPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText("What do you need help with?"), {
+      target: { value: "How do I enter my time?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Ask Coach" }));
+
+    await waitFor(() => expect(coachApi.send).toHaveBeenCalledWith(
+      "How do I enter my time?",
+      { route: "/employee-portal/time", projectName: "Bennett" },
+    ));
+    expect(await screen.findByText("Open Time and choose the correct date and project.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Enter my time/ })).toHaveAttribute(
+      "href",
+      "/employee-portal/time",
+    );
+    expect(screen.getByText("Grounded Help Coach answer")).toBeInTheDocument();
+  });
+
+  it("keeps static Help usable when the Coach is unavailable", async () => {
+    auth.role = "viewer";
+    auth.portalRole = "employee";
+    coachApi.send.mockResolvedValue({
+      answer: "Open Schedule in your portal and find the correct date.",
+      status: "static_fallback",
+      audience: "employee",
+      mode: "read-only",
+      sources: [{ id: "employee-check-schedule", title: "Check my schedule", path: "/employee-portal/schedule" }],
+    });
+    render(
+      <MemoryRouter initialEntries={["/help"]}>
+        <HelpCenterPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByLabelText("What do you need help with?"), {
+      target: { value: "Where is my schedule?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Ask Coach" }));
+
+    expect(await screen.findByText("Open Schedule in your portal and find the correct date.")).toBeInTheDocument();
+    expect(screen.getByText("Approved built-in guidance")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Search Help" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/HelpCenterPage.tsx
+++ b/frontend/src/pages/HelpCenterPage.tsx
@@ -1,7 +1,8 @@
-import { ArrowUpRight, CheckCircle2, CircleHelp, Search, ShieldCheck } from "lucide-react";
-import { useMemo, useState } from "react";
+import { ArrowUpRight, Bot, CheckCircle2, CircleHelp, Search, Send, ShieldCheck } from "lucide-react";
+import { FormEvent, useMemo, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 
+import { HelpCoachReply, helpCoachApi } from "../api/helpCoach";
 import { useAuth } from "../contexts/AuthContext";
 import {
   contextualHelpArticle,
@@ -71,6 +72,11 @@ export function HelpCenterPage() {
   const { user, portalRole } = useAuth();
   const location = useLocation();
   const [query, setQuery] = useState("");
+  const [coachDraft, setCoachDraft] = useState("");
+  const [coachQuestion, setCoachQuestion] = useState("");
+  const [coachReply, setCoachReply] = useState<HelpCoachReply | null>(null);
+  const [coachError, setCoachError] = useState<string | null>(null);
+  const [coachLoading, setCoachLoading] = useState(false);
   const projectContext = readEffectiveProjectContext(location.search);
   const sourcePath = new URLSearchParams(location.search).get("from") ?? "";
   const articles = useMemo(
@@ -84,6 +90,24 @@ export function HelpCenterPage() {
   const results = useMemo(() => searchHelpArticles(articles, query), [articles, query]);
   const featured = articles.filter((article) => article.featured).slice(0, 6);
   const projectName = projectContext.projectName;
+
+  async function askCoach(event: FormEvent) {
+    event.preventDefault();
+    const question = coachDraft.trim();
+    if (!question || coachLoading) return;
+    setCoachLoading(true);
+    setCoachError(null);
+    setCoachReply(null);
+    setCoachQuestion(question);
+    try {
+      setCoachReply(await helpCoachApi.send(question, { route: sourcePath, projectName: projectName ?? undefined }));
+      setCoachDraft("");
+    } catch (reason) {
+      setCoachError(reason instanceof Error ? reason.message : "The Help Coach is unavailable.");
+    } finally {
+      setCoachLoading(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -125,6 +149,81 @@ export function HelpCenterPage() {
           <ArticleInstructions article={contextArticle} />
         </section>
       ) : null}
+
+      <section className="rounded-xl border border-brand-gold/40 bg-white p-4 shadow-sm sm:p-6" aria-labelledby="help-coach-heading">
+        <div className="flex items-start gap-3">
+          <div className="grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-iron-950 text-brand-gold">
+            <Bot className="h-6 w-6" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">Read-only guidance</div>
+            <h2 id="help-coach-heading" className="mt-1 text-xl font-semibold text-iron-950">Ask the Help Coach</h2>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-iron-600">
+              Type what you are trying to do. The Coach uses only approved instructions for your access level and cannot change, submit, approve or send anything.
+            </p>
+          </div>
+        </div>
+
+        <form onSubmit={(event) => void askCoach(event)} className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-end">
+          <label className="min-w-0 flex-1" htmlFor="help-coach-question">
+            <span className="mb-2 block text-sm font-semibold text-iron-900">What do you need help with?</span>
+            <textarea
+              id="help-coach-question"
+              value={coachDraft}
+              onChange={(event) => setCoachDraft(event.target.value)}
+              rows={2}
+              maxLength={1000}
+              placeholder="For example: How do I enter my time?"
+              className="min-h-14 w-full resize-y rounded-lg border border-iron-200 bg-iron-50 px-4 py-3 text-base text-iron-950 outline-none transition placeholder:text-iron-400 focus:border-brand-gold focus:ring-2 focus:ring-brand-gold/30"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={coachLoading || !coachDraft.trim()}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg bg-iron-950 px-5 text-sm font-semibold text-white transition hover:bg-iron-800 disabled:cursor-not-allowed disabled:bg-iron-300"
+          >
+            <Send className="h-4 w-4" aria-hidden="true" />
+            {coachLoading ? "Checking Help…" : "Ask Coach"}
+          </button>
+        </form>
+
+        {coachError ? (
+          <div role="alert" className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-950">
+            {coachError} Use Search Help below while the Coach is unavailable.
+          </div>
+        ) : null}
+
+        {coachReply ? (
+          <div className="mt-5 rounded-xl border border-iron-100 bg-iron-50 p-4" aria-live="polite">
+            <div className="text-xs font-semibold uppercase tracking-wide text-iron-500">Your question</div>
+            <div className="mt-1 font-semibold text-iron-950">{coachQuestion}</div>
+            <div className="mt-4 text-xs font-semibold uppercase tracking-wide text-brand-gold-dark">
+              {coachReply.status === "completed" ? "Grounded Help Coach answer" : "Approved built-in guidance"}
+            </div>
+            <div className="mt-2 whitespace-pre-wrap text-sm leading-6 text-iron-800">{coachReply.answer}</div>
+            {coachReply.sources.length ? (
+              <div className="mt-4 border-t border-iron-200 pt-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-iron-500">Approved sources</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {coachReply.sources.map((source) => (
+                    <Link
+                      key={source.id}
+                      to={modulePathWithProjectContext(source.path, projectContext)}
+                      className="inline-flex min-h-11 items-center gap-2 rounded-md border border-brand-gold/50 bg-white px-3 text-sm font-semibold text-iron-900 hover:bg-brand-gold/10"
+                    >
+                      {source.title} <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        <p className="mt-4 text-xs leading-5 text-iron-500">
+          Do not enter passwords, SINs, banking, medical, payroll, disciplinary or restricted first-aid information. Stop work and contact your supervisor whenever conditions are unsafe or unclear.
+        </p>
+      </section>
 
       <section className="rounded-xl border border-iron-100 bg-white p-4 shadow-sm sm:p-6" aria-labelledby="help-search-heading">
         <h2 id="help-search-heading" className="text-xl font-semibold text-iron-950">Search Help</h2>

--- a/tests/backend/test_help_coach.py
+++ b/tests/backend/test_help_coach.py
@@ -1,0 +1,301 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+from fastapi import Request
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+
+from app.api.dependencies.auth import require_authenticated_user
+from app.api.v1.routes import help_coach as help_coach_route
+from app.main import app
+from app.models.assistant import AssistantConversation
+from app.models.user import Employee
+from app.services.auth import AuthenticatedUser
+from app.services.document_audit import (
+    clear_recent_document_audit_events,
+    list_recent_document_audit_events,
+)
+from app.services import iron_house_chat
+from app.services.help_coach import APPROVED_HELP_ARTICLES
+from app.services.iron_house_chat import AssistantUnavailable
+from conftest import TestingSessionLocal
+
+
+client = TestClient(app)
+
+
+class _ProviderResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps({"output_text": "Use the approved guide."}).encode()
+
+
+def _principal(email: str, role: str = "viewer") -> AuthenticatedUser:
+    return AuthenticatedUser(
+        id=UUID("00000000-0000-0000-0000-000000000039"),
+        email=email,
+        display_name="Help Coach User",
+        role=role,
+        session_version=1,
+    )
+
+
+def _use_user(user: AuthenticatedUser) -> None:
+    def override(request: Request) -> AuthenticatedUser:
+        request.state.authenticated_user = user
+        return user
+
+    app.dependency_overrides[require_authenticated_user] = override
+
+
+def _disable_provider(monkeypatch) -> None:
+    monkeypatch.setattr(
+        help_coach_route,
+        "get_settings",
+        lambda: SimpleNamespace(iron_house_chat_enabled=False, openai_api_key=""),
+    )
+
+
+def test_employee_gets_grounded_static_help_without_creating_chat_records(monkeypatch) -> None:
+    clear_recent_document_audit_events()
+    _disable_provider(monkeypatch)
+    user = _principal("employee39@example.com")
+    _use_user(user)
+    with TestingSessionLocal() as db:
+        db.add(
+            Employee(
+                first_name="Evan",
+                last_name="Employee",
+                email=user.email,
+                portal_role="employee",
+            )
+        )
+        db.commit()
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={"message": "How do I enter my hours?", "route": "/employee-portal/time"},
+        headers={"x-request-id": "help-coach-employee"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["audience"] == "employee"
+    assert body["status"] == "static_fallback"
+    assert body["mode"] == "read-only"
+    assert body["sources"][0]["id"] == "employee-enter-time"
+    assert all(not item["id"].startswith("management-") for item in body["sources"])
+    assert all(not item["id"].startswith("foreman-") for item in body["sources"])
+    with TestingSessionLocal() as db:
+        assert db.scalar(select(func.count()).select_from(AssistantConversation)) == 0
+
+    event = list_recent_document_audit_events(action="help_coach_request")[0]
+    assert event["request_id"] == "help-coach-employee"
+    assert event["metadata"]["audience"] == "employee"
+    assert event["metadata"]["source_ids"][0] == "employee-enter-time"
+    assert "message" not in event["metadata"]
+
+
+def test_server_resolves_foreman_audience_from_employee_record(monkeypatch) -> None:
+    _disable_provider(monkeypatch)
+    user = _principal("foreman39@example.com")
+    _use_user(user)
+    with TestingSessionLocal() as db:
+        db.add(
+            Employee(
+                first_name="Fran",
+                last_name="Foreman",
+                email=user.email,
+                portal_role="foreman",
+            )
+        )
+        db.commit()
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={"message": "How do I enter crew time?", "route": "/foreman-portal/time"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audience"] == "foreman"
+    assert response.json()["sources"][0]["id"] == "foreman-crew-time"
+    assert all(
+        not item["id"].startswith("management-") for item in response.json()["sources"]
+    )
+
+
+def test_estimator_uses_management_help_without_opening_project_brain(monkeypatch) -> None:
+    _disable_provider(monkeypatch)
+    _use_user(_principal("estimator39@example.com", "estimator"))
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={"message": "How do I build an estimate?", "route": "/estimating"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["audience"] == "management"
+    assert response.json()["sources"][0]["id"] == "management-build-estimate"
+
+
+def test_provider_receives_only_approved_role_safe_help_context(monkeypatch) -> None:
+    clear_recent_document_audit_events()
+    captured: dict[str, str] = {}
+    user = _principal("employee-provider39@example.com")
+    _use_user(user)
+    with TestingSessionLocal() as db:
+        db.add(
+            Employee(
+                first_name="Pat",
+                last_name="Provider",
+                email=user.email,
+                portal_role="employee",
+            )
+        )
+        db.commit()
+    monkeypatch.setattr(
+        help_coach_route,
+        "get_settings",
+        lambda: SimpleNamespace(iron_house_chat_enabled=True, openai_api_key="test-key"),
+    )
+
+    def fake_reply(
+        message: str,
+        approved_context: str,
+        *,
+        route: str,
+        project_name: str,
+    ) -> str:
+        captured.update(
+            message=message,
+            approved_context=approved_context,
+            route=route,
+            project_name=project_name,
+        )
+        return "Use the approved Submit a receipt guide."
+
+    monkeypatch.setattr(help_coach_route, "generate_help_coach_reply", fake_reply)
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={
+            "message": "Where do I submit a receipt?",
+            "route": "/employee-portal/receipts",
+            "project_name": "Bennett",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+    assert "employee-submit-receipt" in captured["approved_context"]
+    assert "management-verbal-quote" not in captured["approved_context"]
+    assert "PROJECT BRAIN" not in captured["approved_context"]
+    assert captured["project_name"] == "Bennett"
+    event = list_recent_document_audit_events(action="help_coach_request")[0]
+    assert event["metadata"]["provider_status"] == "completed"
+
+
+def test_help_coach_provider_payload_never_contains_project_brain(monkeypatch) -> None:
+    captured: dict = {}
+    monkeypatch.setattr(
+        iron_house_chat,
+        "get_settings",
+        lambda: SimpleNamespace(
+            openai_api_key="test-key",
+            openai_api_base_url="https://api.openai.test/v1",
+            openai_chat_model="gpt-test",
+        ),
+    )
+
+    def fake_urlopen(request, timeout: int):
+        captured.update(json.loads(request.data.decode()))
+        assert timeout == 45
+        return _ProviderResponse()
+
+    monkeypatch.setattr(iron_house_chat, "urlopen", fake_urlopen)
+
+    answer = iron_house_chat.generate_help_coach_reply(
+        "How do I enter time?",
+        "ARTICLE ID: employee-enter-time\nTITLE: Enter my time",
+        route="/employee-portal/time",
+        project_name="Bennett",
+    )
+
+    assert answer == "Use the approved guide."
+    assert "PROJECT BRAIN" not in captured["instructions"]
+    assert "APPROVED HELP ARTICLES" in captured["instructions"]
+    assert captured["input"] == "How do I enter time?"
+
+
+def test_server_help_registry_ids_exist_in_the_merged_static_help_registry() -> None:
+    registry = (
+        Path(__file__).resolve().parents[2] / "frontend" / "src" / "helpArticles.ts"
+    ).read_text(encoding="utf-8")
+    ids = [article.id for article in APPROVED_HELP_ARTICLES]
+    assert len(ids) == len(set(ids))
+    for article_id in ids:
+        assert f'id: "{article_id}"' in registry
+
+
+def test_provider_failure_keeps_approved_static_help_available(monkeypatch) -> None:
+    _use_user(_principal("manager39@example.com", "operations_manager"))
+    monkeypatch.setattr(
+        help_coach_route,
+        "get_settings",
+        lambda: SimpleNamespace(iron_house_chat_enabled=True, openai_api_key="test-key"),
+    )
+    monkeypatch.setattr(
+        help_coach_route,
+        "generate_help_coach_reply",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssistantUnavailable("offline")),
+    )
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={"message": "How do I create a project?", "route": "/projects"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "static_fallback"
+    assert "Open Projects" in response.json()["answer"]
+
+
+def test_restricted_information_is_blocked_before_provider_call(monkeypatch) -> None:
+    _use_user(_principal("private39@example.com"))
+    monkeypatch.setattr(
+        help_coach_route,
+        "generate_help_coach_reply",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not call provider")),
+    )
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={"message": "My password is forbidden-value. Where should I save it?"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "restricted"
+    assert response.json()["sources"] == []
+    assert "forbidden-value" not in response.json()["answer"]
+
+
+def test_unknown_question_does_not_invite_an_ungrounded_answer(monkeypatch) -> None:
+    _disable_provider(monkeypatch)
+    _use_user(_principal("unknown39@example.com"))
+
+    response = client.post(
+        "/api/v1/help-coach/messages",
+        json={"message": "Calibrate the orbital spectrometer"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "no_match"
+    assert response.json()["sources"] == []
+    assert "cannot guess" in response.json()["answer"]

--- a/tests/backend/test_role_permissions.py
+++ b/tests/backend/test_role_permissions.py
@@ -9,6 +9,7 @@ from app.main import app
 from app.services.access_control import (
     ModulePermission,
     can_access_employee_receipt_route,
+    can_access_help_coach_route,
     can_access_module,
     describe_role_access,
 )
@@ -198,6 +199,17 @@ def test_viewer_receipt_intake_does_not_open_sensitive_finance_routes(
     path: list[str],
 ) -> None:
     assert not can_access_employee_receipt_route("viewer", "finance", method, path)
+
+
+@pytest.mark.parametrize("role", ["admin", "operations_manager", "estimator", "viewer"])
+def test_supported_roles_can_only_post_to_the_read_only_help_coach(role: str) -> None:
+    assert can_access_help_coach_route(role, "help-coach", "POST", ["messages"])
+    assert not can_access_help_coach_route(role, "help-coach", "GET", ["messages"])
+    assert not can_access_help_coach_route(role, "help-coach", "POST", ["brain"])
+
+
+def test_unknown_role_cannot_access_help_coach() -> None:
+    assert not can_access_help_coach_route("unknown", "help-coach", "POST", ["messages"])
 
 
 def test_viewer_can_list_only_their_receipts_but_cannot_access_finance_admin() -> None:


### PR DESCRIPTION
Closes #339
Part of #336
Depends on #341 / #340 for the current-main frontend test stabilization.

## Summary
- adds a typed Help Coach panel to the existing `/help` page
- adds a separate authenticated `/help-coach/messages` endpoint for all supported roles
- derives employee, foreman, or management audience on the server
- retrieves only from a server-owned approved Help registry and returns visible source links
- keeps employee/foreman requests entirely separate from management Project Brain
- falls back to approved static steps when the AI provider is disabled, unconfigured, or unavailable
- blocks restricted information before any provider call
- audits audience, source IDs, route, latency, and provider status without recording the question
- remains read-only: no workflow, record, message, approval, purchasing, or deployment actions

## Verification
- full backend suite passed: 448 tests
- focused Help/security/backend suite passed: 48 tests
- Help Centre UI suite passed: 5 tests
- Ruff passed
- TypeScript and production frontend build passed
- React Router RSC security boundary passed
- visual-design lock passed
- `git diff --check` passed
- full frontend run passed 130/131; the sole current-main timing assertion is isolated and fixed by dependency PR #341