### PR TITLE
Build 228: execute approved Bennett staging award transition

### DIFF
--- a/.github/workflows/bennett-staging-award.yml
+++ b/.github/workflows/bennett-staging-award.yml
@@ -1,0 +1,123 @@
+name: Approved Bennett staging award transition
+
+on:
+  workflow_run:
+    workflows: ["Staging deploy"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: iron-house-os-bennett-staging-award
+  cancel-in-progress: false
+
+jobs:
+  award:
+    name: Accept exact Bennett quote and initialize awarded job
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(github.event.workflow_run.head_commit.message, 'Build 228: execute approved Bennett staging award transition')
+    runs-on: [self-hosted, linux, ihos-staging]
+    timeout-minutes: 30
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+      EVIDENCE_DIR: /tmp/iron-house-os-bennett-staging-award-${{ github.run_id }}-${{ github.run_attempt }}
+      PILOT_OPERATOR: Iron House OS GitHub staging award issue 371
+    steps:
+      - name: Initialize evidence directory
+        run: mkdir -p "$EVIDENCE_DIR"
+
+      - name: Check out exact approved release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+          fetch-depth: 0
+
+      - name: Verify current main and approval marker
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$RELEASE_SHA" = "$(git rev-parse origin/main)"
+          python3 -m json.tool ops/staging-pilots/2026-08-28-bennett-award-transition.json >/dev/null
+          python3 - <<'PY' > "$EVIDENCE_DIR/run-metadata.json"
+          import json
+          import os
+
+          print(json.dumps({
+              "issue": 371,
+              "parent_issues": [365, 367, 369],
+              "environment": "staging",
+              "release_sha": os.environ["RELEASE_SHA"],
+              "approval_boundary": "staging_acceptance_award_no_external_issue",
+              "quote_id": "8f854940-e710-45c2-aae4-7d5706c3a9e2",
+              "approval_evidence": "Jeremie Peters replied Accepted on 2026-08-28",
+          }, indent=2, sort_keys=True))
+          PY
+
+      - name: Verify exact live staging release
+        run: |
+          readiness="$(curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness)"
+          READINESS_JSON="$readiness" python3 - <<'PY' > "$EVIDENCE_DIR/readiness.json"
+          import json
+          import os
+
+          readiness = json.loads(os.environ["READINESS_JSON"])
+          actual = readiness.get("checks", {}).get("release_id")
+          expected = os.environ["RELEASE_SHA"]
+          if actual != expected:
+              raise SystemExit(f"Live staging release mismatch: expected {expected}, got {actual}")
+          print(json.dumps(readiness, indent=2, sort_keys=True))
+          PY
+
+      - name: Execute and verify approved staging award
+        run: |
+          compose=(
+            sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose
+            --env-file /etc/iron-house-os/staging.env
+            -f "$GITHUB_WORKSPACE/docker-compose.staging.yml"
+            -p iron-house-os-staging
+          )
+          "${compose[@]}" exec -T backend python -m app.tools.bennett_quote_staging_award \
+            --operator "$PILOT_OPERATOR" \
+            --base-url https://staging.os.ironhousecivil.com \
+            > "$EVIDENCE_DIR/award-report.json"
+          EVIDENCE_DIR="$EVIDENCE_DIR" python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          report = json.loads((Path(os.environ["EVIDENCE_DIR"]) / "award-report.json").read_text())
+          if report.get("status") != "passed":
+              raise SystemExit("Bennett staging award did not pass.")
+          if report.get("approval_boundary") != "staging_acceptance_award_no_external_issue":
+              raise SystemExit("Bennett award crossed its approval boundary.")
+          job_number = report.get("project", {}).get("job_number")
+          if not isinstance(job_number, str) or not re.fullmatch(r"IH2026\d{3}", job_number):
+              raise SystemExit("Bennett award did not allocate a valid permanent job number.")
+          if report.get("quote", {}).get("job_number") != job_number:
+              raise SystemExit("Bennett quote and project job numbers do not match.")
+          if report.get("project", {}).get("status") != "awarded":
+              raise SystemExit("Bennett project is not awarded.")
+          if report.get("quote", {}).get("status") != "accepted":
+              raise SystemExit("Bennett quote is not accepted.")
+          if report.get("idempotent_retry") is not True:
+              raise SystemExit("Bennett acceptance retry was not idempotent.")
+          if report.get("external_issuance_performed") is not False:
+              raise SystemExit("Bennett award performed prohibited external issuance.")
+          if report.get("production_mutation_performed") is not False:
+              raise SystemExit("Bennett award performed prohibited production mutation.")
+          PY
+
+      - name: Upload immutable award evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bennett-staging-award-${{ github.run_id }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 90

--- a/backend/app/tools/bennett_quote_staging_award.py
+++ b/backend/app/tools/bennett_quote_staging_award.py
@@ -1,0 +1,402 @@
+"""Execute and verify the explicitly approved Bennett quote award in shared staging."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from argparse import ArgumentParser
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.core.config import get_settings
+from app.services.bennett_strata_staging_import import PROJECT_NAME, SOURCE_KEY, SOURCE_REVISION
+from app.services.drive_tender_import import ImportValidationError
+from app.tools.bennett_estimate_quote_staging_pilot import (
+    Api,
+    ApiClient,
+    STAGING_BASE_URL,
+    _require_value,
+)
+
+PROJECT_ID = "9ece69c0-cd6b-4d7b-b208-df77ed849e23"
+WORKSPACE_ID = "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2"
+QUOTE_ID = "8f854940-e710-45c2-aae4-7d5706c3a9e2"
+QUOTE_NUMBER = "Q-2026-002"
+EXPECTED_SUBTOTAL = "36266.67"
+EXPECTED_GST = "1813.33"
+EXPECTED_TOTAL = "38080.00"
+ACCEPTANCE_REFERENCE = "Jeremie Peters management acceptance in ChatGPT on 2026-08-28"
+ACCEPTANCE_NOTE = (
+    "Accepted after Build 227 verified Bennett concrete quote Q-2026-002 in staging; "
+    "staging award only."
+)
+JOB_NUMBER_PATTERN = re.compile(r"^IH2026\d{3}$")
+
+
+def _money(value: object) -> str:
+    try:
+        return str(Decimal(str(value)).quantize(Decimal("0.01")))
+    except (InvalidOperation, TypeError, ValueError) as error:
+        raise ImportValidationError(f"Invalid money value: {value!r}") from error
+
+
+def _verify_source_records(
+    project: dict[str, Any],
+    workspace: dict[str, Any],
+    quote: dict[str, Any],
+) -> None:
+    project_metadata = project.get("metadata") or {}
+    source_metadata = project_metadata.get(SOURCE_KEY) or {}
+    estimate = workspace.get("estimate") or {}
+    expected = {
+        "project.id": (str(project.get("id")), PROJECT_ID),
+        "project.name": (project.get("name"), PROJECT_NAME),
+        "project.source_revision": (
+            source_metadata.get("latest_source_revision"),
+            SOURCE_REVISION,
+        ),
+        "workspace.id": (str(workspace.get("id")), WORKSPACE_ID),
+        "workspace.source": (estimate.get("source"), SOURCE_KEY),
+        "workspace.source_revision": (estimate.get("source_revision"), SOURCE_REVISION),
+        "workspace.estimate_key": (estimate.get("estimate_key"), "concrete"),
+        "quote.id": (str(quote.get("id")), QUOTE_ID),
+        "quote.project_id": (str(quote.get("project_id")), PROJECT_ID),
+        "quote.workspace_id": (
+            str(quote.get("source_estimate_workspace_id")),
+            WORKSPACE_ID,
+        ),
+        "quote.quote_number": (quote.get("quote_number"), QUOTE_NUMBER),
+        "quote.customer_name": (quote.get("customer_name"), "Bennett Strata"),
+        "quote.issue_status": (quote.get("issue_status"), "draft"),
+        "quote.subtotal": (_money(quote.get("subtotal")), EXPECTED_SUBTOTAL),
+        "quote.gst": (_money(quote.get("gst")), EXPECTED_GST),
+        "quote.total": (_money(quote.get("total")), EXPECTED_TOTAL),
+    }
+    mismatches = {
+        key: {"actual": actual, "expected": wanted}
+        for key, (actual, wanted) in expected.items()
+        if actual != wanted
+    }
+    if mismatches:
+        raise ImportValidationError(f"Bennett award source mismatch: {mismatches}")
+    if quote.get("issued_at") is not None:
+        raise ImportValidationError("Bennett quote was externally issued; this approval does not cover issuance.")
+
+
+def _classify_pre_state(project: dict[str, Any], quote: dict[str, Any]) -> str:
+    project_status = project.get("status")
+    project_number = project.get("project_number")
+    quote_status = quote.get("status")
+    quote_number = quote.get("job_number")
+    if (
+        project_status == "opportunity"
+        and project_number is None
+        and quote_status == "draft"
+        and quote_number is None
+        and quote.get("accepted_at") is None
+    ):
+        return "accept_and_award"
+    if (
+        project_status == "awarded"
+        and isinstance(project_number, str)
+        and JOB_NUMBER_PATTERN.fullmatch(project_number)
+        and quote_status == "accepted"
+        and quote_number == project_number
+        and quote.get("accepted_at") is not None
+    ):
+        return "reuse_existing_award"
+    raise ImportValidationError(
+        "Bennett project and quote are not in the exact pre-award or idempotent awarded state."
+    )
+
+
+def _verify_accepted_quote(quote: dict[str, Any], *, authenticated_email: str) -> str:
+    job_number = quote.get("job_number")
+    expected = {
+        "id": QUOTE_ID,
+        "project_id": PROJECT_ID,
+        "source_estimate_workspace_id": WORKSPACE_ID,
+        "quote_number": QUOTE_NUMBER,
+        "status": "accepted",
+        "issue_status": "draft",
+        "subtotal": EXPECTED_SUBTOTAL,
+        "gst": EXPECTED_GST,
+        "total": EXPECTED_TOTAL,
+        "accepted_by": authenticated_email,
+        "acceptance_reference": ACCEPTANCE_REFERENCE,
+        "acceptance_note": ACCEPTANCE_NOTE,
+    }
+    actual = {
+        **{key: quote.get(key) for key in expected},
+        "id": str(quote.get("id")),
+        "project_id": str(quote.get("project_id")),
+        "source_estimate_workspace_id": str(quote.get("source_estimate_workspace_id")),
+        "subtotal": _money(quote.get("subtotal")),
+        "gst": _money(quote.get("gst")),
+        "total": _money(quote.get("total")),
+    }
+    mismatches = {
+        key: {"actual": actual.get(key), "expected": value}
+        for key, value in expected.items()
+        if actual.get(key) != value
+    }
+    if mismatches:
+        raise ImportValidationError(f"Accepted Bennett quote mismatch: {mismatches}")
+    if not isinstance(job_number, str) or not JOB_NUMBER_PATTERN.fullmatch(job_number):
+        raise ImportValidationError(f"Invalid awarded job number: {job_number!r}")
+    if quote.get("accepted_at") is None or quote.get("issued_at") is not None:
+        raise ImportValidationError("Accepted quote lacks acceptance evidence or crossed issuance boundary.")
+    return job_number
+
+
+def _verify_awarded_project(project: dict[str, Any], *, job_number: str) -> dict[str, Any]:
+    if project.get("status") != "awarded" or project.get("project_number") != job_number:
+        raise ImportValidationError("Bennett project was not awarded under the quote job number.")
+    if _money(project.get("contract_value")) != EXPECTED_TOTAL:
+        raise ImportValidationError("Bennett awarded contract value does not match the accepted quote.")
+    metadata = project.get("metadata") or {}
+    baseline = metadata.get("award_pricing_baseline") or {}
+    procurement = metadata.get("procurement_plan") or {}
+    expected_baseline = {
+        "source_quote_id": QUOTE_ID,
+        "source_quote_number": QUOTE_NUMBER,
+        "pricing_subtotal": EXPECTED_SUBTOTAL,
+        "basis": "accepted_customer_quote_price",
+        "cost_budget_status": "needs_cost_allocation",
+    }
+    baseline_mismatches = {
+        key: {"actual": baseline.get(key), "expected": value}
+        for key, value in expected_baseline.items()
+        if str(baseline.get(key)) != value
+    }
+    if baseline_mismatches:
+        raise ImportValidationError(f"Bennett award baseline mismatch: {baseline_mismatches}")
+    lines = baseline.get("lines") or []
+    if not lines or any(line.get("cost_budget_amount") is not None for line in lines):
+        raise ImportValidationError("Award pricing was treated as a committed cost budget.")
+    if (
+        procurement.get("source_quote_id") != QUOTE_ID
+        or procurement.get("status") != "draft"
+        or procurement.get("automatic_commitment") is not False
+    ):
+        raise ImportValidationError("Bennett procurement draft controls were not initialized safely.")
+    requirements = procurement.get("requirements") or []
+    if any(item.get("po_number") is not None or item.get("approval") is not None for item in requirements):
+        raise ImportValidationError("Award initialization created a prohibited procurement commitment.")
+    return {
+        "award_line_count": len(lines),
+        "procurement_requirement_count": len(requirements),
+        "cost_budget_status": baseline.get("cost_budget_status"),
+        "procurement_status": procurement.get("status"),
+        "automatic_commitment": procurement.get("automatic_commitment"),
+    }
+
+
+def run_award(
+    api: Api,
+    *,
+    operator: str,
+    email: str,
+    password: str,
+) -> dict[str, Any]:
+    readiness = _require_value(api.request("/readiness"), "Readiness")
+    api.request(
+        "/api/v1/auth/login",
+        method="POST",
+        body={"email": email, "password": password},
+    )
+    authenticated = _require_value(api.request("/api/v1/auth/me"), "Authenticated user")
+    authenticated_user = authenticated.get("user") or authenticated
+    authenticated_email = str(authenticated_user.get("email") or "")
+    if authenticated_user.get("role") not in {"admin", "operations_manager"}:
+        raise ImportValidationError("Authenticated staging user lacks management award authority.")
+
+    project = _require_value(api.request(f"/api/v1/projects/{PROJECT_ID}"), "Bennett project")
+    workspaces = _require_value(
+        api.request(f"/api/v1/estimates/workspace/project/{PROJECT_ID}"),
+        "Bennett estimate workspaces",
+    )
+    workspace_matches = [
+        item for item in workspaces.get("items", []) if str(item.get("id")) == WORKSPACE_ID
+    ]
+    if len(workspace_matches) != 1:
+        raise ImportValidationError("Expected one exact Bennett concrete estimate workspace.")
+    workspace = workspace_matches[0]
+    quote = _require_value(api.request(f"/api/v1/customer-quotes/{QUOTE_ID}"), "Bennett quote")
+    _verify_source_records(project, workspace, quote)
+    transition_action = _classify_pre_state(project, quote)
+
+    acceptance = {
+        "expected_revision": int(quote.get("record_revision") or 0),
+        "acceptance_reference": ACCEPTANCE_REFERENCE,
+        "acceptance_note": ACCEPTANCE_NOTE,
+    }
+    accepted = _require_value(
+        api.request(
+            f"/api/v1/customer-quotes/{QUOTE_ID}/accept",
+            method="POST",
+            body=acceptance,
+        ),
+        "Accepted Bennett quote",
+    )
+    job_number = _verify_accepted_quote(accepted, authenticated_email=authenticated_email)
+    accepted_retry = _require_value(
+        api.request(
+            f"/api/v1/customer-quotes/{QUOTE_ID}/accept",
+            method="POST",
+            body=acceptance,
+        ),
+        "Idempotent Bennett acceptance retry",
+    )
+    retry_job_number = _verify_accepted_quote(
+        accepted_retry,
+        authenticated_email=authenticated_email,
+    )
+    immutable_fields = ("id", "record_revision", "accepted_at", "accepted_by", "acceptance_reference")
+    if retry_job_number != job_number or any(
+        accepted_retry.get(field) != accepted.get(field) for field in immutable_fields
+    ):
+        raise ImportValidationError("Acceptance retry changed the awarded quote or job number.")
+
+    project_after = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}"),
+        "Awarded Bennett project",
+    )
+    controls = _verify_awarded_project(project_after, job_number=job_number)
+    awarded_workspace = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}/workspace"),
+        "Awarded Bennett workspace",
+    )
+    checklist = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}/start-checklist"),
+        "Bennett start checklist",
+    )
+    dashboard = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}/launch-dashboard"),
+        "Bennett launch dashboard",
+    )
+    if awarded_workspace.get("job_number") != job_number:
+        raise ImportValidationError("Awarded project workspace does not use the permanent job number.")
+    if checklist.get("total_count") != 10 or checklist.get("completed_count") != 0:
+        raise ImportValidationError("Bennett start checklist was not initialized in the expected safe state.")
+    expected_dashboard = {
+        "job_number": job_number,
+        "mobilization_status": "not_ready",
+        "award_baseline_source": QUOTE_NUMBER,
+        "award_pricing_subtotal": EXPECTED_SUBTOTAL,
+        "award_cost_budget_status": "needs_cost_allocation",
+        "procurement_plan_status": "draft",
+    }
+    dashboard_actual = {
+        **{key: dashboard.get(key) for key in expected_dashboard},
+        "award_pricing_subtotal": _money(dashboard.get("award_pricing_subtotal")),
+    }
+    dashboard_mismatches = {
+        key: {"actual": dashboard_actual.get(key), "expected": value}
+        for key, value in expected_dashboard.items()
+        if dashboard_actual.get(key) != value
+    }
+    if dashboard_mismatches:
+        raise ImportValidationError(f"Bennett launch dashboard mismatch: {dashboard_mismatches}")
+
+    api.request("/api/v1/auth/logout", method="POST", expected_status=204)
+    return {
+        "status": "passed",
+        "pilot": "bennett_quote_staging_award",
+        "approval_boundary": "staging_acceptance_award_no_external_issue",
+        "operator": operator,
+        "authenticated_as": authenticated_email,
+        "authenticated_role": authenticated_user.get("role"),
+        "release_id": (readiness.get("checks") or {}).get("release_id"),
+        "source": SOURCE_KEY,
+        "source_revision": SOURCE_REVISION,
+        "transition_action": transition_action,
+        "project": {
+            "id": PROJECT_ID,
+            "status": project_after.get("status"),
+            "job_number": job_number,
+            "contract_value": _money(project_after.get("contract_value")),
+        },
+        "workspace": {"id": WORKSPACE_ID, "estimate_key": "concrete"},
+        "quote": {
+            "id": QUOTE_ID,
+            "quote_number": QUOTE_NUMBER,
+            "status": accepted.get("status"),
+            "issue_status": accepted.get("issue_status"),
+            "record_revision": accepted.get("record_revision"),
+            "subtotal": _money(accepted.get("subtotal")),
+            "gst": _money(accepted.get("gst")),
+            "total": _money(accepted.get("total")),
+            "job_number": job_number,
+            "accepted_at": accepted.get("accepted_at"),
+            "accepted_by": accepted.get("accepted_by"),
+            "acceptance_reference": accepted.get("acceptance_reference"),
+            "issued_at": accepted.get("issued_at"),
+        },
+        "award_controls": controls,
+        "project_workspace_root": awarded_workspace.get("root_folder"),
+        "start_checklist": {
+            "status": checklist.get("status"),
+            "completed_count": checklist.get("completed_count"),
+            "total_count": checklist.get("total_count"),
+        },
+        "launch_dashboard": {
+            key: dashboard.get(key)
+            for key in (
+                "mobilization_status",
+                "award_baseline_source",
+                "award_pricing_subtotal",
+                "award_cost_budget_status",
+                "uncoded_award_line_count",
+                "procurement_requirement_count",
+                "procurement_plan_status",
+                "po_request_count",
+            )
+        },
+        "idempotent_retry": True,
+        "external_issuance_performed": False,
+        "production_mutation_performed": False,
+        "verified_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Execute the approved Bennett quote award in staging.")
+    parser.add_argument("--operator", required=True)
+    parser.add_argument("--base-url", default=STAGING_BASE_URL)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    settings = get_settings()
+    if settings.environment != "staging":
+        print(json.dumps({"status": "blocked", "issues": ["This award is staging-only."]}, indent=2))
+        raise SystemExit(2)
+    email = os.environ.get("BOOTSTRAP_ADMIN_EMAIL", "").strip()
+    password = os.environ.get("BOOTSTRAP_ADMIN_PASSWORD", "")
+    if not email or not password:
+        print(
+            json.dumps(
+                {"status": "blocked", "issues": ["Staging administrator credentials are unavailable."]},
+                indent=2,
+            )
+        )
+        raise SystemExit(2)
+    try:
+        report = run_award(
+            ApiClient(args.base_url),
+            operator=args.operator.strip(),
+            email=email,
+            password=password,
+        )
+    except (ImportValidationError, OSError, ValueError) as error:
+        print(json.dumps({"status": "blocked", "issues": [str(error)]}, indent=2))
+        raise SystemExit(2) from error
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/validation/bennett-staging-award-transition.md
+++ b/docs/validation/bennett-staging-award-transition.md
@@ -1,0 +1,23 @@
+# Bennett staging award transition
+
+## Objective
+
+Convert the exact verified Bennett concrete quote draft into one awarded staging job after explicit management acceptance, without external issuance or production mutation.
+
+## Approval and scope
+
+Build 227 created and verified `Q-2026-002` in shared staging. On 2026-08-28, after the handoff identified explicit management acceptance or award as the next gate, Jeremie Peters replied **Accepted**.
+
+The Build 228 workflow is therefore limited to:
+
+- the exact Bennett opportunity, concrete estimate workspace, and quote recorded in `ops/staging-pilots/2026-08-28-bennett-award-transition.json`;
+- the existing authenticated management acceptance endpoint;
+- one permanent `IHYYYYNNN` job number with no hyphens;
+- idempotent initialization and verification of the award pricing baseline, draft procurement plan, project workspace, start checklist, and launch dashboard;
+- immutable staging evidence retained for 90 days.
+
+It does not issue or send the quote, create procurement commitments, or mutate production.
+
+## Execution gate
+
+The workflow runs only after a human merges the exact Build 228 pull request and that exact release deploys successfully to staging. It fails closed on release drift, record drift, value drift, prior external issuance, an unexpected job number, duplicate allocation, or unsafe downstream controls.

--- a/ops/staging-pilots/2026-08-28-bennett-award-transition.json
+++ b/ops/staging-pilots/2026-08-28-bennett-award-transition.json
@@ -1,0 +1,41 @@
+{
+  "issue": 371,
+  "parent_issues": [365, 367, 369],
+  "environment": "staging",
+  "source": "bennett_strata_issue_314",
+  "source_revision": "2026-08-27-final",
+  "approval_evidence": "Jeremie Peters replied Accepted on 2026-08-28 immediately after the Build 227 handoff identified explicit management acceptance or award as the next gate",
+  "approval_scope": "accept the exact verified Bennett concrete quote and initialize its awarded staging job",
+  "trigger": "human merge of the exact Build 228 pull request followed by a successful exact-release staging deployment",
+  "exact_records": {
+    "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+    "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+    "quote_id": "8f854940-e710-45c2-aae4-7d5706c3a9e2",
+    "quote_number": "Q-2026-002"
+  },
+  "expected_quote": {
+    "subtotal": "36266.67",
+    "gst": "1813.33",
+    "total": "38080.00"
+  },
+  "acceptance": {
+    "reference": "Jeremie Peters management acceptance in ChatGPT on 2026-08-28",
+    "note": "Accepted after Build 227 verified Bennett concrete quote Q-2026-002 in staging; staging award only."
+  },
+  "permitted_actions": [
+    "authenticate through the live HTTPS staging origin",
+    "accept the exact quote once through the existing management endpoint",
+    "allocate one permanent IHYYYYNNN job number with no hyphens",
+    "initialize the award pricing baseline, draft procurement plan, project workspace, start checklist, and launch dashboard",
+    "repeat the acceptance request to prove idempotency",
+    "upload immutable evidence retained for 90 days"
+  ],
+  "prohibited_actions": [
+    "issue or externally send the quote",
+    "change quote scope or value",
+    "create a second quote, opportunity, or job number",
+    "approve procurement commitments or purchase orders",
+    "mutate production",
+    "change DNS, certificates, secrets, backups, authentication, or infrastructure"
+  ]
+}

--- a/tests/backend/test_bennett_quote_staging_award.py
+++ b/tests/backend/test_bennett_quote_staging_award.py
@@ -1,0 +1,229 @@
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from app.services.bennett_strata_staging_import import PROJECT_NAME, SOURCE_KEY, SOURCE_REVISION
+from app.services.drive_tender_import import ImportValidationError
+from app.tools.bennett_quote_staging_award import (
+    ACCEPTANCE_NOTE,
+    ACCEPTANCE_REFERENCE,
+    PROJECT_ID,
+    QUOTE_ID,
+    STAGING_BASE_URL,
+    WORKSPACE_ID,
+    _parser,
+    run_award,
+)
+
+JOB_NUMBER = "IH2026007"
+
+
+def test_cli_defaults_to_secure_live_staging_origin() -> None:
+    args = _parser().parse_args(["--operator", "GitHub staging award"])
+
+    assert args.base_url == STAGING_BASE_URL
+    assert args.base_url == "https://staging.os.ironhousecivil.com"
+
+
+class FakeApi:
+    def __init__(self, *, already_awarded: bool = False) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None, int]] = []
+        self.project = {
+            "id": PROJECT_ID,
+            "name": PROJECT_NAME,
+            "status": "opportunity",
+            "project_number": None,
+            "contract_value": None,
+            "metadata": {SOURCE_KEY: {"latest_source_revision": SOURCE_REVISION}},
+        }
+        self.workspace = {
+            "id": WORKSPACE_ID,
+            "estimate": {
+                "source": SOURCE_KEY,
+                "source_revision": SOURCE_REVISION,
+                "estimate_key": "concrete",
+            },
+        }
+        self.quote = {
+            "id": QUOTE_ID,
+            "project_id": PROJECT_ID,
+            "source_estimate_workspace_id": WORKSPACE_ID,
+            "quote_number": "Q-2026-002",
+            "customer_name": "Bennett Strata",
+            "subtotal": "36266.67",
+            "gst": "1813.33",
+            "total": "38080.00",
+            "status": "draft",
+            "issue_status": "draft",
+            "record_revision": 1,
+            "job_number": None,
+            "accepted_at": None,
+            "accepted_by": None,
+            "acceptance_reference": None,
+            "acceptance_note": None,
+            "issued_at": None,
+        }
+        if already_awarded:
+            self._apply_award()
+
+    def _apply_award(self) -> None:
+        if self.quote["status"] == "accepted":
+            return
+        self.quote.update(
+            {
+                "status": "accepted",
+                "record_revision": 2,
+                "job_number": JOB_NUMBER,
+                "accepted_at": "2026-08-28T01:30:00Z",
+                "accepted_by": "admin@ironhousecontracting.com",
+                "acceptance_reference": ACCEPTANCE_REFERENCE,
+                "acceptance_note": ACCEPTANCE_NOTE,
+            }
+        )
+        self.project.update(
+            {
+                "status": "awarded",
+                "project_number": JOB_NUMBER,
+                "contract_value": 38080.0,
+            }
+        )
+        self.project["metadata"].update(
+            {
+                "award_pricing_baseline": {
+                    "source_quote_id": QUOTE_ID,
+                    "source_quote_number": "Q-2026-002",
+                    "source_quote_revision": 2,
+                    "pricing_subtotal": "36266.67",
+                    "basis": "accepted_customer_quote_price",
+                    "cost_budget_status": "needs_cost_allocation",
+                    "lines": [
+                        {
+                            "description": "Concrete pull and pour",
+                            "cost_code": None,
+                            "cost_budget_amount": None,
+                        }
+                    ],
+                },
+                "procurement_plan": {
+                    "source_quote_id": QUOTE_ID,
+                    "status": "draft",
+                    "automatic_commitment": False,
+                    "requirements": [
+                        {"description": "Concrete", "po_number": None, "approval": None}
+                    ],
+                },
+            }
+        )
+
+    def request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+        expected_status: int = 200,
+    ) -> dict[str, Any] | None:
+        self.calls.append((path, method, body, expected_status))
+        if path == "/readiness":
+            return {"checks": {"release_id": "b" * 40}}
+        if path == "/api/v1/auth/login":
+            return {"user": {"email": "admin@ironhousecontracting.com", "role": "admin"}}
+        if path == "/api/v1/auth/me":
+            return {"user": {"email": "admin@ironhousecontracting.com", "role": "admin"}}
+        if path == f"/api/v1/projects/{PROJECT_ID}" and method == "GET":
+            return deepcopy(self.project)
+        if path == f"/api/v1/estimates/workspace/project/{PROJECT_ID}":
+            return {"items": [deepcopy(self.workspace)], "total": 1}
+        if path == f"/api/v1/customer-quotes/{QUOTE_ID}" and method == "GET":
+            return deepcopy(self.quote)
+        if path == f"/api/v1/customer-quotes/{QUOTE_ID}/accept":
+            self._apply_award()
+            return deepcopy(self.quote)
+        if path == f"/api/v1/projects/{PROJECT_ID}/workspace":
+            return {"job_number": JOB_NUMBER, "root_folder": f"{JOB_NUMBER}_BennettStrata"}
+        if path == f"/api/v1/projects/{PROJECT_ID}/start-checklist":
+            return {"status": "not_ready", "completed_count": 0, "total_count": 10}
+        if path == f"/api/v1/projects/{PROJECT_ID}/launch-dashboard":
+            return {
+                "job_number": JOB_NUMBER,
+                "mobilization_status": "not_ready",
+                "award_baseline_source": "Q-2026-002",
+                "award_pricing_subtotal": 36266.67,
+                "award_cost_budget_status": "needs_cost_allocation",
+                "uncoded_award_line_count": 1,
+                "procurement_requirement_count": 1,
+                "procurement_plan_status": "draft",
+                "po_request_count": 0,
+            }
+        if path == "/api/v1/auth/logout":
+            return None
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+
+@pytest.mark.parametrize(
+    ("already_awarded", "expected_action"),
+    [(False, "accept_and_award"), (True, "reuse_existing_award")],
+)
+def test_award_is_exact_safe_and_idempotent(already_awarded: bool, expected_action: str) -> None:
+    api = FakeApi(already_awarded=already_awarded)
+
+    report = run_award(
+        api,
+        operator="GitHub staging award",
+        email="admin@ironhousecontracting.com",
+        password="not-recorded",
+    )
+
+    assert report["status"] == "passed"
+    assert report["approval_boundary"] == "staging_acceptance_award_no_external_issue"
+    assert report["transition_action"] == expected_action
+    assert report["project"] == {
+        "id": PROJECT_ID,
+        "status": "awarded",
+        "job_number": JOB_NUMBER,
+        "contract_value": "38080.00",
+    }
+    assert report["quote"]["status"] == "accepted"
+    assert report["quote"]["issue_status"] == "draft"
+    assert report["quote"]["job_number"] == JOB_NUMBER
+    assert report["quote"]["issued_at"] is None
+    assert report["idempotent_retry"] is True
+    assert report["external_issuance_performed"] is False
+    assert report["production_mutation_performed"] is False
+    assert "not-recorded" not in str(report)
+
+    acceptance_calls = [call for call in api.calls if call[0].endswith("/accept")]
+    assert len(acceptance_calls) == 2
+    assert all(call[1] == "POST" and call[2]["acceptance_reference"] == ACCEPTANCE_REFERENCE for call in acceptance_calls)
+    assert not any("issue-status" in path for path, *_ in api.calls)
+
+
+def test_award_fails_closed_on_quote_value_drift() -> None:
+    api = FakeApi()
+    api.quote["total"] = "38079.99"
+
+    with pytest.raises(ImportValidationError, match="source mismatch"):
+        run_award(
+            api,
+            operator="GitHub staging award",
+            email="admin@ironhousecontracting.com",
+            password="not-recorded",
+        )
+
+    assert not any(path.endswith("/accept") for path, *_ in api.calls)
+
+
+def test_award_fails_closed_after_external_issuance() -> None:
+    api = FakeApi()
+    api.quote["issued_at"] = "2026-08-28T01:00:00Z"
+
+    with pytest.raises(ImportValidationError, match="does not cover issuance"):
+        run_award(
+            api,
+            operator="GitHub staging award",
+            email="admin@ironhousecontracting.com",
+            password="not-recorded",
+        )
+
+    assert not any(path.endswith("/accept") for path, *_ in api.calls)

--- a/tests/backend/test_bennett_staging_award_workflow.py
+++ b/tests/backend/test_bennett_staging_award_workflow.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/bennett-staging-award.yml"
+MARKER = ROOT / "ops/staging-pilots/2026-08-28-bennett-award-transition.json"
+AWARD_TOOL = ROOT / "backend/app/tools/bennett_quote_staging_award.py"
+
+
+def test_workflow_runs_only_after_exact_human_merged_build_and_staging_deploy() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'workflows: ["Staging deploy"]' in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "github.event.workflow_run.event == 'push'" in workflow
+    assert "github.event.workflow_run.head_branch == 'main'" in workflow
+    assert "Build 228: execute approved Bennett staging award transition" in workflow
+    assert "runner.temp" not in workflow
+    assert (
+        "/tmp/iron-house-os-bennett-staging-award-${{ github.run_id }}-${{ github.run_attempt }}"
+        in workflow
+    )
+    assert 'test "$RELEASE_SHA" = "$(git rev-parse origin/main)"' in workflow
+    assert "Live staging release mismatch" in workflow
+    assert "bennett_quote_staging_award" in workflow
+    assert "--base-url https://staging.os.ironhousecivil.com" in workflow
+    assert "http://127.0.0.1:8000" not in workflow
+    assert "retention-days: 90" in workflow
+
+
+def test_approval_marker_and_tool_match_the_exact_authorized_boundary() -> None:
+    marker = json.loads(MARKER.read_text(encoding="utf-8"))
+    tool = AWARD_TOOL.read_text(encoding="utf-8")
+
+    assert marker["issue"] == 371
+    assert marker["environment"] == "staging"
+    assert marker["source_revision"] == "2026-08-27-final"
+    assert "replied Accepted" in marker["approval_evidence"]
+    assert "Build 228" in marker["trigger"]
+    assert marker["exact_records"] == {
+        "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+        "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+        "quote_id": "8f854940-e710-45c2-aae4-7d5706c3a9e2",
+        "quote_number": "Q-2026-002",
+    }
+    assert marker["expected_quote"] == {
+        "subtotal": "36266.67",
+        "gst": "1813.33",
+        "total": "38080.00",
+    }
+    assert "mutate production" in marker["prohibited_actions"]
+    assert "issue or externally send the quote" in marker["prohibited_actions"]
+
+    assert "/api/v1/auth/login" in tool
+    assert '/api/v1/customer-quotes/{QUOTE_ID}/accept' in tool
+    assert '"approval_boundary": "staging_acceptance_award_no_external_issue"' in tool
+    assert "JOB_NUMBER_PATTERN" in tool
+    assert "/issue-status" not in tool


### PR DESCRIPTION
## Outcome

Implements the exact, staging-only award transition authorized by Jeremie Peters’ explicit **“Accepted”** response on 2026-08-28.

Build 227 already verified the source-linked Bennett concrete quote:

- project `9ece69c0-cd6b-4d7b-b208-df77ed849e23`
- concrete workspace `6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2`
- quote `8f854940-e710-45c2-aae4-7d5706c3a9e2` / `Q-2026-002`
- $36,266.67 subtotal + $1,813.33 GST = $38,080.00
- opportunity/draft state with no job number

## Controlled transition

After human merge and a successful deployment of the exact merge release to staging, the new one-time workflow will:

- authenticate through the live HTTPS staging origin;
- fail closed unless every exact record, source, amount, and pre-award state matches;
- call the existing management acceptance endpoint for the exact quote;
- verify the quote becomes accepted and the project becomes awarded;
- verify one shared permanent `IHYYYYNNN` job number with no hyphens;
- verify award pricing, draft procurement, project workspace, ten-item start checklist, and launch dashboard controls;
- repeat acceptance to prove idempotency;
- retain immutable evidence for 90 days.

The workflow also supports a safe rerun if the exact award already completed.

## Approval boundary

Merging this exact PR authorizes only the shared-staging acceptance and award transition described above.

It will **not**:

- issue, email, text, or externally send the quote;
- change scope, rates, GST, totals, terms, customer, or location;
- create a second quote, opportunity, or job number;
- approve procurement commitments or purchase orders;
- mutate production, DNS, certificates, secrets, backups, authentication, or infrastructure.

## Verification

- 7 focused award/workflow tests passed
- 597 backend tests passed
- 140 frontend tests passed
- backend and frontend lint passed
- frontend production build passed
- visual design lock passed
- React Router RSC security boundary passed
- local verified tree matches remote commit tree `e10a5902badc0690b86ff9b8e482a66eddab80d6`

Closes #371
