### PR TITLE
Align Bowline import with final August 27 invoice

### DIFF
--- a/ops/production-awarded-invoice-imports/2026-08-25-bowline-rawlison.json
+++ b/ops/production-awarded-invoice-imports/2026-08-25-bowline-rawlison.json
@@ -1,26 +1,31 @@
 {
   "schema_version": 1,
-  "issue_number": 322,
+  "issue_number": 351,
   "import_key": "bowline-rawlison-2026-08-25",
-  "requested_at": "2026-08-25",
+  "requested_at": "2026-08-27",
   "project": {
     "payload": {
       "name": "Rawlison Cres Common Excavation",
       "client_owner": "Bowline Construction",
       "municipality": "Langley",
       "project_address": "Rawlison Cres, Langley, BC",
-      "contract_value": 10738.77,
+      "contract_value": 11153.52,
       "status": "awarded",
-      "notes": "Historical completed-work intake from source invoice BOW-2026-0811. Import creates the awarded IHOS job so the system allocates the permanent job number; invoice remains draft pending normal review/issue controls.",
+      "notes": "Historical completed-work intake from the August 27 revision of source invoice BOW-2026-0811. Import creates the awarded IHOS job so the system allocates the permanent job number; invoice remains draft pending billing-address confirmation and normal review/issue controls.",
       "metadata": {
         "source_import_key": "bowline-rawlison-2026-08-25",
         "source_issue": 322,
+        "correction_issue": 351,
         "source_invoice_number": "BOW-2026-0811",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "source_drive_modified_at": "2026-08-27T00:41:46.422Z",
+        "source_file_name": "Bowline_Rawlison_Crescent_Invoice.pdf",
         "historical_completed_work": true,
-        "billing_address": "20526 50A Avenue, Langley, BC V3A 6Z2",
-        "customer_phone": "778-808-3725",
-        "total_hours": 43.5,
-        "source_file_name": "Bowline_Rawlins_Crescent_Invoice_updated_fixed.pdf"
+        "billing_contact_name": "Zakaria Tadrous",
+        "billing_contact_email": "ztadrous@hotmail.com",
+        "billing_address_status": "not provided in source invoice; confirm before issue",
+        "customer_phone_status": "not provided in source invoice",
+        "total_hours": 43.5
       }
     }
   },
@@ -30,25 +35,24 @@
       "invoice_number": "BOW-2026-0811",
       "project_name": "Rawlison Cres Common Excavation",
       "site_address": "Rawlison Cres, Langley, BC",
-      "customer_name": "Bowline Construction",
-      "customer_address": "20526 50A Avenue, Langley, BC V3A 6Z2",
-      "customer_phone": "778-808-3725",
+      "customer_name": "Zakaria Tadrous",
+      "customer_address": "Not provided in source invoice - confirm before issue",
       "invoice_date": "2026-08-15",
-      "due_date": "2026-09-14",
-      "terms": "Net 30",
+      "due_date": "2026-08-15",
+      "terms": "Due upon receipt",
       "gst_rate": "5.00",
       "line_items": [
-        {"description": "Common excavation - Tuesday, August 11, 2026", "quantity": "12.5", "unit_price": "210.00"},
-        {"description": "Common excavation - Wednesday, August 12, 2026", "quantity": "12.0", "unit_price": "210.00"},
-        {"description": "Common excavation - Thursday, August 13, 2026", "quantity": "9.0", "unit_price": "210.00"},
-        {"description": "Common excavation - Friday, August 14, 2026", "quantity": "6.0", "unit_price": "210.00"},
+        {"description": "Common excavation - Tuesday, August 11, 2026", "quantity": "12.5", "unit_price": "220.00"},
+        {"description": "Common excavation - Wednesday, August 12, 2026", "quantity": "12.0", "unit_price": "220.00"},
+        {"description": "Common excavation - Thursday, August 13, 2026", "quantity": "9.0", "unit_price": "220.00"},
+        {"description": "Common excavation - Friday, August 14, 2026", "quantity": "6.0", "unit_price": "220.00"},
+        {"description": "Mini excavator - footings and plumbing", "quantity": "4.0", "unit_price": "130.00"},
         {"description": "Mobilize In", "quantity": "1", "unit_price": "706.20"},
-        {"description": "Mobilize Out", "quantity": "1", "unit_price": "706.20"},
-        {"description": "Mini excavator footings and plumbing", "quantity": "4.0", "unit_price": "130.00"}
+        {"description": "Mobilize Out", "quantity": "1", "unit_price": "706.20"}
       ]
     },
-    "expected_subtotal": "10227.40",
-    "expected_gst": "511.37",
-    "expected_total": "10738.77"
+    "expected_subtotal": "10622.40",
+    "expected_gst": "531.12",
+    "expected_total": "11153.52"
   }
 }

