### PR TITLE
Preserve Bowline completed-work source records

### DIFF
--- a/backend/app/api/v1/routes/field_operations.py
+++ b/backend/app/api/v1/routes/field_operations.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, Query, Response, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies.auth import CurrentUser
@@ -106,6 +106,16 @@ def create_time_entry(payload: TimeEntryCreate, db: DBSession, user: CurrentUser
 @router.post("/records", response_model=FieldRecordRead, status_code=status.HTTP_201_CREATED)
 def create_field_record(payload: FieldRecordCreate, db: DBSession, user: CurrentUser) -> FieldRecordRead:
     return field_operations.create_field_record(db, payload, user)
+
+
+@router.get("/completed-work", response_model=list[FieldRecordRead])
+def list_completed_work(
+    project_id: UUID,
+    source_import_key: Annotated[str, Query(min_length=1, max_length=255)],
+    db: DBSession,
+    user: CurrentUser,
+) -> list[FieldRecordRead]:
+    return field_operations.list_completed_work(db, project_id, source_import_key, user)
 
 
 @router.post("/records/{record_id}/invoice", response_model=FieldRecordRead)

--- a/backend/app/schemas/field_operations.py
+++ b/backend/app/schemas/field_operations.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Literal
 from uuid import UUID
 
@@ -32,7 +33,11 @@ RecordType = Literal[
     "emergency_action_card",
     "incident",
     "first_aid_record",
+    "completed_work",
 ]
+
+
+MONEY = Decimal("0.01")
 
 
 class EmployeeCreate(BaseModel):
@@ -264,6 +269,70 @@ class FieldRecordCreate(BaseModel):
                 "transported_for_further_assessment",
             }:
                 raise ValueError("Select the recorded outcome.")
+        if self.record_type == "completed_work":
+            if not self.project_id:
+                raise ValueError("Completed work requires a project.")
+            if self.severity != "none" or self.alert_recipients:
+                raise ValueError("Completed-work revenue records cannot carry safety severity or alerts.")
+            required = {
+                "source_import_key": "Completed work requires a source import key.",
+                "source_line_key": "Completed work requires a source line key.",
+                "source_invoice_number": "Completed work requires a source invoice number.",
+                "source_drive_file_id": "Completed work requires a source Drive file ID.",
+                "source_invoice_date": "Completed work requires a source invoice date.",
+                "description": "Completed work requires a description.",
+                "unit": "Completed work requires a unit.",
+            }
+            for key, message in required.items():
+                if not str(self.details.get(key) or "").strip():
+                    raise ValueError(message)
+            if self.details.get("cost_status") != "internal_cost_unverified":
+                raise ValueError("Completed work must identify internal cost as unverified.")
+            if self.details.get("revenue_trace_only") is not True:
+                raise ValueError("Completed work must be marked as revenue trace only.")
+            prohibited_cost_fields = {
+                "actual_cost",
+                "actual_cost_amount",
+                "internal_cost_amount",
+                "internal_cost_rate",
+            }
+            if prohibited_cost_fields.intersection(self.details):
+                raise ValueError("Unverified completed work cannot include internal actual-cost values.")
+            try:
+                quantity = Decimal(str(self.details.get("quantity")))
+                billable_rate = Decimal(str(self.details.get("billable_rate")))
+                billable_amount = Decimal(str(self.details.get("billable_amount")))
+            except (InvalidOperation, TypeError, ValueError) as exc:
+                raise ValueError("Completed-work quantity, billable rate, and billable amount must be numbers.") from exc
+            if not all(value.is_finite() for value in (quantity, billable_rate, billable_amount)):
+                raise ValueError("Completed-work quantity, billable rate, and billable amount must be finite.")
+            if quantity <= 0 or billable_rate <= 0 or billable_amount <= 0:
+                raise ValueError("Completed-work quantity, billable rate, and billable amount must be greater than zero.")
+            if billable_rate != billable_rate.quantize(MONEY) or billable_amount != billable_amount.quantize(MONEY):
+                raise ValueError("Completed-work billable rate and amount must use two-decimal currency precision.")
+            expected_amount = (quantity * billable_rate).quantize(MONEY, rounding=ROUND_HALF_UP)
+            if billable_amount != expected_amount:
+                raise ValueError("Completed-work billable amount must equal quantity times billable rate.")
+            try:
+                invoice_date = date.fromisoformat(str(self.details["source_invoice_date"]))
+            except ValueError as exc:
+                raise ValueError("Completed work requires a valid source invoice date.") from exc
+            date_basis = self.details.get("record_date_basis")
+            source_work_date = self.details.get("source_work_date")
+            if date_basis == "source_work_date":
+                try:
+                    parsed_work_date = date.fromisoformat(str(source_work_date or ""))
+                except ValueError as exc:
+                    raise ValueError("Source-dated completed work requires a valid source work date.") from exc
+                if parsed_work_date != self.work_date:
+                    raise ValueError("Completed-work date must match the source work date.")
+            elif date_basis == "invoice_date_reference_only":
+                if source_work_date:
+                    raise ValueError("Invoice-date reference records cannot claim a source work date.")
+                if self.work_date != invoice_date:
+                    raise ValueError("Invoice-date reference records must use the source invoice date.")
+            else:
+                raise ValueError("Completed work requires a valid record date basis.")
         return self
 
 

