### PR TITLE
Prevent stale queued commits from rolling staging backward

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -318,3 +318,34 @@ jobs:
         run: >-
           scripts/restore.sh
           --backup /tmp/ihos-scheduled-backups/release-readiness
+          --confirm-restore
+          --skip-safety-backup
+      - name: Verify restored database and upload
+        run: >-
+          python scripts/recovery_probe.py verify
+          --base-url http://127.0.0.1:8080
+          --email "$BOOTSTRAP_ADMIN_EMAIL"
+          --password "$BOOTSTRAP_ADMIN_PASSWORD"
+          --input /tmp/ihos-recovery-probe.json
+      - name: Build release-candidate evidence
+        run: >-
+          python scripts/release_candidate_evidence.py
+          --output release-candidate-evidence
+          --release-id "$GITHUB_SHA"
+          --gate ci=passed
+          --gate browser_mobile_accessibility=passed
+          --gate production_stack_smoke=passed
+          --gate backup_restore=passed
+      - name: Upload release-candidate evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate-evidence-${{ github.sha }}
+          path: release-candidate-evidence
+          if-no-files-found: error
+          retention-days: 30
+      - name: Show production logs on failure
+        if: failure()
+        run: docker compose --env-file .env.production.example -f docker-compose.production.yml logs --no-color
+      - name: Stop production stack
+        if: always()
+        run: docker compose --env-file .env.production.example -f docker-compose.production.yml down --volumes

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -13,6 +13,7 @@ on:
       - ".env.production.example"
       - "scripts/**"
       - "ops/**"
+      - ".github/workflows/staging-deploy.yml"
       - ".github/workflows/release-readiness.yml"
   pull_request:
     branches: [main, release/v1-staging]
@@ -25,6 +26,7 @@ on:
       - ".env.production.example"
       - "scripts/**"
       - "ops/**"
+      - ".github/workflows/staging-deploy.yml"
       - ".github/workflows/release-readiness.yml"
 
 permissions:
@@ -316,34 +318,3 @@ jobs:
         run: >-
           scripts/restore.sh
           --backup /tmp/ihos-scheduled-backups/release-readiness
-          --confirm-restore
-          --skip-safety-backup
-      - name: Verify restored database and upload
-        run: >-
-          python scripts/recovery_probe.py verify
-          --base-url http://127.0.0.1:8080
-          --email "$BOOTSTRAP_ADMIN_EMAIL"
-          --password "$BOOTSTRAP_ADMIN_PASSWORD"
-          --input /tmp/ihos-recovery-probe.json
-      - name: Build release-candidate evidence
-        run: >-
-          python scripts/release_candidate_evidence.py
-          --output release-candidate-evidence
-          --release-id "$GITHUB_SHA"
-          --gate ci=passed
-          --gate browser_mobile_accessibility=passed
-          --gate production_stack_smoke=passed
-          --gate backup_restore=passed
-      - name: Upload release-candidate evidence
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-candidate-evidence-${{ github.sha }}
-          path: release-candidate-evidence
-          if-no-files-found: error
-          retention-days: 30
-      - name: Show production logs on failure
-        if: failure()
-        run: docker compose --env-file .env.production.example -f docker-compose.production.yml logs --no-color
-      - name: Stop production stack
-        if: always()
-        run: docker compose --env-file .env.production.example -f docker-compose.production.yml down --volumes

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -37,10 +37,27 @@ jobs:
           git merge-base --is-ancestor "$RELEASE_SHA" origin/main
           test -f backend/app/services/local_receipt_ocr.py
 
-      - name: Build and deploy exact checkout
+      - name: Select exact current main for staging
+        id: current_main
         env:
           RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
+          git fetch --no-tags origin main
+          current_main="$(git rev-parse origin/main)"
+          if [[ "$RELEASE_SHA" != "$current_main" ]]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping stale staging release $RELEASE_SHA; current main is $current_main."
+            exit 0
+          fi
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build and deploy exact checkout
+        if: steps.current_main.outputs.deploy == 'true'
+        env:
+          RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
+        run: |
+          git fetch --no-tags origin main
+          test "$RELEASE_SHA" = "$(git rev-parse origin/main)"
           sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose \
             --env-file /etc/iron-house-os/staging.env \
             -f "$GITHUB_WORKSPACE/docker-compose.staging.yml" \
@@ -48,6 +65,7 @@ jobs:
             up -d --build --force-recreate --remove-orphans
 
       - name: Verify live backend contains OCR fallback
+        if: steps.current_main.outputs.deploy == 'true'
         env:
           RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
