### PR TITLE
Build 226: repair Bennett staging pilot workflow and resume draft proof

### DIFF
--- a/.github/workflows/bennett-staging-draft-pilot.yml
+++ b/.github/workflows/bennett-staging-draft-pilot.yml
@@ -20,13 +20,13 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
-      contains(github.event.workflow_run.head_commit.message, 'Build 225: repair Bennett staging pilot prerequisites and prove draft handoff')
+      contains(github.event.workflow_run.head_commit.message, 'Build 226: repair Bennett staging pilot workflow and resume draft proof')
     runs-on: [self-hosted, linux, ihos-staging]
     timeout-minutes: 45
     env:
       RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
-      EVIDENCE_DIR: ${{ runner.temp }}/bennett-staging-draft-pilot-evidence
-      PILOT_OPERATOR: Iron House OS GitHub staging pilot issue 365
+      EVIDENCE_DIR: /tmp/iron-house-os-bennett-staging-draft-pilot-${{ github.run_id }}-${{ github.run_attempt }}
+      PILOT_OPERATOR: Iron House OS GitHub staging pilot issue 367
     steps:
       - name: Initialize evidence directory
         run: mkdir -p "$EVIDENCE_DIR"

--- a/docs/validation/bennett-estimate-quote-staging-pilot.md
+++ b/docs/validation/bennett-estimate-quote-staging-pilot.md
@@ -6,7 +6,7 @@ Prove the issue #268 saved-estimate to customer-quote handoff against the authen
 
 ## Current scope
 
-The Build 225 pilot is intentionally draft-only. Human merge of the exact pull request authorizes the one-time shared-staging data plan recorded in `ops/staging-pilots/2026-08-27-bennett-draft-pilot.json`.
+The pilot is intentionally draft-only. Human merge of Build 225 authorized the shared-staging data plan recorded in `ops/staging-pilots/2026-08-27-bennett-draft-pilot.json`, but GitHub rejected run `33110981733` before any job or data action because `runner.temp` is unsupported in job-level `env`. Human merge of the exact Build 226 repair authorizes the same bounded proof to resume after the repair release deploys successfully to staging.
 
 The workflow:
 

--- a/ops/staging-pilots/2026-08-27-bennett-draft-pilot.json
+++ b/ops/staging-pilots/2026-08-27-bennett-draft-pilot.json
@@ -5,7 +5,9 @@
   "environment": "staging",
   "source": "bennett_strata_issue_314",
   "source_revision": "2026-08-27-final",
-  "trigger": "human merge of the exact Build 225 pull request followed by a successful exact-release staging deployment",
+  "initial_authorization": "human merge of Build 225 at ce57e72c4073f25decec2ca659a20585796de1d5",
+  "initial_workflow_result": "GitHub rejected run 33110981733 before any job or data action because runner.temp is unsupported in job-level env",
+  "trigger": "human merge of the exact Build 226 repair pull request followed by a successful exact-release staging deployment",
   "approval_scope": "authenticated shared-staging estimate-to-draft-quote proof only",
   "permitted_actions": [
     "repair the exact legacy STAGE-BENNETT-2026 opportunity marker",

--- a/tests/backend/test_bennett_staging_draft_pilot_workflow.py
+++ b/tests/backend/test_bennett_staging_draft_pilot_workflow.py
@@ -14,7 +14,12 @@ def test_workflow_runs_only_after_exact_human_merged_build_and_staging_deploy() 
     assert "github.event.workflow_run.conclusion == 'success'" in workflow
     assert "github.event.workflow_run.event == 'push'" in workflow
     assert "github.event.workflow_run.head_branch == 'main'" in workflow
-    assert "Build 225: repair Bennett staging pilot prerequisites and prove draft handoff" in workflow
+    assert "Build 226: repair Bennett staging pilot workflow and resume draft proof" in workflow
+    assert "runner.temp" not in workflow
+    assert (
+        "/tmp/iron-house-os-bennett-staging-draft-pilot-${{ github.run_id }}-${{ github.run_attempt }}"
+        in workflow
+    )
     assert 'test "$RELEASE_SHA" = "$(git rev-parse origin/main)"' in workflow
     assert "Live staging release mismatch" in workflow
     assert "bennett_strata_staging_import" in workflow
@@ -28,6 +33,9 @@ def test_approval_marker_and_pilot_are_draft_only() -> None:
 
     assert marker["environment"] == "staging"
     assert marker["source_revision"] == "2026-08-27-final"
+    assert "Build 225" in marker["initial_authorization"]
+    assert "before any job or data action" in marker["initial_workflow_result"]
+    assert "Build 226" in marker["trigger"]
     assert marker["expected_concrete_quote"] == {
         "subtotal": "36266.67",
         "gst": "1813.33",


### PR DESCRIPTION
## Outcome

Repairs the pre-job GitHub workflow rejection from the human-merged Build 225 Bennett staging pilot.

Build 225 deployed successfully to staging at `ce57e72c4073f25decec2ca659a20585796de1d5`, but pilot run [33110981733](https://github.com/iron-house-os/iron-house-os/actions/runs/33110981733) was rejected before any job or data action:

```
(Line: 28, Col: 21): Unrecognized named-value: 'runner'
```

No Bennett record or customer quote was changed by that failed run.

## Repair

- replaces unsupported job-level `runner.temp` with a unique narrow `/tmp` path keyed by GitHub run ID and retry attempt
- adds a regression assertion that forbids `runner.temp` in this workflow
- retargets the exact post-deploy trigger to this Build 226 repair merge
- records the Build 225 no-op failure and Build 226 recovery trigger
- preserves exact-current-main, exact-live-staging-release, immutable source, authenticated draft-only, no-job-number, no-award, and no-production controls

## Human merge effect

Merging this exact PR authorizes only the same bounded shared-staging draft proof approved in #365. After this exact release deploys successfully to staging, the workflow will import/reuse the immutable Bennett source and create/reuse one concrete customer quote draft.

It will **not** approve, issue, accept, send, or award the quote; allocate a job number; or mutate production.

## Verification

- 15 focused Bennett/workflow tests passed
- 589 backend tests passed
- 140 frontend tests passed
- backend and frontend lint passed
- frontend production build passed
- visual design lock passed
- React Router RSC security boundary passed
- Build 225 CI, Release Readiness, and exact staging deployment passed

Closes #367