--- a/backend/app/services/field_operations.py
+++ b/backend/app/services/field_operations.py
@@ -2,7 +2,7 @@ import csv
 from datetime import UTC, date, datetime, timedelta
 from io import StringIO
 import secrets
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import select, update
@@ -180,6 +180,8 @@ def get_bootstrap(db: Session, user: AuthenticatedUser) -> FieldOperationsBootst
     vehicle_logs = list(db.scalars(select(VehicleLog).order_by(VehicleLog.entry_date.desc()).limit(100)))
     time_entries = list(db.scalars(select(TimeEntry).order_by(TimeEntry.work_date.desc()).limit(200)))
     records_query = select(FieldRecord)
+    if user.role not in MANAGEMENT_ROLES:
+        records_query = records_query.where(FieldRecord.record_type != "completed_work")
     if user.role == "estimator" or (
         user.role == "viewer" and field_role in {"foreman", "management"}
     ):
@@ -798,6 +800,13 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
         alerts = MANAGEMENT_ALERT_RECIPIENTS
     values = payload.model_dump()
     profile = db.scalar(select(Employee).where(Employee.email.ilike(user.email)))
+    if payload.record_type == "completed_work":
+        if user.role not in MANAGEMENT_ROLES:
+            raise AppError("Management access is required to create completed-work records.", status_code=403)
+        existing = _find_completed_work_record(db, payload)
+        if existing is not None:
+            _verify_completed_work_record(existing, payload)
+            return FieldRecordRead.model_validate(existing)
     if user.role == "viewer":
         if profile is None:
             raise AppError("Your employee profile is not linked to this account.", status_code=400)
@@ -914,13 +923,106 @@ def create_field_record(db: Session, payload: FieldRecordCreate, user: Authentic
             "recorded_by": user.display_name,
             "recorded_at": datetime.now(UTC).isoformat(),
         }
+    if payload.record_type == "completed_work":
+        values["status"] = "recorded"
     values["document_ids"] = [str(document_id) for document_id in payload.document_ids]
     values["alert_recipients"] = alerts
-    item = FieldRecord(**values, submitted_by=user.email)
+    if payload.record_type == "completed_work":
+        item_id = uuid5(
+            NAMESPACE_URL,
+            ":".join((
+                "ihos-completed-work",
+                str(payload.project_id),
+                str(payload.details["source_import_key"]),
+                str(payload.details["source_line_key"]),
+            )),
+        )
+    else:
+        item_id = None
+    item = FieldRecord(**values, submitted_by=user.email, **({"id": item_id} if item_id else {}))
     db.add(item)
-    commit(db)
+    if payload.record_type == "completed_work":
+        try:
+            db.commit()
+        except IntegrityError as exc:
+            db.rollback()
+            concurrent = db.get(FieldRecord, item_id)
+            if concurrent is None:
+                raise AppError("Unable to save the completed-work record.", status_code=409) from exc
+            _verify_completed_work_record(concurrent, payload)
+            return FieldRecordRead.model_validate(concurrent)
+    else:
+        commit(db)
     db.refresh(item)
     return FieldRecordRead.model_validate(item)
