### PR TITLE
Build 229: seed awarded Bennett cost budget and job codes

### DIFF
--- a/.github/workflows/bennett-staging-cost-budget.yml
+++ b/.github/workflows/bennett-staging-cost-budget.yml
@@ -1,0 +1,123 @@
+name: Approved Bennett staging original cost budget
+
+on:
+  workflow_run:
+    workflows: ["Staging deploy"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: iron-house-os-bennett-staging-cost-budget
+  cancel-in-progress: false
+
+jobs:
+  budget:
+    name: Seed exact Bennett original budget and approved job codes
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(github.event.workflow_run.head_commit.message, 'Build 229: seed awarded Bennett cost budget and job codes')
+    runs-on: [self-hosted, linux, ihos-staging]
+    timeout-minutes: 30
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+      EVIDENCE_DIR: /tmp/iron-house-os-bennett-staging-cost-budget-${{ github.run_id }}-${{ github.run_attempt }}
+      PILOT_OPERATOR: Iron House OS GitHub staging budget issue 373
+    steps:
+      - name: Initialize evidence directory
+        run: mkdir -p "$EVIDENCE_DIR"
+
+      - name: Check out exact approved release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+          fetch-depth: 0
+
+      - name: Verify current main and approval marker
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$RELEASE_SHA" = "$(git rev-parse origin/main)"
+          python3 -m json.tool ops/staging-pilots/2026-08-28-bennett-cost-budget.json >/dev/null
+          python3 - <<'PY' > "$EVIDENCE_DIR/run-metadata.json"
+          import json
+          import os
+
+          print(json.dumps({
+              "issue": 373,
+              "parent_issues": [268, 314, 371],
+              "environment": "staging",
+              "release_sha": os.environ["RELEASE_SHA"],
+              "approval_boundary": "staging_original_budget_only_no_commitments",
+              "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+              "job_number": "IH2026002",
+              "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+          }, indent=2, sort_keys=True))
+          PY
+
+      - name: Verify exact live staging release
+        run: |
+          readiness="$(curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness)"
+          READINESS_JSON="$readiness" python3 - <<'PY' > "$EVIDENCE_DIR/readiness.json"
+          import json
+          import os
+
+          readiness = json.loads(os.environ["READINESS_JSON"])
+          actual = readiness.get("checks", {}).get("release_id")
+          expected = os.environ["RELEASE_SHA"]
+          if actual != expected:
+              raise SystemExit(f"Live staging release mismatch: expected {expected}, got {actual}")
+          print(json.dumps(readiness, indent=2, sort_keys=True))
+          PY
+
+      - name: Seed and verify approved original cost budget
+        run: |
+          compose=(
+            sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose
+            --env-file /etc/iron-house-os/staging.env
+            -f "$GITHUB_WORKSPACE/docker-compose.staging.yml"
+            -p iron-house-os-staging
+          )
+          "${compose[@]}" exec -T backend python -m app.tools.bennett_cost_budget_staging_pilot \
+            --operator "$PILOT_OPERATOR" \
+            --base-url https://staging.os.ironhousecivil.com \
+            > "$EVIDENCE_DIR/budget-report.json"
+          EVIDENCE_DIR="$EVIDENCE_DIR" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads((Path(os.environ["EVIDENCE_DIR"]) / "budget-report.json").read_text())
+          if report.get("status") != "passed":
+              raise SystemExit("Bennett original cost-budget pilot did not pass.")
+          if report.get("approval_boundary") != "staging_original_budget_only_no_commitments":
+              raise SystemExit("Bennett budget pilot crossed its approval boundary.")
+          if report.get("project", {}).get("job_number") != "IH2026002":
+              raise SystemExit("Bennett budget attached to the wrong job number.")
+          if report.get("budget", {}).get("total") != "26660.93":
+              raise SystemExit("Bennett original budget total is wrong.")
+          if report.get("budget", {}).get("entry_count") != 5:
+              raise SystemExit("Bennett original budget entry count is wrong.")
+          if report.get("idempotent_retry") is not True:
+              raise SystemExit("Bennett cost-budget retry was not idempotent.")
+          for field in ("commitments_created", "actuals_created", "po_requests_created", "checklist_items_completed"):
+              if report.get(field) != 0:
+                  raise SystemExit(f"Bennett budget pilot crossed prohibited boundary: {field}")
+          if report.get("external_issuance_performed") is not False:
+              raise SystemExit("Bennett budget pilot performed prohibited external issuance.")
+          if report.get("production_mutation_performed") is not False:
+              raise SystemExit("Bennett budget pilot performed prohibited production mutation.")
+          PY
+
+      - name: Upload immutable budget evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bennett-staging-cost-budget-${{ github.run_id }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 90

--- a/backend/app/schemas/finance.py
+++ b/backend/app/schemas/finance.py
@@ -148,6 +148,10 @@ class CompletedWorkCostLedger(BaseModel):
 
 class EstimateBudgetImportRequest(BaseModel):
     workspace_id: UUID | None = None
+    cost_code_mappings: dict[str, str] = Field(default_factory=dict)
+    cost_code_names: dict[str, str] = Field(default_factory=dict)
+    risk_cost_code: str | None = Field(default=None, min_length=1, max_length=32)
+    risk_cost_code_name: str | None = Field(default=None, min_length=1, max_length=255)
 
 
 InvoiceStatus = Literal["draft", "approved", "issued", "paid", "void"]

--- a/backend/app/services/daily_timesheets.py
+++ b/backend/app/services/daily_timesheets.py
@@ -51,9 +51,22 @@ def _event(action: str, user: AuthenticatedUser, *, reason: str | None = None, f
 
 
 def _project_cost_codes(db: Session) -> dict[str, list[dict]]:
-    bids = list(db.scalars(select(Bid).order_by(Bid.project_id, Bid.created_at.desc())))
+    projects = list(db.scalars(select(Project)))
     result: dict[str, list[dict]] = {}
-    seen: set[UUID] = set()
+    for project in projects:
+        approved = (project.metadata_json or {}).get("project_cost_codes") or []
+        codes = {
+            str(item.get("code") or "").strip().upper(): {
+                "code": str(item.get("code") or "").strip().upper(),
+                "name": str(item.get("name") or item.get("code") or "").strip(),
+            }
+            for item in approved
+            if str(item.get("code") or "").strip()
+        }
+        if codes:
+            result[str(project.id)] = list(codes.values())
+    bids = list(db.scalars(select(Bid).order_by(Bid.project_id, Bid.created_at.desc())))
+    seen: set[UUID] = {UUID(project_id) for project_id in result}
     for bid in bids:
         if bid.project_id in seen or (bid.bid_json or {}).get("source") != "estimate_workspace":
             continue

--- a/backend/app/services/finance.py
+++ b/backend/app/services/finance.py
@@ -2,7 +2,7 @@ from datetime import date
 from uuid import UUID
 
 from fastapi import HTTPException, status
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.bid import Bid
@@ -88,22 +88,188 @@ def import_estimate_budget(db: Session, project_id: UUID, payload: EstimateBudge
     bid = db.scalar(query.order_by(Bid.updated_at.desc()))
     if bid is None or not (bid.bid_json or {}).get("summary"):
         raise HTTPException(status_code=400, detail="Save a priced estimate workspace before creating the project budget.")
+    specs = _estimate_budget_specs(bid, payload)
+    all_budget_entries = list(
+        db.scalars(
+            select(FinancialEntry).where(
+                FinancialEntry.project_id == project_id,
+                FinancialEntry.entry_type == "budget",
+            )
+        )
+    )
+    existing = [entry for entry in all_budget_entries if entry.status != "void"]
+    conflicting = [
+        entry
+        for entry in existing
+        if entry.source_type != "estimate_workspace" or entry.source_id != bid.id
+    ]
+    if conflicting:
+        raise HTTPException(
+            status_code=409,
+            detail="A manual or different-workspace budget already exists. Review it before importing.",
+        )
+    legacy = [entry for entry in existing if not entry.source_key]
+    for entry in legacy:
+        db.delete(entry)
+    keyed = {
+        entry.source_key: entry
+        for entry in all_budget_entries
+        if entry.source_type == "estimate_workspace"
+        and entry.source_id == bid.id
+        and entry.source_key
+    }
+    expected_keys = {spec["source_key"] for spec in specs}
+    for source_key, entry in keyed.items():
+        if source_key not in expected_keys:
+            entry.status = "void"
+    for spec in specs:
+        entry = keyed.get(spec["source_key"])
+        values = {
+            "cost_code": spec["cost_code"],
+            "category": spec["category"],
+            "amount": spec["amount"],
+            "entry_date": date.today(),
+            "description": spec["description"],
+            "source_type": "estimate_workspace",
+            "source_id": bid.id,
+            "source_key": spec["source_key"],
+            "status": "posted",
+            "metadata_json": {
+                "workspace_id": str(bid.id),
+                "source_code": spec["source_code"],
+                "cost_code_name": spec["cost_code_name"],
+            },
+            "created_by": user.email,
+        }
+        if entry is None:
+            db.add(FinancialEntry(project_id=project_id, entry_type="budget", **values))
+        else:
+            for key, value in values.items():
+                setattr(entry, key, value)
+
+    metadata = dict(project.metadata_json or {})
+    baseline = dict(metadata.get("award_pricing_baseline") or {})
+    budget_lines = [
+        {
+            "source_key": spec["source_key"],
+            "source_code": spec["source_code"],
+            "cost_code": spec["cost_code"],
+            "cost_code_name": spec["cost_code_name"],
+            "category": spec["category"],
+            "description": spec["description"],
+            "amount": f'{spec["amount"]:.2f}',
+        }
+        for spec in specs
+    ]
+    baseline.update(
+        {
+            "cost_budget_status": "allocated",
+            "cost_budget_source_workspace_id": str(bid.id),
+            "cost_budget_total": f'{sum(spec["amount"] for spec in specs):.2f}',
+            "cost_budget_lines": budget_lines,
+        }
+    )
+    metadata["award_pricing_baseline"] = baseline
+    cost_codes: dict[str, dict[str, str]] = {}
+    for spec in specs:
+        cost_codes[spec["cost_code"]] = {
+            "code": spec["cost_code"],
+            "name": spec["cost_code_name"],
+        }
+    metadata["project_cost_codes"] = list(cost_codes.values())
+    project.metadata_json = metadata
     summary = bid.bid_json["summary"]
-    db.execute(delete(FinancialEntry).where(FinancialEntry.project_id == project_id, FinancialEntry.entry_type == "budget"))
-    for line in summary.get("line_items") or []:
-        amount = float(line.get("direct_cost") or 0)
-        if amount <= 0:
-            continue
-        db.add(FinancialEntry(project_id=project_id, cost_code=str(line.get("code") or "UNALLOCATED"), entry_type="budget", category=_category(line.get("item_type")), amount=amount, entry_date=date.today(), description=str(line.get("description") or "Estimate budget line"), source_type="estimate_workspace", source_id=bid.id, status="posted", metadata_json={"workspace_id": str(bid.id)}, created_by=user.email))
-    extras = [("90-100", "overhead", summary.get("indirect_cost", 0), "Indirect costs"), ("90-200", "contingency", summary.get("risk_cost", 0), "Risk allowance"), ("90-300", "contingency", summary.get("contingency", 0), "Contingency"), ("90-400", "bonding", summary.get("bonding", 0), "Bonding"), ("90-500", "insurance", summary.get("insurance", 0), "Insurance"), ("90-600", "overhead", summary.get("overhead", 0), "Corporate overhead")]
-    for cost_code, category, amount, description in extras:
-        if float(amount or 0) > 0:
-            db.add(FinancialEntry(project_id=project_id, cost_code=cost_code, entry_type="budget", category=category, amount=float(amount), entry_date=date.today(), description=description, source_type="estimate_workspace", source_id=bid.id, status="posted", metadata_json={"workspace_id": str(bid.id)}, created_by=user.email))
     if project.contract_value is None and summary.get("final_price"):
         project.contract_value = float(summary["final_price"])
         db.add(project)
     db.commit()
     return project_summary(db, project_id, user)
+
+
+def _estimate_budget_specs(bid: Bid, payload: EstimateBudgetImportRequest) -> list[dict]:
+    bid_json = bid.bid_json or {}
+    summary = bid_json.get("summary") or {}
+    estimate = bid_json.get("estimate") or {}
+    mappings = {str(key).strip().upper(): str(value).strip().upper() for key, value in payload.cost_code_mappings.items()}
+    names = {str(key).strip().upper(): str(value).strip() for key, value in payload.cost_code_names.items()}
+    specs: list[dict] = []
+
+    def add(
+        *,
+        position: str,
+        source_code: str,
+        default_code: str,
+        category: str,
+        amount: object,
+        description: str,
+        override_code: str | None = None,
+        override_name: str | None = None,
+    ) -> None:
+        numeric = round(float(amount or 0), 2)
+        if numeric <= 0:
+            return
+        normalized_source = source_code.strip().upper()
+        cost_code = (override_code or mappings.get(normalized_source) or default_code).strip().upper()
+        if not cost_code:
+            cost_code = "UNALLOCATED"
+        specs.append(
+            {
+                "source_key": f"estimate-budget:{bid.id}:{position}",
+                "source_code": normalized_source,
+                "cost_code": cost_code,
+                "cost_code_name": (override_name or names.get(cost_code) or description).strip(),
+                "category": category,
+                "amount": numeric,
+                "description": description.strip(),
+            }
+        )
+
+    for index, line in enumerate(summary.get("line_items") or [], start=1):
+        source_code = str(line.get("code") or f"LINE-{index:03d}")
+        add(
+            position=f"line-{index:03d}",
+            source_code=source_code,
+            default_code=source_code,
+            category=_category(line.get("item_type")),
+            amount=line.get("direct_cost"),
+            description=str(line.get("description") or "Estimate budget line"),
+        )
+
+    risk_amount = float(summary.get("risk_cost") or 0)
+    risks = estimate.get("risks") or []
+    if len(risks) == 1:
+        risk_description = str(risks[0].get("description") or "Risk allowance")
+    else:
+        risk_description = "Risk allowance"
+    add(
+        position="risk",
+        source_code="RISK",
+        default_code="90-200",
+        category="contingency",
+        amount=risk_amount,
+        description=risk_description,
+        override_code=payload.risk_cost_code,
+        override_name=payload.risk_cost_code_name,
+    )
+    extras = [
+        ("indirect", "INDIRECT", "90-100", "overhead", summary.get("indirect_cost", 0), "Indirect costs"),
+        ("contingency", "CONTINGENCY", "90-300", "contingency", summary.get("contingency", 0), "Contingency"),
+        ("bonding", "BONDING", "90-400", "bonding", summary.get("bonding", 0), "Bonding"),
+        ("insurance", "INSURANCE", "90-500", "insurance", summary.get("insurance", 0), "Insurance"),
+        ("overhead", "OVERHEAD", "90-600", "overhead", summary.get("overhead", 0), "Corporate overhead"),
+    ]
+    for position, source_code, cost_code, category, amount, description in extras:
+        add(
+            position=position,
+            source_code=source_code,
+            default_code=cost_code,
+            category=category,
+            amount=amount,
+            description=description,
+        )
+    if not specs:
+        raise HTTPException(status_code=400, detail="The selected estimate has no cost basis to import.")
+    return specs
 
 
 def project_summary(db: Session, project_id: UUID, user: AuthenticatedUser) -> ProjectFinancialSummary:

--- a/backend/app/services/project_launch.py
+++ b/backend/app/services/project_launch.py
@@ -82,6 +82,7 @@ def get_project_launch_dashboard(db: Session, project_id: UUID) -> ProjectLaunch
     award_baseline = metadata.get("award_pricing_baseline") or {}
     procurement_plan = metadata.get("procurement_plan") or {}
     award_lines = award_baseline.get("lines") or []
+    cost_budget_lines = award_baseline.get("cost_budget_lines") or []
     requirements = procurement_plan.get("requirements") or []
     total_count = len(checklist)
     return ProjectLaunchDashboard(
@@ -112,7 +113,9 @@ def get_project_launch_dashboard(db: Session, project_id: UUID) -> ProjectLaunch
         award_baseline_source=award_baseline.get("source_quote_number"),
         award_pricing_subtotal=round(float(award_baseline.get("pricing_subtotal") or 0), 2),
         award_cost_budget_status=str(award_baseline.get("cost_budget_status") or "not_started"),
-        uncoded_award_line_count=sum(not line.get("cost_code") for line in award_lines),
+        uncoded_award_line_count=sum(
+            not line.get("cost_code") for line in (cost_budget_lines or award_lines)
+        ),
         procurement_requirement_count=len(requirements),
         procurement_plan_status=str(procurement_plan.get("status") or "not_started"),
     )

--- a/backend/app/tools/bennett_cost_budget_staging_pilot.py
+++ b/backend/app/tools/bennett_cost_budget_staging_pilot.py
@@ -1,0 +1,350 @@
+"""Seed and verify the approved Bennett original cost budget in shared staging."""
+
+from __future__ import annotations
+
+import json
+import os
+from argparse import ArgumentParser
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.core.config import get_settings
+from app.services.bennett_strata_staging_import import PROJECT_NAME, SOURCE_KEY, SOURCE_REVISION
+from app.services.drive_tender_import import ImportValidationError
+from app.tools.bennett_estimate_quote_staging_pilot import Api, ApiClient, STAGING_BASE_URL, _require_value
+from app.tools.bennett_quote_staging_award import PROJECT_ID, QUOTE_ID, QUOTE_NUMBER, WORKSPACE_ID
+
+JOB_NUMBER = "IH2026002"
+EXPECTED_CONTRACT_VALUE = "38080.00"
+EXPECTED_CUSTOMER_SUBTOTAL = "36266.67"
+EXPECTED_BUDGET = "26660.93"
+EXPECTED_CODES = {
+    "4100": {"name": "Concrete restoration", "budget": "24610.93"},
+    "5100": {"name": "Small equipment rental", "budget": "200.00"},
+    "5110": {"name": "Skid steer / hydraulic attachment", "budget": "1100.00"},
+    "6100": {"name": "Trucking, disposal and material hauling", "budget": "750.00"},
+}
+BUDGET_REQUEST = {
+    "workspace_id": WORKSPACE_ID,
+    "cost_code_mappings": {
+        "CON-001": "4100",
+        "EQP-001": "5100",
+        "EQP-002": "5110",
+        "TRK-001": "6100",
+    },
+    "cost_code_names": {code: values["name"] for code, values in EXPECTED_CODES.items()},
+    "risk_cost_code": "4100",
+    "risk_cost_code_name": "Concrete restoration",
+}
+
+
+def _money(value: object) -> str:
+    try:
+        return str(Decimal(str(value)).quantize(Decimal("0.01")))
+    except (InvalidOperation, TypeError, ValueError) as error:
+        raise ImportValidationError(f"Invalid money value: {value!r}") from error
+
+
+def _budget_entries(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    return [item for item in summary.get("entries", []) if item.get("entry_type") == "budget"]
+
+
+def _verify_financial_summary(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    expected = {
+        "project_id": PROJECT_ID,
+        "contract_value": EXPECTED_CONTRACT_VALUE,
+        "budget": EXPECTED_BUDGET,
+        "committed": "0.00",
+        "actual": "0.00",
+        "forecast_cost": "0.00",
+    }
+    actual = {
+        "project_id": str(summary.get("project_id")),
+        **{key: _money(summary.get(key)) for key in expected if key != "project_id"},
+    }
+    mismatches = {
+        key: {"actual": actual.get(key), "expected": value}
+        for key, value in expected.items()
+        if actual.get(key) != value
+    }
+    if mismatches:
+        raise ImportValidationError(f"Bennett financial summary mismatch: {mismatches}")
+    entries = _budget_entries(summary)
+    if len(entries) != 5 or len(summary.get("entries", [])) != 5:
+        raise ImportValidationError("Bennett financial summary must contain only five budget entries.")
+    if any(
+        item.get("source_type") != "estimate_workspace"
+        or str(item.get("source_id")) != WORKSPACE_ID
+        or not item.get("source_key")
+        or item.get("status") != "posted"
+        for item in entries
+    ):
+        raise ImportValidationError("Bennett budget entries lack immutable estimate provenance.")
+    code_totals: dict[str, Decimal] = {}
+    for item in entries:
+        code = str(item.get("cost_code") or "")
+        code_totals[code] = code_totals.get(code, Decimal("0")) + Decimal(str(item.get("amount")))
+    normalized = {code: str(value.quantize(Decimal("0.01"))) for code, value in code_totals.items()}
+    wanted = {code: values["budget"] for code, values in EXPECTED_CODES.items()}
+    if normalized != wanted:
+        raise ImportValidationError(f"Bennett cost-code totals mismatch: {normalized}")
+    return entries
+
+
+def _verify_exact_source(
+    project: dict[str, Any],
+    workspace: dict[str, Any],
+    quote: dict[str, Any],
+) -> None:
+    bid_json = workspace.get("estimate") or {}
+    summary = bid_json.get("summary") or {}
+    source_metadata = (project.get("metadata") or {}).get(SOURCE_KEY) or {}
+    expected = {
+        "project.id": (str(project.get("id")), PROJECT_ID),
+        "project.name": (project.get("name"), PROJECT_NAME),
+        "project.status": (project.get("status"), "awarded"),
+        "project.job_number": (project.get("project_number"), JOB_NUMBER),
+        "project.contract_value": (_money(project.get("contract_value")), EXPECTED_CONTRACT_VALUE),
+        "project.source_revision": (source_metadata.get("latest_source_revision"), SOURCE_REVISION),
+        "workspace.id": (str(workspace.get("id")), WORKSPACE_ID),
+        "workspace.source": (bid_json.get("source"), SOURCE_KEY),
+        "workspace.source_revision": (bid_json.get("source_revision"), SOURCE_REVISION),
+        "workspace.estimate_key": (bid_json.get("estimate_key"), "concrete"),
+        "workspace.direct_cost": (_money(summary.get("direct_cost")), "21910.93"),
+        "workspace.risk_cost": (_money(summary.get("risk_cost")), "4750.00"),
+        "workspace.cost_basis": (
+            _money(Decimal(str(summary.get("direct_cost"))) + Decimal(str(summary.get("risk_cost")))),
+            EXPECTED_BUDGET,
+        ),
+        "quote.id": (str(quote.get("id")), QUOTE_ID),
+        "quote.quote_number": (quote.get("quote_number"), QUOTE_NUMBER),
+        "quote.status": (quote.get("status"), "accepted"),
+        "quote.issue_status": (quote.get("issue_status"), "draft"),
+        "quote.job_number": (quote.get("job_number"), JOB_NUMBER),
+        "quote.subtotal": (_money(quote.get("subtotal")), EXPECTED_CUSTOMER_SUBTOTAL),
+        "quote.total": (_money(quote.get("total")), EXPECTED_CONTRACT_VALUE),
+    }
+    mismatches = {
+        key: {"actual": actual, "expected": wanted}
+        for key, (actual, wanted) in expected.items()
+        if actual != wanted
+    }
+    if mismatches:
+        raise ImportValidationError(f"Bennett budget source mismatch: {mismatches}")
+    if quote.get("issued_at") is not None:
+        raise ImportValidationError("Bennett quote issuance is outside this budget approval.")
+
+
+def _verify_project_controls(project: dict[str, Any]) -> list[dict[str, str]]:
+    metadata = project.get("metadata") or {}
+    baseline = metadata.get("award_pricing_baseline") or {}
+    procurement = metadata.get("procurement_plan") or {}
+    if baseline.get("pricing_subtotal") != EXPECTED_CUSTOMER_SUBTOTAL:
+        raise ImportValidationError("Customer pricing baseline changed during cost-budget allocation.")
+    if (
+        baseline.get("cost_budget_status") != "allocated"
+        or str(baseline.get("cost_budget_source_workspace_id")) != WORKSPACE_ID
+        or _money(baseline.get("cost_budget_total")) != EXPECTED_BUDGET
+    ):
+        raise ImportValidationError("Bennett award cost-budget metadata was not allocated exactly.")
+    lines = baseline.get("cost_budget_lines") or []
+    if len(lines) != 5 or any(not line.get("cost_code") for line in lines):
+        raise ImportValidationError("Bennett cost-budget detail is missing or uncoded.")
+    if (
+        procurement.get("status") != "draft"
+        or procurement.get("automatic_commitment") is not False
+        or any(
+            item.get("po_number") is not None or item.get("approval") is not None
+            for item in procurement.get("requirements") or []
+        )
+    ):
+        raise ImportValidationError("Cost-budget allocation crossed the procurement boundary.")
+    codes = metadata.get("project_cost_codes") or []
+    normalized = [{"code": item.get("code"), "name": item.get("name")} for item in codes]
+    wanted = [{"code": code, "name": values["name"]} for code, values in EXPECTED_CODES.items()]
+    if normalized != wanted:
+        raise ImportValidationError(f"Bennett project cost-code directory mismatch: {normalized}")
+    return normalized
+
+
+def run_pilot(api: Api, *, operator: str, email: str, password: str) -> dict[str, Any]:
+    readiness = _require_value(api.request("/readiness"), "Readiness")
+    api.request("/api/v1/auth/login", method="POST", body={"email": email, "password": password})
+    authenticated = _require_value(api.request("/api/v1/auth/me"), "Authenticated user")
+    authenticated_user = authenticated.get("user") or authenticated
+    if authenticated_user.get("role") not in {"admin", "operations_manager"}:
+        raise ImportValidationError("Authenticated staging user lacks management financial access.")
+
+    project = _require_value(api.request(f"/api/v1/projects/{PROJECT_ID}"), "Bennett project")
+    quote = _require_value(api.request(f"/api/v1/customer-quotes/{QUOTE_ID}"), "Bennett quote")
+    workspaces = _require_value(
+        api.request(f"/api/v1/estimates/workspace/project/{PROJECT_ID}"),
+        "Bennett workspaces",
+    )
+    matches = [item for item in workspaces.get("items", []) if str(item.get("id")) == WORKSPACE_ID]
+    if len(matches) != 1:
+        raise ImportValidationError("Expected one exact Bennett concrete estimate workspace.")
+    workspace = matches[0]
+    _verify_exact_source(project, workspace, quote)
+
+    before = _require_value(
+        api.request(f"/api/v1/finance/projects/{PROJECT_ID}"),
+        "Bennett financial baseline",
+    )
+    before_budget = _money(before.get("budget"))
+    if before_budget == "0.00" and not before.get("entries"):
+        transition_action = "create_original_cost_budget"
+    elif before_budget == EXPECTED_BUDGET:
+        _verify_financial_summary(before)
+        transition_action = "reuse_existing_cost_budget"
+    else:
+        raise ImportValidationError("Bennett already has an unexpected financial baseline.")
+    if any(_money(before.get(key)) != "0.00" for key in ("committed", "actual", "forecast_cost")):
+        raise ImportValidationError("Bennett has commitments or actuals outside this budget-only approval.")
+
+    imported = _require_value(
+        api.request(
+            f"/api/v1/finance/projects/{PROJECT_ID}/import-estimate",
+            method="POST",
+            body=BUDGET_REQUEST,
+        ),
+        "Imported Bennett cost budget",
+    )
+    first_entries = _verify_financial_summary(imported)
+    retry = _require_value(
+        api.request(
+            f"/api/v1/finance/projects/{PROJECT_ID}/import-estimate",
+            method="POST",
+            body=BUDGET_REQUEST,
+        ),
+        "Retried Bennett cost budget",
+    )
+    retry_entries = _verify_financial_summary(retry)
+    def identity(items: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
+        return sorted(
+            (str(item.get("id")), str(item.get("source_key")), _money(item.get("amount")))
+            for item in items
+        )
+
+    if identity(first_entries) != identity(retry_entries):
+        raise ImportValidationError("Bennett cost-budget retry changed entry identity or value.")
+
+    project_after = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}"),
+        "Bennett project after budget import",
+    )
+    project_codes = _verify_project_controls(project_after)
+    dashboard = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}/launch-dashboard"),
+        "Bennett launch dashboard",
+    )
+    dashboard_expected = {
+        "job_number": JOB_NUMBER,
+        "mobilization_status": "not_ready",
+        "baseline_budget_total": EXPECTED_BUDGET,
+        "budget_entry_count": 5,
+        "award_baseline_source": QUOTE_NUMBER,
+        "award_pricing_subtotal": EXPECTED_CUSTOMER_SUBTOTAL,
+        "award_cost_budget_status": "allocated",
+        "uncoded_award_line_count": 0,
+        "procurement_plan_status": "draft",
+        "po_request_count": 0,
+    }
+    dashboard_actual = {
+        **{key: dashboard.get(key) for key in dashboard_expected},
+        "baseline_budget_total": _money(dashboard.get("baseline_budget_total")),
+        "award_pricing_subtotal": _money(dashboard.get("award_pricing_subtotal")),
+    }
+    dashboard_mismatches = {
+        key: {"actual": dashboard_actual.get(key), "expected": value}
+        for key, value in dashboard_expected.items()
+        if dashboard_actual.get(key) != value
+    }
+    if dashboard_mismatches:
+        raise ImportValidationError(f"Bennett launch dashboard mismatch: {dashboard_mismatches}")
+    timesheets = _require_value(
+        api.request("/api/v1/daily-timesheets/bootstrap"),
+        "Daily timesheet bootstrap",
+    )
+    if (timesheets.get("project_cost_codes") or {}).get(PROJECT_ID) != project_codes:
+        raise ImportValidationError("Bennett approved job cost codes are unavailable to daily timesheets.")
+
+    api.request("/api/v1/auth/logout", method="POST", expected_status=204)
+    return {
+        "status": "passed",
+        "pilot": "bennett_original_cost_budget",
+        "approval_boundary": "staging_original_budget_only_no_commitments",
+        "operator": operator,
+        "authenticated_as": authenticated_user.get("email"),
+        "authenticated_role": authenticated_user.get("role"),
+        "release_id": (readiness.get("checks") or {}).get("release_id"),
+        "source": SOURCE_KEY,
+        "source_revision": SOURCE_REVISION,
+        "transition_action": transition_action,
+        "project": {"id": PROJECT_ID, "job_number": JOB_NUMBER, "status": "awarded"},
+        "quote": {
+            "id": QUOTE_ID,
+            "quote_number": QUOTE_NUMBER,
+            "status": quote.get("status"),
+            "subtotal": _money(quote.get("subtotal")),
+            "total": _money(quote.get("total")),
+            "issued_at": quote.get("issued_at"),
+        },
+        "workspace": {"id": WORKSPACE_ID, "estimate_key": "concrete"},
+        "budget": {
+            "total": EXPECTED_BUDGET,
+            "entry_count": len(first_entries),
+            "cost_codes": EXPECTED_CODES,
+            "status": "allocated",
+        },
+        "project_cost_codes": project_codes,
+        "idempotent_retry": True,
+        "commitments_created": 0,
+        "actuals_created": 0,
+        "po_requests_created": 0,
+        "checklist_items_completed": 0,
+        "external_issuance_performed": False,
+        "production_mutation_performed": False,
+        "verified_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Seed the approved Bennett original cost budget in staging.")
+    parser.add_argument("--operator", required=True)
+    parser.add_argument("--base-url", default=STAGING_BASE_URL)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    settings = get_settings()
+    if settings.environment != "staging":
+        print(json.dumps({"status": "blocked", "issues": ["This budget pilot is staging-only."]}, indent=2))
+        raise SystemExit(2)
+    email = os.environ.get("BOOTSTRAP_ADMIN_EMAIL", "").strip()
+    password = os.environ.get("BOOTSTRAP_ADMIN_PASSWORD", "")
+    if not email or not password:
+        print(
+            json.dumps(
+                {"status": "blocked", "issues": ["Staging administrator credentials are unavailable."]},
+                indent=2,
+            )
+        )
+        raise SystemExit(2)
+    try:
+        report = run_pilot(
+            ApiClient(args.base_url),
+            operator=args.operator.strip(),
+            email=email,
+            password=password,
+        )
+    except (ImportValidationError, OSError, ValueError) as error:
+        print(json.dumps({"status": "blocked", "issues": [str(error)]}, indent=2))
+        raise SystemExit(2) from error
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/validation/bennett-staging-cost-budget.md
+++ b/docs/validation/bennett-staging-cost-budget.md
@@ -1,0 +1,29 @@
+# Bennett staging original cost budget
+
+## Objective
+
+Complete issue #268 step 7 by carrying the immutable Bennett concrete estimate cost basis into awarded staging job `IH2026002` under the approved pilot cost codes.
+
+## Financial boundary
+
+Customer price and internal cost budget remain separate:
+
+- accepted customer quote subtotal: `$36,266.67`;
+- GST: `$1,813.33`;
+- contract value: `$38,080.00`;
+- original internal cost budget: `$26,660.93`.
+
+The controlled allocation is recorded in `ops/staging-pilots/2026-08-28-bennett-cost-budget.json`. It produces five estimate-sourced budget entries across four job cost codes. It does not create commitments, actual costs, POs, invoices, accounting exports, or checklist completions.
+
+## Application controls
+
+- Management-only budget import accepts explicit source-to-job cost-code mappings.
+- Existing manual budgets or another workspace budget block the import.
+- Deterministic source keys make exact retries preserve budget-entry identity.
+- Award metadata keeps customer pricing intact and stores detailed cost-budget lines separately.
+- Approved project cost codes are available to daily timesheets.
+- Launch readiness reports allocated budget status and zero uncoded cost-budget lines.
+
+## Execution gate
+
+The staging pilot runs only after a human merges the exact Build 229 pull request and that release deploys successfully to staging. It fails closed on release drift, record drift, source or amount drift, a conflicting budget, commitments or actuals, quote issuance, unsafe procurement state, or an unexpected job number.

--- a/ops/staging-pilots/2026-08-28-bennett-cost-budget.json
+++ b/ops/staging-pilots/2026-08-28-bennett-cost-budget.json
@@ -1,0 +1,47 @@
+{
+  "issue": 373,
+  "parent_issues": [268, 314, 371],
+  "environment": "staging",
+  "source": "bennett_strata_issue_314",
+  "source_revision": "2026-08-27-final",
+  "trigger": "human merge of the exact Build 229 pull request followed by a successful exact-release staging deployment",
+  "approval_scope": "seed the exact original cost budget and approved pilot job cost codes for awarded staging job IH2026002",
+  "exact_records": {
+    "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+    "job_number": "IH2026002",
+    "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+    "quote_id": "8f854940-e710-45c2-aae4-7d5706c3a9e2",
+    "quote_number": "Q-2026-002"
+  },
+  "customer_pricing": {
+    "subtotal": "36266.67",
+    "gst": "1813.33",
+    "total": "38080.00"
+  },
+  "original_cost_budget": {
+    "total": "26660.93",
+    "allocations": [
+      {"source_code": "CON-001", "cost_code": "4100", "name": "Concrete restoration", "amount": "19860.93"},
+      {"source_code": "RISK", "cost_code": "4100", "name": "Concrete restoration", "amount": "4750.00"},
+      {"source_code": "EQP-001", "cost_code": "5100", "name": "Small equipment rental", "amount": "200.00"},
+      {"source_code": "EQP-002", "cost_code": "5110", "name": "Skid steer / hydraulic attachment", "amount": "1100.00"},
+      {"source_code": "TRK-001", "cost_code": "6100", "name": "Trucking, disposal and material hauling", "amount": "750.00"}
+    ]
+  },
+  "permitted_actions": [
+    "authenticate through the live HTTPS staging origin",
+    "create or reuse five estimate-sourced original budget entries",
+    "publish four approved job cost codes to daily timesheets",
+    "mark the award cost-budget metadata allocated",
+    "repeat the import to prove stable entry identity and totals",
+    "upload immutable evidence retained for 90 days"
+  ],
+  "prohibited_actions": [
+    "change customer pricing or contract value",
+    "create a commitment, actual cost, purchase order, invoice, or accounting export",
+    "mark mobilization ready or complete a project-start checklist item",
+    "issue or externally send the quote",
+    "mutate production",
+    "change DNS, certificates, secrets, backups, authentication, or infrastructure"
+  ]
+}

--- a/tests/backend/test_bennett_cost_budget_staging_pilot.py
+++ b/tests/backend/test_bennett_cost_budget_staging_pilot.py
@@ -1,0 +1,261 @@
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from app.services.bennett_strata_staging_import import PROJECT_NAME, SOURCE_KEY, SOURCE_REVISION
+from app.services.drive_tender_import import ImportValidationError
+from app.tools.bennett_cost_budget_staging_pilot import (
+    BUDGET_REQUEST,
+    EXPECTED_CODES,
+    JOB_NUMBER,
+    PROJECT_ID,
+    QUOTE_ID,
+    STAGING_BASE_URL,
+    WORKSPACE_ID,
+    _parser,
+    run_pilot,
+)
+
+
+def test_cli_defaults_to_secure_live_staging_origin() -> None:
+    args = _parser().parse_args(["--operator", "GitHub staging budget"])
+
+    assert args.base_url == STAGING_BASE_URL
+    assert args.base_url == "https://staging.os.ironhousecivil.com"
+
+
+class FakeApi:
+    def __init__(self, *, already_budgeted: bool = False) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None, int]] = []
+        self.project = {
+            "id": PROJECT_ID,
+            "name": PROJECT_NAME,
+            "status": "awarded",
+            "project_number": JOB_NUMBER,
+            "contract_value": "38080.00",
+            "metadata": {
+                SOURCE_KEY: {"latest_source_revision": SOURCE_REVISION},
+                "award_pricing_baseline": {
+                    "source_quote_id": QUOTE_ID,
+                    "source_quote_number": "Q-2026-002",
+                    "pricing_subtotal": "36266.67",
+                    "cost_budget_status": "needs_cost_allocation",
+                    "lines": [{"description": "Concrete pull and pour", "cost_code": None}],
+                },
+                "procurement_plan": {
+                    "status": "draft",
+                    "automatic_commitment": False,
+                    "requirements": [
+                        {"description": "Concrete", "po_number": None, "approval": None}
+                    ],
+                },
+            },
+        }
+        self.workspace = {
+            "id": WORKSPACE_ID,
+            "estimate": {
+                "source": SOURCE_KEY,
+                "source_revision": SOURCE_REVISION,
+                "estimate_key": "concrete",
+                "summary": {
+                    "direct_cost": "21910.93",
+                    "risk_cost": "4750.00",
+                },
+            },
+        }
+        self.quote = {
+            "id": QUOTE_ID,
+            "quote_number": "Q-2026-002",
+            "status": "accepted",
+            "issue_status": "draft",
+            "job_number": JOB_NUMBER,
+            "subtotal": "36266.67",
+            "total": "38080.00",
+            "issued_at": None,
+        }
+        self.entries: list[dict[str, Any]] = []
+        if already_budgeted:
+            self._apply_budget()
+
+    def _apply_budget(self) -> None:
+        if self.entries:
+            return
+        specs = [
+            ("line-001", "4100", "19860.93"),
+            ("line-002", "5100", "200.00"),
+            ("line-003", "5110", "1100.00"),
+            ("line-004", "6100", "750.00"),
+            ("risk", "4100", "4750.00"),
+        ]
+        self.entries = [
+            {
+                "id": f"00000000-0000-0000-0000-00000000000{index}",
+                "project_id": PROJECT_ID,
+                "cost_code": code,
+                "entry_type": "budget",
+                "amount": amount,
+                "status": "posted",
+                "source_type": "estimate_workspace",
+                "source_id": WORKSPACE_ID,
+                "source_key": f"estimate-budget:{WORKSPACE_ID}:{position}",
+            }
+            for index, (position, code, amount) in enumerate(specs, start=1)
+        ]
+        baseline = self.project["metadata"]["award_pricing_baseline"]
+        baseline.update(
+            {
+                "cost_budget_status": "allocated",
+                "cost_budget_source_workspace_id": WORKSPACE_ID,
+                "cost_budget_total": "26660.93",
+                "cost_budget_lines": [
+                    {"cost_code": item["cost_code"], "amount": item["amount"]}
+                    for item in self.entries
+                ],
+            }
+        )
+        self.project["metadata"]["project_cost_codes"] = [
+            {"code": code, "name": values["name"]}
+            for code, values in EXPECTED_CODES.items()
+        ]
+
+    def _financial_summary(self) -> dict[str, Any]:
+        return {
+            "project_id": PROJECT_ID,
+            "contract_value": "38080.00",
+            "budget": "26660.93" if self.entries else "0.00",
+            "committed": "0.00",
+            "actual": "0.00",
+            "forecast_cost": "0.00",
+            "entries": deepcopy(self.entries),
+        }
+
+    def request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: dict[str, Any] | None = None,
+        expected_status: int = 200,
+    ) -> dict[str, Any] | None:
+        self.calls.append((path, method, body, expected_status))
+        if path == "/readiness":
+            return {"checks": {"release_id": "b" * 40}}
+        if path == "/api/v1/auth/login":
+            return {"user": {"email": "admin@ironhousecontracting.com", "role": "admin"}}
+        if path == "/api/v1/auth/me":
+            return {"user": {"email": "admin@ironhousecontracting.com", "role": "admin"}}
+        if path == f"/api/v1/projects/{PROJECT_ID}":
+            return deepcopy(self.project)
+        if path == f"/api/v1/customer-quotes/{QUOTE_ID}":
+            return deepcopy(self.quote)
+        if path == f"/api/v1/estimates/workspace/project/{PROJECT_ID}":
+            return {"items": [deepcopy(self.workspace)], "total": 1}
+        if path == f"/api/v1/finance/projects/{PROJECT_ID}" and method == "GET":
+            return self._financial_summary()
+        if path == f"/api/v1/finance/projects/{PROJECT_ID}/import-estimate":
+            assert method == "POST"
+            assert body == BUDGET_REQUEST
+            self._apply_budget()
+            return self._financial_summary()
+        if path == f"/api/v1/projects/{PROJECT_ID}/launch-dashboard":
+            return {
+                "job_number": JOB_NUMBER,
+                "mobilization_status": "not_ready",
+                "baseline_budget_total": "26660.93",
+                "budget_entry_count": 5,
+                "award_baseline_source": "Q-2026-002",
+                "award_pricing_subtotal": "36266.67",
+                "award_cost_budget_status": "allocated",
+                "uncoded_award_line_count": 0,
+                "procurement_plan_status": "draft",
+                "po_request_count": 0,
+            }
+        if path == "/api/v1/daily-timesheets/bootstrap":
+            return {
+                "project_cost_codes": {
+                    PROJECT_ID: deepcopy(self.project["metadata"]["project_cost_codes"])
+                }
+            }
+        if path == "/api/v1/auth/logout":
+            return None
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+
+@pytest.mark.parametrize(
+    ("already_budgeted", "expected_action"),
+    [(False, "create_original_cost_budget"), (True, "reuse_existing_cost_budget")],
+)
+def test_budget_pilot_is_exact_safe_and_idempotent(
+    already_budgeted: bool,
+    expected_action: str,
+) -> None:
+    api = FakeApi(already_budgeted=already_budgeted)
+
+    report = run_pilot(
+        api,
+        operator="GitHub staging budget",
+        email="admin@ironhousecontracting.com",
+        password="not-recorded",
+    )
+
+    assert report["status"] == "passed"
+    assert report["approval_boundary"] == "staging_original_budget_only_no_commitments"
+    assert report["transition_action"] == expected_action
+    assert report["project"] == {
+        "id": PROJECT_ID,
+        "job_number": JOB_NUMBER,
+        "status": "awarded",
+    }
+    assert report["budget"]["total"] == "26660.93"
+    assert report["budget"]["entry_count"] == 5
+    assert report["idempotent_retry"] is True
+    assert report["commitments_created"] == 0
+    assert report["actuals_created"] == 0
+    assert report["po_requests_created"] == 0
+    assert report["checklist_items_completed"] == 0
+    assert report["external_issuance_performed"] is False
+    assert report["production_mutation_performed"] is False
+    assert "not-recorded" not in str(report)
+
+    imports = [call for call in api.calls if call[0].endswith("/import-estimate")]
+    assert len(imports) == 2
+    assert all(call[1] == "POST" and call[2] == BUDGET_REQUEST for call in imports)
+    assert not any("purchase-orders" in path or "quickbooks" in path for path, *_ in api.calls)
+
+
+def test_budget_pilot_fails_closed_on_job_number_drift() -> None:
+    api = FakeApi()
+    api.project["project_number"] = "IH2026999"
+
+    with pytest.raises(ImportValidationError, match="source mismatch"):
+        run_pilot(
+            api,
+            operator="GitHub staging budget",
+            email="admin@ironhousecontracting.com",
+            password="not-recorded",
+        )
+
+    assert not any(path.endswith("/import-estimate") for path, *_ in api.calls)
+
+
+def test_budget_pilot_fails_closed_on_existing_commitment() -> None:
+    api = FakeApi()
+    original = api._financial_summary
+
+    def summary_with_commitment() -> dict[str, Any]:
+        summary = original()
+        summary["committed"] = "100.00"
+        return summary
+
+    api._financial_summary = summary_with_commitment  # type: ignore[method-assign]
+
+    with pytest.raises(ImportValidationError, match="commitments or actuals"):
+        run_pilot(
+            api,
+            operator="GitHub staging budget",
+            email="admin@ironhousecontracting.com",
+            password="not-recorded",
+        )
+
+    assert not any(path.endswith("/import-estimate") for path, *_ in api.calls)

--- a/tests/backend/test_bennett_staging_cost_budget_workflow.py
+++ b/tests/backend/test_bennett_staging_cost_budget_workflow.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/bennett-staging-cost-budget.yml"
+MARKER = ROOT / "ops/staging-pilots/2026-08-28-bennett-cost-budget.json"
+BUDGET_TOOL = ROOT / "backend/app/tools/bennett_cost_budget_staging_pilot.py"
+
+
+def test_workflow_runs_only_after_exact_human_merged_build_and_staging_deploy() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'workflows: ["Staging deploy"]' in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "github.event.workflow_run.event == 'push'" in workflow
+    assert "github.event.workflow_run.head_branch == 'main'" in workflow
+    assert "Build 229: seed awarded Bennett cost budget and job codes" in workflow
+    assert "runner.temp" not in workflow
+    assert (
+        "/tmp/iron-house-os-bennett-staging-cost-budget-${{ github.run_id }}-${{ github.run_attempt }}"
+        in workflow
+    )
+    assert 'test "$RELEASE_SHA" = "$(git rev-parse origin/main)"' in workflow
+    assert "Live staging release mismatch" in workflow
+    assert "bennett_cost_budget_staging_pilot" in workflow
+    assert "--base-url https://staging.os.ironhousecivil.com" in workflow
+    assert "http://127.0.0.1:8000" not in workflow
+    assert "retention-days: 90" in workflow
+
+
+def test_approval_marker_and_tool_match_the_exact_authorized_boundary() -> None:
+    marker = json.loads(MARKER.read_text(encoding="utf-8"))
+    tool = BUDGET_TOOL.read_text(encoding="utf-8")
+
+    assert marker["issue"] == 373
+    assert marker["environment"] == "staging"
+    assert marker["source_revision"] == "2026-08-27-final"
+    assert "Build 229" in marker["trigger"]
+    assert marker["exact_records"] == {
+        "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+        "job_number": "IH2026002",
+        "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+        "quote_id": "8f854940-e710-45c2-aae4-7d5706c3a9e2",
+        "quote_number": "Q-2026-002",
+    }
+    assert marker["original_cost_budget"]["total"] == "26660.93"
+    assert len(marker["original_cost_budget"]["allocations"]) == 5
+    assert "create a commitment, actual cost, purchase order, invoice, or accounting export" in marker["prohibited_actions"]
+    assert "issue or externally send the quote" in marker["prohibited_actions"]
+    assert "mutate production" in marker["prohibited_actions"]
+
+    assert "/api/v1/auth/login" in tool
+    assert "/api/v1/finance/projects/{PROJECT_ID}/import-estimate" in tool
+    assert '"approval_boundary": "staging_original_budget_only_no_commitments"' in tool
+    assert 'JOB_NUMBER = "IH2026002"' in tool
+    assert "purchase-orders" not in tool
+    assert "quickbooks" not in tool

--- a/tests/backend/test_finance.py
+++ b/tests/backend/test_finance.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import date
 from uuid import UUID
 
@@ -7,6 +8,7 @@ from fastapi.testclient import TestClient
 from app.api.dependencies.auth import require_authenticated_user
 from app.main import app
 from app.models.bid import Bid
+from app.models.project import Project
 from app.services.auth import AuthenticatedUser
 from conftest import TestingSessionLocal
 
@@ -28,6 +30,85 @@ def _estimate(project_id: str) -> UUID:
         return bid.id
 
 
+def _bennett_style_estimate(project_id: str) -> UUID:
+    with TestingSessionLocal() as db:
+        project = db.get(Project, UUID(project_id))
+        assert project is not None
+        project.metadata_json = {
+            "award_pricing_baseline": {
+                "source_quote_id": "quote-1",
+                "source_quote_number": "Q-2026-002",
+                "pricing_subtotal": "36266.67",
+                "cost_budget_status": "needs_cost_allocation",
+                "lines": [{"description": "Concrete pull and pour", "cost_code": None}],
+            },
+            "procurement_plan": {
+                "status": "draft",
+                "automatic_commitment": False,
+                "requirements": [],
+            },
+        }
+        bid = Bid(
+            project_id=UUID(project_id),
+            status="approved",
+            total_amount=36266.67,
+            summary="Bennett concrete estimate",
+            bid_json={
+                "source": "bennett_strata_issue_314",
+                "source_revision": "2026-08-27-final",
+                "estimate_key": "concrete",
+                "estimate": {
+                    "risks": [
+                        {
+                            "description": "Subgrade / buried deficiencies provisional allowance",
+                            "amount": 4750,
+                            "probability": 1,
+                        }
+                    ]
+                },
+                "summary": {
+                    "final_price": 36266.67,
+                    "line_items": [
+                        {"code": "CON-001", "description": "4 in concrete pull and pour", "item_type": "self_perform", "direct_cost": 19860.93},
+                        {"code": "EQP-001", "description": "14 in cutoff saw", "item_type": "equipment", "direct_cost": 200},
+                        {"code": "EQP-002", "description": "Skid steer with hydraulic hammer", "item_type": "equipment", "direct_cost": 1100},
+                        {"code": "TRK-001", "description": "Concrete disposal tandem", "item_type": "subcontract", "direct_cost": 750},
+                    ],
+                    "indirect_cost": 0,
+                    "risk_cost": 4750,
+                    "contingency": 0,
+                    "bonding": 0,
+                    "insurance": 0,
+                    "overhead": 0,
+                },
+            },
+        )
+        db.add(bid)
+        db.commit()
+        db.refresh(bid)
+        return bid.id
+
+
+def _bennett_budget_payload(workspace_id: UUID) -> dict:
+    return {
+        "workspace_id": str(workspace_id),
+        "cost_code_mappings": {
+            "CON-001": "4100",
+            "EQP-001": "5100",
+            "EQP-002": "5110",
+            "TRK-001": "6100",
+        },
+        "cost_code_names": {
+            "4100": "Concrete restoration",
+            "5100": "Small equipment rental",
+            "5110": "Skid steer / hydraulic attachment",
+            "6100": "Trucking, disposal and material hauling",
+        },
+        "risk_cost_code": "4100",
+        "risk_cost_code_name": "Concrete restoration",
+    }
+
+
 def test_estimate_budget_actual_commitment_and_forecast_summary() -> None:
     project = _project()
     workspace_id = _estimate(project["id"])
@@ -44,6 +125,133 @@ def test_estimate_budget_actual_commitment_and_forecast_summary() -> None:
     assert summary["actual"] == 25000
     assert summary["forecast_cost"] == 65000
     assert summary["forecast_profit"] == 85000
+
+
+def test_estimate_budget_mapping_is_idempotent_and_initializes_job_cost_codes() -> None:
+    project = _project()
+    awarded = client.patch(f"/api/v1/projects/{project['id']}", json={"status": "awarded"})
+    assert awarded.status_code == 200
+    workspace_id = _bennett_style_estimate(project["id"])
+    payload = _bennett_budget_payload(workspace_id)
+
+    first = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+    second = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["budget"] == 26660.93
+    assert second.json()["budget"] == 26660.93
+    first_entries = [item for item in first.json()["entries"] if item["entry_type"] == "budget"]
+    second_entries = [item for item in second.json()["entries"] if item["entry_type"] == "budget"]
+    assert len(first_entries) == len(second_entries) == 5
+    assert {item["id"] for item in first_entries} == {item["id"] for item in second_entries}
+    assert all(item["source_key"] for item in first_entries)
+    code_totals = {item["cost_code"]: item["budget"] for item in second.json()["cost_codes"]}
+    assert code_totals == {"4100": 24610.93, "5100": 200, "5110": 1100, "6100": 750}
+    refreshed = client.get(f"/api/v1/projects/{project['id']}").json()
+    baseline = refreshed["metadata"]["award_pricing_baseline"]
+    assert baseline["pricing_subtotal"] == "36266.67"
+    assert baseline["cost_budget_status"] == "allocated"
+    assert baseline["cost_budget_total"] == "26660.93"
+    assert len(baseline["cost_budget_lines"]) == 5
+    assert refreshed["metadata"]["project_cost_codes"] == [
+        {"code": "4100", "name": "Concrete restoration"},
+        {"code": "5100", "name": "Small equipment rental"},
+        {"code": "5110", "name": "Skid steer / hydraulic attachment"},
+        {"code": "6100", "name": "Trucking, disposal and material hauling"},
+    ]
+    assert refreshed["metadata"]["procurement_plan"]["automatic_commitment"] is False
+    launch = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard").json()
+    assert launch["baseline_budget_total"] == 26660.93
+    assert launch["budget_entry_count"] == 5
+    assert launch["award_cost_budget_status"] == "allocated"
+    assert launch["uncoded_award_line_count"] == 0
+    timesheets = client.get("/api/v1/daily-timesheets/bootstrap").json()
+    assert timesheets["project_cost_codes"][project["id"]] == [
+        {"code": "4100", "name": "Concrete restoration"},
+        {"code": "5100", "name": "Small equipment rental"},
+        {"code": "5110", "name": "Skid steer / hydraulic attachment"},
+        {"code": "6100", "name": "Trucking, disposal and material hauling"},
+    ]
+
+
+def test_estimate_budget_reactivates_a_previously_voided_source_key() -> None:
+    project = _project()
+    workspace_id = _bennett_style_estimate(project["id"])
+    payload = _bennett_budget_payload(workspace_id)
+    first = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+    assert first.status_code == 200
+    trucking = next(item for item in first.json()["entries"] if item["cost_code"] == "6100")
+
+    with TestingSessionLocal() as db:
+        bid = db.get(Bid, workspace_id)
+        assert bid is not None
+        estimate = deepcopy(bid.bid_json)
+        estimate["summary"]["line_items"][3]["direct_cost"] = 0
+        bid.bid_json = estimate
+        db.commit()
+    reduced = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+    assert reduced.status_code == 200
+    assert reduced.json()["budget"] == 25910.93
+    assert all(item["cost_code"] != "6100" for item in reduced.json()["entries"])
+
+    with TestingSessionLocal() as db:
+        bid = db.get(Bid, workspace_id)
+        assert bid is not None
+        estimate = deepcopy(bid.bid_json)
+        estimate["summary"]["line_items"][3]["direct_cost"] = 750
+        bid.bid_json = estimate
+        db.commit()
+    restored = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+    assert restored.status_code == 200
+    restored_trucking = next(
+        item for item in restored.json()["entries"] if item["cost_code"] == "6100"
+    )
+    assert restored.json()["budget"] == 26660.93
+    assert restored_trucking["id"] == trucking["id"]
+
+
+def test_estimate_budget_import_does_not_replace_a_manual_budget() -> None:
+    project = _project()
+    workspace_id = _estimate(project["id"])
+    manual = client.post(
+        "/api/v1/finance/entries",
+        json={
+            "project_id": project["id"],
+            "cost_code": "MANUAL",
+            "entry_type": "budget",
+            "category": "other",
+            "amount": 100,
+            "entry_date": str(date.today()),
+            "description": "Management-entered budget",
+        },
+    )
+    assert manual.status_code == 201
+
+    blocked = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json={"workspace_id": str(workspace_id)},
+    )
+
+    assert blocked.status_code == 409
+    assert "manual or different-workspace budget" in blocked.json()["detail"]
+    summary = client.get(f"/api/v1/finance/projects/{project['id']}").json()
+    assert summary["budget"] == 100
 
 
 def test_quickbooks_export_contains_posted_cost_references() -> None:


### PR DESCRIPTION
Closes #373

## Outcome

Carries the authoritative Bennett concrete estimate cost basis into awarded staging job `IH2026002` as an internal original budget, while keeping accepted customer pricing and the contract value unchanged.

## Controlled allocation

| Job cost code | Description | Original budget |
| --- | --- | ---: |
| 4100 | Concrete restoration, including risk allowance | $24,610.93 |
| 5100 | Small equipment rental | $200.00 |
| 5110 | Skid steer / hydraulic attachment | $1,100.00 |
| 6100 | Trucking, disposal and material hauling | $750.00 |
| **Total** |  | **$26,660.93** |

## Controls

- Uses deterministic estimate source keys and preserves entry identity on exact retries.
- Blocks replacement of a manual or different-workspace budget.
- Keeps quote subtotal `$36,266.67` and contract value `$38,080.00` separate from internal cost.
- Publishes the four approved job codes to daily timesheets.
- Leaves procurement in draft with no automatic commitment, PO, actual, invoice, export, checklist completion, quote issuance, or production mutation.
- Runs the exact Bennett staging transition only after human merge and successful exact-release staging deployment.

## Verification

- Backend: 607 passed
- Frontend: 140 passed
- Ruff: passed
- TypeScript: passed
- Production build: passed
- Visual design lock: passed
- React Router RSC security boundary: passed
- Local Playwright execution was unavailable because the scratch runner could not download browser binaries; the required hosted browser/mobile/accessibility gate remains enforced by CI.