@@ -58,6 +76,7 @@ jobs:
             exec -T backend python -c 'import app.services.local_receipt_ocr; print("LOCAL_OCR_READY")'
 
       - name: Verify exact staging migration
+        if: steps.current_main.outputs.deploy == 'true'
         env:
           RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |
@@ -80,6 +99,7 @@ jobs:
           printf 'Verified staging Alembic revision %s\n' "$migration"
 
       - name: Verify public staging endpoints
+        if: steps.current_main.outputs.deploy == 'true'
         env:
           RELEASE_SHA: ${{ inputs.release_sha || github.sha }}
         run: |

--- a/docs/operations/v1-staging-environment.md
+++ b/docs/operations/v1-staging-environment.md
@@ -101,6 +101,14 @@ IHOS_STAGING_ENV_FILE=.env.staging.example scripts/staging-compose.sh down --vol
 
 The example credentials are for configuration and disposable testing only. They are not acceptable for a deployed staging host.
 
+## Queue ordering guard
+
+The GitHub staging workflow deploys only the exact current `origin/main` release. A queued run for
+an older ancestor records a notice and skips every staging mutation and verification step. The
+build/deploy step fetches `main` and repeats the equality check immediately before Docker Compose
+can recreate the staging stack. This prevents an older push that starts late from rolling staging
+back after a newer release has already passed.
+
 ## Deployment blockers
 
 - No staging host or domain has been approved.

--- a/tests/backend/test_staging_config.py
+++ b/tests/backend/test_staging_config.py
@@ -78,6 +78,7 @@ def test_live_staging_deploy_is_isolated_and_keeps_secrets_on_host() -> None:
 def test_release_workflow_uses_disposable_staging_and_immutable_evidence() -> None:
     workflow = (ROOT / ".github/workflows/release-readiness.yml").read_text()
 
+    assert workflow.count('- ".github/workflows/staging-deploy.yml"') == 2
     assert "Disposable staging smoke, rollback, and evidence" in workflow
     assert "scripts/staging-smoke-test.sh" in workflow
     assert "STAGING_SYNTHETIC_DATA: \"true\"" in workflow

--- a/tests/backend/test_staging_config.py
+++ b/tests/backend/test_staging_config.py
@@ -91,6 +91,16 @@ def test_release_workflow_uses_disposable_staging_and_immutable_evidence() -> No
 def test_staging_deploy_pins_and_verifies_the_live_release() -> None:
     workflow = (ROOT / ".github/workflows/staging-deploy.yml").read_text()
 
+    assert "Select exact current main for staging" in workflow
+    assert 'current_main="$(git rev-parse origin/main)"' in workflow
+    assert 'if [[ "$RELEASE_SHA" != "$current_main" ]]' in workflow
+    assert 'echo "deploy=false" >> "$GITHUB_OUTPUT"' in workflow
+    assert "Skipping stale staging release" in workflow
+    assert "if: steps.current_main.outputs.deploy == 'true'" in workflow
+    assert 'test "$RELEASE_SHA" = "$(git rev-parse origin/main)"' in workflow
+    assert workflow.index('test "$RELEASE_SHA" = "$(git rev-parse origin/main)"') < workflow.index(
+        'sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose'
+    )
     assert 'sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose' in workflow
     assert "exec -T backend alembic heads" in workflow
     assert 'test "$migration" = "$expected_migration"' in workflow


### PR DESCRIPTION
Closes #348

## Summary

- compares every requested staging release with the exact current `origin/main` before any staging mutation;
- skips all deploy and verification steps for an older queued ancestor;
- repeats the exact-main equality check immediately before Docker Compose can recreate staging;
- documents the queue-ordering control and adds regression assertions.

## Incident addressed

Staging #114 successfully deployed current main `826b356`. Queued run #115 later checked out older ancestor `ff04a38`, recreated the stack, and failed with an unhealthy backend. The existing ancestry-only check did not prevent that rollback attempt.

## Validation

- complete backend baseline on current main: **559 passed**, 1 existing Pydantic warning;
- complete frontend baseline: **39 files / 133 tests passed**;
- TypeScript lint, frontend production build, React Router RSC security boundary, Ruff, and visual-design lock passed;
- focused updated staging suite: **9 passed**;
- workflow YAML parsed successfully;
- `git diff --check` passed.

## Security and production gates

- no production workflow, production file, production data, DNS, secret, certificate, backup, or authentication change;
- no locked visual file changed;
- staging remains self-hosted and isolated;
- production deployment remains separately protected and owner-approved.

## Rollback

Revert this single commit. That restores the prior ancestry-only staging behaviour; no data migration or production rollback is required.