+
+
+def list_completed_work(
+    db: Session,
+    project_id: UUID,
+    source_import_key: str,
+    user: AuthenticatedUser,
+) -> list[FieldRecordRead]:
+    if user.role not in MANAGEMENT_ROLES:
+        raise AppError("Management access is required to view completed-work imports.", status_code=403)
+    require_exists(db, Project, project_id, "Project")
+    records = list(db.scalars(
+        select(FieldRecord)
+        .where(
+            FieldRecord.project_id == project_id,
+            FieldRecord.record_type == "completed_work",
+        )
+        .order_by(FieldRecord.work_date, FieldRecord.created_at, FieldRecord.id)
+    ))
+    matches = [
+        item
+        for item in records
+        if str((item.details or {}).get("source_import_key") or "") == source_import_key
+    ]
+    return [FieldRecordRead.model_validate(item) for item in matches]
+
+
+def _find_completed_work_record(db: Session, payload: FieldRecordCreate) -> FieldRecord | None:
+    records = list(db.scalars(
+        select(FieldRecord).where(
+            FieldRecord.project_id == payload.project_id,
+            FieldRecord.record_type == "completed_work",
+        )
+    ))
+    matches = [
+        item
+        for item in records
+        if str((item.details or {}).get("source_import_key") or "") == str(payload.details["source_import_key"])
+        and str((item.details or {}).get("source_line_key") or "") == str(payload.details["source_line_key"])
+    ]
+    if len(matches) > 1:
+        raise AppError("Multiple completed-work records match the same source line; manual review is required.", status_code=409)
+    return matches[0] if matches else None
+
+
+def _verify_completed_work_record(item: FieldRecord, payload: FieldRecordCreate) -> None:
+    expected = {
+        "project_id": payload.project_id,
+        "record_type": payload.record_type,
+        "work_date": payload.work_date,
+        "title": payload.title,
+        "status": "recorded",
+        "severity": payload.severity,
+        "cost_code": payload.cost_code,
+        "employee_id": payload.employee_id,
+        "equipment_id": payload.equipment_id,
+        "supplier_id": payload.supplier_id,
+        "details": payload.details,
+        "document_ids": [str(value) for value in payload.document_ids],
+        "signatures": payload.signatures,
+        "alert_recipients": payload.alert_recipients,
+    }
+    mismatches = [key for key, value in expected.items() if getattr(item, key) != value]
+    if mismatches:
+        raise AppError(
+            "Completed-work source key already exists with different content; manual review is required.",
+            status_code=409,
+        )
 
 
 def attach_purchase_order_invoice(

--- a/ops/production-awarded-invoice-imports/2026-08-25-bowline-rawlison.json
+++ b/ops/production-awarded-invoice-imports/2026-08-25-bowline-rawlison.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "issue_number": 351,
+  "issue_number": 353,
   "import_key": "bowline-rawlison-2026-08-25",
   "requested_at": "2026-08-27",
   "project": {
@@ -16,6 +16,7 @@
         "source_import_key": "bowline-rawlison-2026-08-25",
         "source_issue": 322,
         "correction_issue": 351,
+        "completed_work_issue": 353,
         "source_invoice_number": "BOW-2026-0811",
         "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
         "source_drive_modified_at": "2026-08-27T00:41:46.422Z",
@@ -54,5 +55,158 @@
     "expected_subtotal": "10622.40",
     "expected_gst": "531.12",
     "expected_total": "11153.52"
-  }
+  },
+  "completed_work_records": [
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-11",
+      "title": "Common excavation - Tuesday, August 11, 2026",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "01-common-excavation-2026-08-11",
+        "source_line_position": 1,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Common excavation - Tuesday, August 11, 2026",
+        "quantity": "12.5",
+        "unit": "hour",
+        "billable_rate": "220.00",
+        "billable_amount": "2750.00",
+        "record_date_basis": "source_work_date",
+        "source_work_date": "2026-08-11",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    },
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-12",
+      "title": "Common excavation - Wednesday, August 12, 2026",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "02-common-excavation-2026-08-12",
+        "source_line_position": 2,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Common excavation - Wednesday, August 12, 2026",
+        "quantity": "12.0",
+        "unit": "hour",
+        "billable_rate": "220.00",
+        "billable_amount": "2640.00",
+        "record_date_basis": "source_work_date",
+        "source_work_date": "2026-08-12",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    },
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-13",
+      "title": "Common excavation - Thursday, August 13, 2026",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "03-common-excavation-2026-08-13",
+        "source_line_position": 3,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Common excavation - Thursday, August 13, 2026",
+        "quantity": "9.0",
+        "unit": "hour",
+        "billable_rate": "220.00",
+        "billable_amount": "1980.00",
+        "record_date_basis": "source_work_date",
+        "source_work_date": "2026-08-13",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    },
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-14",
+      "title": "Common excavation - Friday, August 14, 2026",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "04-common-excavation-2026-08-14",
+        "source_line_position": 4,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Common excavation - Friday, August 14, 2026",
+        "quantity": "6.0",
+        "unit": "hour",
+        "billable_rate": "220.00",
+        "billable_amount": "1320.00",
+        "record_date_basis": "source_work_date",
+        "source_work_date": "2026-08-14",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    },
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-15",
+      "title": "Mini excavator - footings and plumbing",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "05-mini-excavator-footings-plumbing",
+        "source_line_position": 5,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Mini excavator - footings and plumbing",
+        "quantity": "4.0",
+        "unit": "hour",
+        "billable_rate": "130.00",
+        "billable_amount": "520.00",
+        "record_date_basis": "invoice_date_reference_only",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    },
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-15",
+      "title": "Mobilize In",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "06-mobilize-in",
+        "source_line_position": 6,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Mobilize In",
+        "quantity": "1",
+        "unit": "each",
+        "billable_rate": "706.20",
+        "billable_amount": "706.20",
+        "record_date_basis": "invoice_date_reference_only",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    },
+    {
+      "record_type": "completed_work",
+      "work_date": "2026-08-15",
+      "title": "Mobilize Out",
+      "details": {
+        "source_import_key": "bowline-rawlison-2026-08-25",
+        "source_line_key": "07-mobilize-out",
+        "source_line_position": 7,
+        "source_invoice_number": "BOW-2026-0811",
+        "source_invoice_date": "2026-08-15",
+        "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+        "description": "Mobilize Out",
+        "quantity": "1",
+        "unit": "each",
+        "billable_rate": "706.20",
+        "billable_amount": "706.20",
+        "record_date_basis": "invoice_date_reference_only",
+        "cost_status": "internal_cost_unverified",
+        "revenue_trace_only": true
+      }
+    }
+  ]
 }