--- a/ops/scripts/production_awarded_invoice_import.py
+++ b/ops/scripts/production_awarded_invoice_import.py
@@ -47,12 +47,17 @@ def validate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
     require(project.get("name") and project.get("client_owner") and project.get("project_address"), "project identity is required")
     metadata = project.get("metadata") or {}
     require(metadata.get("source_import_key") == bundle["import_key"], "project metadata must carry source_import_key")
+    require(metadata.get("source_drive_file_id"), "project metadata must carry source_drive_file_id")
+    require(metadata.get("source_drive_modified_at"), "project metadata must carry source_drive_modified_at")
     invoice = bundle.get("invoice") or {}
     ref = invoice.get("external_reference")
     payload = invoice.get("payload") or {}
     require(ref and payload.get("invoice_number") == ref, "invoice external reference must match invoice_number")
+    require(metadata.get("source_invoice_number") == ref, "project metadata source invoice must match invoice reference")
     require("status" not in payload, "invoice must use API draft default")
     require(payload.get("customer_name") and payload.get("customer_address") and payload.get("line_items"), "invoice billing and line items are required")
+    require(payload.get("project_name") and payload.get("invoice_date") and payload.get("due_date") and payload.get("terms"), "invoice project, dates and terms are required")
+    require(all(Decimal(str(item["quantity"])) > 0 for item in payload["line_items"]), "invoice quantities must be positive")
     calculated = invoice_totals(payload)
     expected = tuple(money(invoice[k]) for k in ("expected_subtotal", "expected_gst", "expected_total"))
     require(calculated == expected, f"invoice totals mismatch: calculated={calculated}, expected={expected}")

--- a/ops/scripts/tests/test_production_awarded_invoice_import.py
+++ b/ops/scripts/tests/test_production_awarded_invoice_import.py
@@ -41,6 +41,28 @@ class AwardedInvoiceImportTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "totals mismatch"):
             MODULE.validate_bundle(bundle)
 
+    def test_final_drive_revision_is_staged_exactly(self):
+        bundle = valid_bundle()
+        project = bundle["project"]["payload"]
+        invoice = bundle["invoice"]
+        payload = invoice["payload"]
+        metadata = project["metadata"]
+        self.assertEqual(metadata["source_drive_file_id"], "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS")
+        self.assertEqual(metadata["source_drive_modified_at"], "2026-08-27T00:41:46.422Z")
+        self.assertEqual(payload["customer_name"], "Zakaria Tadrous")
+        self.assertEqual(payload["due_date"], "2026-08-15")
+        self.assertEqual(payload["terms"], "Due upon receipt")
+        self.assertEqual([item["unit_price"] for item in payload["line_items"][:4]], ["220.00"] * 4)
+        self.assertEqual(invoice["expected_subtotal"], "10622.40")
+        self.assertEqual(invoice["expected_gst"], "531.12")
+        self.assertEqual(invoice["expected_total"], "11153.52")
+
+    def test_source_provenance_is_required(self):
+        bundle = valid_bundle()
+        del bundle["project"]["payload"]["metadata"]["source_drive_file_id"]
+        with self.assertRaisesRegex(ValueError, "source_drive_file_id"):
+            MODULE.validate_bundle(bundle)
+
     def test_job_number_rejects_hyphens(self):
         with self.assertRaisesRegex(RuntimeError, "invalid"):
             MODULE.verify_job_number("IH-2026-001")


### PR DESCRIPTION
Closes #351
Refs #268

## Summary

- replaces the stale Bowline BOW-2026-0811 bundle with the authoritative Drive PDF revised on August 27;
- updates the four common-excavation lines from $210/hour to $220/hour;
- stages exact totals of **$10,622.40 + $531.12 GST = $11,153.52**;
- aligns the invoice and due date to August 15, terms to Due upon receipt, and bill-to contact to Zakaria Tadrous;
- removes the unsupported historical billing address and phone, explicitly requiring billing-address confirmation before issue;
- adds exact Drive provenance and validator coverage.

## Authoritative source

- Drive file `Bowline_Rawlison_Crescent_Invoice.pdf`
- file ID `1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS`
- modified `2026-08-27T00:41:46.422Z`

## Validation

- `7 passed` in `ops/scripts/tests/test_production_awarded_invoice_import.py`
- bundle validator passed: 1 awarded project, 1 draft invoice
- Ruff passed

## Approval and data gates

- this PR changes only the staged, approval-gated bundle and validator/tests;
- no production project, job number, invoice, field record, cost entry, payment, or customer communication was created or changed;
- the invoice remains draft and the generated IHOS job number remains protected by the existing no-hyphen/idempotency controls;
- production import requires separate exact owner approval after merge and production release availability;
- the missing billing address must be confirmed before invoice issue.

## Rollback

Revert this PR before any protected import. If an import has occurred, stop and reconcile the existing project/invoice manually; do not rerun a stale bundle.