--- a/ops/scripts/production_awarded_invoice_import.py
+++ b/ops/scripts/production_awarded_invoice_import.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
@@ -61,7 +62,55 @@ def validate_bundle(bundle: dict[str, Any]) -> dict[str, Any]:
     calculated = invoice_totals(payload)
     expected = tuple(money(invoice[k]) for k in ("expected_subtotal", "expected_gst", "expected_total"))
     require(calculated == expected, f"invoice totals mismatch: calculated={calculated}, expected={expected}")
-    return {"issue_number": bundle["issue_number"], "import_key": bundle["import_key"], "project_count": 1, "invoice_count": 1, "validated": True}
+    completed_work_records = bundle.get("completed_work_records")
+    require(isinstance(completed_work_records, list), "completed_work_records must be a list")
+    require(len(completed_work_records) == len(payload["line_items"]), "completed-work count must match invoice line-item count")
+    source_line_keys: set[str] = set()
+    completed_work_total = Decimal("0")
+    for position, (completed_work, invoice_line) in enumerate(
+        zip(completed_work_records, payload["line_items"], strict=True),
+        start=1,
+    ):
+        require(completed_work.get("record_type") == "completed_work", "completed-work record_type must be completed_work")
+        require(not completed_work.get("project_id"), "completed-work bundle records must not supply project_id")
+        require("status" not in completed_work, "completed-work records must use the API recorded status")
+        details = completed_work.get("details") or {}
+        line_key = str(details.get("source_line_key") or "")
+        require(bool(line_key), "completed-work source_line_key is required")
+        require(line_key not in source_line_keys, f"duplicate completed-work source_line_key: {line_key}")
+        source_line_keys.add(line_key)
+        require(details.get("source_line_position") == position, "completed-work source line position mismatch")
+        require(details.get("source_import_key") == bundle["import_key"], "completed-work source import key mismatch")
+        require(details.get("source_invoice_number") == ref, "completed-work source invoice mismatch")
+        require(details.get("source_drive_file_id") == metadata["source_drive_file_id"], "completed-work source Drive file mismatch")
+        require(details.get("source_invoice_date") == payload["invoice_date"], "completed-work source invoice date mismatch")
+        require(completed_work.get("title") == invoice_line["description"], "completed-work title must match invoice line")
+        require(details.get("description") == invoice_line["description"], "completed-work description must match invoice line")
+        require(Decimal(str(details.get("quantity"))) == Decimal(str(invoice_line["quantity"])), "completed-work quantity must match invoice line")
+        require(Decimal(str(details.get("billable_rate"))) == Decimal(str(invoice_line["unit_price"])), "completed-work billable rate must match invoice line")
+        line_amount = money(Decimal(str(details["quantity"])) * Decimal(str(details["billable_rate"])))
+        require(money(details.get("billable_amount")) == line_amount, "completed-work billable amount mismatch")
+        require(details.get("cost_status") == "internal_cost_unverified", "completed-work internal cost must remain unverified")
+        require(details.get("revenue_trace_only") is True, "completed work must be revenue trace only")
+        require(not {"actual_cost", "actual_cost_amount", "internal_cost_amount", "internal_cost_rate"}.intersection(details), "completed work cannot include unverified actual-cost values")
+        source_work_date = details.get("source_work_date")
+        if source_work_date:
+            require(details.get("record_date_basis") == "source_work_date", "source work dates require source_work_date basis")
+            require(completed_work.get("work_date") == source_work_date, "completed-work date must match source work date")
+        else:
+            require(details.get("record_date_basis") == "invoice_date_reference_only", "undated source lines must use invoice-date reference basis")
+            require(completed_work.get("work_date") == payload["invoice_date"], "invoice-date reference must use invoice date")
+        completed_work_total += line_amount
+    require(money(completed_work_total) == expected[0], "completed-work total must match invoice subtotal")
+    return {
+        "issue_number": bundle["issue_number"],
+        "import_key": bundle["import_key"],
+        "project_count": 1,
+        "invoice_count": 1,
+        "completed_work_count": len(completed_work_records),
+        "completed_work_billable_total": str(money(completed_work_total)),
+        "validated": True,
+    }
 
 
 class IHOSClient:
@@ -71,7 +120,7 @@ class IHOSClient:
         jar = http.cookiejar.CookieJar()
         self.opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
 
-    def request(self, path: str, method: str = "GET", body: dict[str, Any] | None = None, expected: tuple[int, ...] = (200,)) -> dict[str, Any]:
+    def request(self, path: str, method: str = "GET", body: dict[str, Any] | None = None, expected: tuple[int, ...] = (200,)) -> Any:
         request = urllib.request.Request(self.base + path, data=None if body is None else json.dumps(body).encode(), method=method, headers={"Content-Type": "application/json"})
         try:
             with self.opener.open(request, timeout=30) as response:
@@ -93,6 +142,31 @@ def verify_job_number(value: Any) -> str:
     if "-" in number or not JOB_RE.fullmatch(number):
         raise RuntimeError(f"Generated IHOS job number is invalid: {number!r}")
     return number
+
+
+def verify_completed_work(record: dict[str, Any], payload: dict[str, Any], project_id: Any) -> None:
+    expected = {
+        "record_type": "completed_work",
+        "project_id": str(project_id),
+        "work_date": payload["work_date"],
+        "title": payload["title"],
+        "status": "recorded",
+        "severity": payload.get("severity", "none"),
+        "cost_code": payload.get("cost_code"),
+        "employee_id": payload.get("employee_id"),
+        "equipment_id": payload.get("equipment_id"),
+        "supplier_id": payload.get("supplier_id"),
+        "details": payload["details"],
+        "document_ids": payload.get("document_ids", []),
+        "signatures": payload.get("signatures", []),
+        "alert_recipients": payload.get("alert_recipients", []),
+    }
+    actual = dict(record)
+    actual["project_id"] = str(actual.get("project_id"))
+    mismatches = [field for field, value in expected.items() if actual.get(field) != value]
+    if mismatches:
+        line_key = payload["details"]["source_line_key"]
+        raise RuntimeError(f"Completed-work source line {line_key} differs in: {', '.join(mismatches)}")
 
 
 def import_bundle(bundle: dict[str, Any], client: IHOSClient) -> dict[str, Any]:
@@ -139,7 +213,56 @@ def import_bundle(bundle: dict[str, Any], client: IHOSClient) -> dict[str, Any]:
     for field, expected in (("subtotal", record["expected_subtotal"]), ("gst", record["expected_gst"]), ("total", record["expected_total"])):
         if str(invoice.get(field)) != str(expected):
             raise RuntimeError(f"Invoice {field} mismatch")
-    return {**validation, "project": {"id": project["id"], "operation": project_operation, "job_number": job_number, "status": project["status"]}, "invoice": {"id": invoice["id"], "operation": invoice_operation, "invoice_number": ref, "status": invoice["status"], "total": invoice["total"]}, "production_verified": True}
+
+    query = urllib.parse.urlencode({"project_id": project["id"], "source_import_key": bundle["import_key"]})
+    existing_records = client.request(f"/api/v1/field-operations/completed-work?{query}")
+    if not isinstance(existing_records, list):
+        raise RuntimeError("Completed-work lookup returned an invalid response")
+    existing_by_key: dict[str, dict[str, Any]] = {}
+    for existing in existing_records:
+        line_key = str((existing.get("details") or {}).get("source_line_key") or "")
+        if not line_key:
+            raise RuntimeError("Completed-work lookup returned a record without source_line_key")
+        if line_key in existing_by_key:
+            raise RuntimeError(f"Multiple completed-work records match source line {line_key}")
+        existing_by_key[line_key] = existing
+    expected_keys = {item["details"]["source_line_key"] for item in bundle["completed_work_records"]}
+    unexpected_keys = sorted(set(existing_by_key) - expected_keys)
+    if unexpected_keys:
+        raise RuntimeError(f"Unexpected completed-work source lines require manual review: {unexpected_keys}")
+
+    completed_results: list[dict[str, Any]] = []
+    for completed_payload in bundle["completed_work_records"]:
+        line_key = completed_payload["details"]["source_line_key"]
+        existing = existing_by_key.get(line_key)
+        if existing is not None:
+            verify_completed_work(existing, completed_payload, project["id"])
+            completed_results.append({"id": existing["id"], "source_line_key": line_key, "operation": "verified_existing"})
+            continue
+        create_payload = dict(completed_payload)
+        create_payload["project_id"] = project["id"]
+        created = client.request(
+            "/api/v1/field-operations/records",
+            method="POST",
+            body=create_payload,
+            expected=(201,),
+        )
+        verify_completed_work(created, completed_payload, project["id"])
+        completed_results.append({"id": created["id"], "source_line_key": line_key, "operation": "created"})
+
+    return {
+        **validation,
+        "project": {"id": project["id"], "operation": project_operation, "job_number": job_number, "status": project["status"]},
+        "invoice": {"id": invoice["id"], "operation": invoice_operation, "invoice_number": ref, "status": invoice["status"], "total": invoice["total"]},
+        "completed_work": {
+            "created": sum(item["operation"] == "created" for item in completed_results),
+            "verified_existing": sum(item["operation"] == "verified_existing" for item in completed_results),
+            "records": completed_results,
+            "billable_total": validation["completed_work_billable_total"],
+            "cost_status": "internal_cost_unverified",
+        },
+        "production_verified": True,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/ops/scripts/tests/test_production_awarded_invoice_import.py
+++ b/ops/scripts/tests/test_production_awarded_invoice_import.py
@@ -16,12 +16,72 @@ def valid_bundle():
     return json.loads((ROOT / "ops" / "production-awarded-invoice-imports" / "2026-08-25-bowline-rawlison.json").read_text())
 
 
+class FakeClient:
+    def __init__(self) -> None:
+        self.projects = []
+        self.invoices = []
+        self.completed_work = []
+        self.logged_in = False
+
+    def login(self):
+        self.logged_in = True
+
+    def request(self, path, method="GET", body=None, expected=(200,)):
+        assert self.logged_in
+        if path == "/api/v1/projects" and method == "GET":
+            return {"items": copy.deepcopy(self.projects)}
+        if path == "/api/v1/projects" and method == "POST":
+            record = {
+                **copy.deepcopy(body),
+                "id": "project-1",
+                "project_number": "IH2026001",
+            }
+            self.projects.append(record)
+            return copy.deepcopy(record)
+        if path == "/api/v1/finance/customer-invoices" and method == "GET":
+            return {"items": copy.deepcopy(self.invoices)}
+        if path == "/api/v1/finance/customer-invoices" and method == "POST":
+            subtotal, gst, total = MODULE.invoice_totals(body)
+            record = {
+                **copy.deepcopy(body),
+                "id": "invoice-1",
+                "status": "draft",
+                "subtotal": str(subtotal),
+                "gst": str(gst),
+                "total": str(total),
+            }
+            self.invoices.append(record)
+            return copy.deepcopy(record)
+        if path.startswith("/api/v1/field-operations/completed-work?") and method == "GET":
+            return copy.deepcopy(self.completed_work)
+        if path == "/api/v1/field-operations/records" and method == "POST":
+            record = {
+                **copy.deepcopy(body),
+                "id": f"completed-{len(self.completed_work) + 1}",
+                "status": "recorded",
+                "severity": body.get("severity", "none"),
+                "cost_code": body.get("cost_code"),
+                "employee_id": body.get("employee_id"),
+                "equipment_id": body.get("equipment_id"),
+                "supplier_id": body.get("supplier_id"),
+                "document_ids": body.get("document_ids", []),
+                "signatures": body.get("signatures", []),
+                "alert_recipients": body.get("alert_recipients", []),
+            }
+            self.completed_work.append(record)
+            return copy.deepcopy(record)
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+
 class AwardedInvoiceImportTests(unittest.TestCase):
     def test_bowline_bundle_validates(self):
         result = MODULE.validate_bundle(valid_bundle())
         self.assertTrue(result["validated"])
         self.assertEqual(result["project_count"], 1)
         self.assertEqual(result["invoice_count"], 1)
+        self.assertEqual(result["issue_number"], 353)
+        self.assertEqual(result["completed_work_count"], 7)
+        self.assertEqual(result["completed_work_billable_total"], "10622.40")
 
     def test_bundle_cannot_supply_job_number(self):
         bundle = valid_bundle()
@@ -62,6 +122,40 @@ class AwardedInvoiceImportTests(unittest.TestCase):
         del bundle["project"]["payload"]["metadata"]["source_drive_file_id"]
         with self.assertRaisesRegex(ValueError, "source_drive_file_id"):
             MODULE.validate_bundle(bundle)
+
+    def test_completed_work_must_match_invoice_and_cannot_invent_actual_cost(self):
+        bundle = valid_bundle()
+        bundle["completed_work_records"][0]["details"]["billable_amount"] = "1.00"
+        with self.assertRaisesRegex(ValueError, "billable amount mismatch"):
+            MODULE.validate_bundle(bundle)
+
+        bundle = valid_bundle()
+        bundle["completed_work_records"][0]["details"]["internal_cost_amount"] = "1000.00"
+        with self.assertRaisesRegex(ValueError, "actual-cost"):
+            MODULE.validate_bundle(bundle)
+
+    def test_import_creates_then_verifies_all_completed_work_idempotently(self):
+        client = FakeClient()
+        first = MODULE.import_bundle(valid_bundle(), client)
+        self.assertEqual(first["completed_work"]["created"], 7)
+        self.assertEqual(first["completed_work"]["verified_existing"], 0)
+        self.assertEqual(first["completed_work"]["billable_total"], "10622.40")
+        self.assertEqual(first["completed_work"]["cost_status"], "internal_cost_unverified")
+        self.assertEqual(len(client.completed_work), 7)
+
+        second = MODULE.import_bundle(valid_bundle(), client)
+        self.assertEqual(second["project"]["operation"], "verified_existing")
+        self.assertEqual(second["invoice"]["operation"], "verified_existing")
+        self.assertEqual(second["completed_work"]["created"], 0)
+        self.assertEqual(second["completed_work"]["verified_existing"], 7)
+        self.assertEqual(len(client.completed_work), 7)
+
+    def test_import_fails_closed_when_source_line_key_content_differs(self):
+        client = FakeClient()
+        MODULE.import_bundle(valid_bundle(), client)
+        client.completed_work[0]["title"] = "Conflicting historical claim"
+        with self.assertRaisesRegex(RuntimeError, "differs in: title"):
+            MODULE.import_bundle(valid_bundle(), client)
 
     def test_job_number_rejects_hyphens(self):
         with self.assertRaisesRegex(RuntimeError, "invalid"):

--- a/tests/backend/test_field_operations.py
+++ b/tests/backend/test_field_operations.py
@@ -64,6 +64,32 @@ def _project() -> dict:
     return response.json()
 
 
+def _completed_work_payload(project_id: str) -> dict:
+    return {
+        "record_type": "completed_work",
+        "project_id": project_id,
+        "work_date": "2026-08-11",
+        "title": "Common excavation - Tuesday, August 11, 2026",
+        "details": {
+            "source_import_key": "bowline-rawlison-2026-08-25",
+            "source_line_key": "01-common-excavation-2026-08-11",
+            "source_line_position": 1,
+            "source_invoice_number": "BOW-2026-0811",
+            "source_invoice_date": "2026-08-15",
+            "source_drive_file_id": "1laUuqBbgcU5ck8rIz0Qd3N-Gd6I8U5ZS",
+            "description": "Common excavation - Tuesday, August 11, 2026",
+            "quantity": "12.5",
+            "unit": "hour",
+            "billable_rate": "220.00",
+            "billable_amount": "2750.00",
+            "record_date_basis": "source_work_date",
+            "source_work_date": "2026-08-11",
+            "cost_status": "internal_cost_unverified",
+            "revenue_trace_only": True,
+        },
+    }
+
+
 def _invoice_document(project_id: str, name: str = "invoice.pdf") -> str:
     with TestingSessionLocal() as db:
         document = Document(
@@ -233,6 +259,55 @@ def test_flagged_inspection_alerts_management_and_accepts_signature() -> None:
     )
     assert signed.status_code == 200
     assert signed.json()["signatures"][0]["employee_name"] == "Crew Member"
+
+
+def test_completed_work_is_management_only_source_exact_and_idempotent() -> None:
+    project = _project()
+    payload = _completed_work_payload(project["id"])
+
+    created = client.post("/api/v1/field-operations/records", json=payload)
+    assert created.status_code == 201, created.text
+    assert created.json()["status"] == "recorded"
+    assert created.json()["details"]["cost_status"] == "internal_cost_unverified"
+
+    repeated = client.post("/api/v1/field-operations/records", json=payload)
+    assert repeated.status_code == 201, repeated.text
+    assert repeated.json()["id"] == created.json()["id"]
+
+    listed = client.get(
+        "/api/v1/field-operations/completed-work",
+        params={"project_id": project["id"], "source_import_key": payload["details"]["source_import_key"]},
+    )
+    assert listed.status_code == 200
+    assert [item["id"] for item in listed.json()] == [created.json()["id"]]
+
+    conflict_payload = {**payload, "title": "Conflicting description"}
+    conflict = client.post("/api/v1/field-operations/records", json=conflict_payload)
+    assert conflict.status_code == 409
+    assert "different content" in conflict.json()["error"]["message"]
+
+    _authenticate_as("viewer")
+    assert client.post("/api/v1/field-operations/records", json=payload).status_code == 403
+    assert client.get(
+        "/api/v1/field-operations/completed-work",
+        params={"project_id": project["id"], "source_import_key": payload["details"]["source_import_key"]},
+    ).status_code == 403
+    assert created.json()["id"] not in {
+        item["id"] for item in client.get("/api/v1/field-operations/bootstrap").json()["records"]
+    }
+
+
+def test_completed_work_rejects_inexact_revenue_or_invented_actual_cost() -> None:
+    project = _project()
+    payload = _completed_work_payload(project["id"])
+    payload["details"]["billable_amount"] = "1.00"
+    inexact = client.post("/api/v1/field-operations/records", json=payload)
+    assert inexact.status_code == 422
+
+    payload = _completed_work_payload(project["id"])
+    payload["details"]["internal_cost_amount"] = "1000.00"
+    invented_cost = client.post("/api/v1/field-operations/records", json=payload)
+    assert invented_cost.status_code == 422
 
 
 def test_safety_control_records_require_evidence_for_release_and_keep_history() -> None:


### PR DESCRIPTION
## Summary

- add management-only `completed_work` records with deterministic source identity and exact conflict checks
- keep completed work explicitly classified as revenue trace only with internal actual cost unverified
- expose a project/import-key lookup that is not capped by field bootstrap pagination
- stage all seven verified Bowline invoice lines with Drive/invoice provenance and exact $10,622.40 subtotal reconciliation
- make the awarded-project importer create missing work records and verify existing records on rerun

## Safety and governance

- invoice remains draft
- no employee, supervisor, cost code, source date, or internal cost fact is invented
- mini-excavator and mobilization entries use the invoice date as a reference only
- no production import, deployment, secret, or infrastructure mutation is included
- production workflow remains protected and requires explicit approval

## Validation

- `561 passed` — full backend test suite
- `10 passed` — awarded-project/importer focused tests
- Ruff: all checks passed
- bundle validation: 7 completed-work records; billable total `10622.40`
- `git diff --check`: clean

Closes #353
Relates #268
Source correction #351