### PR TITLE
Build 230: seed Bennett procurement planning requirements

### DIFF
--- a/.github/workflows/bennett-staging-procurement-plan.yml
+++ b/.github/workflows/bennett-staging-procurement-plan.yml
@@ -1,0 +1,126 @@
+name: Approved Bennett staging procurement plan
+
+on:
+  workflow_run:
+    workflows: ["Staging deploy"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: iron-house-os-bennett-staging-procurement-plan
+  cancel-in-progress: false
+
+jobs:
+  procurement:
+    name: Seed exact Bennett procurement planning requirements
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(github.event.workflow_run.head_commit.message, 'Build 230: seed Bennett procurement planning requirements')
+    runs-on: [self-hosted, linux, ihos-staging]
+    timeout-minutes: 30
+    env:
+      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+      EVIDENCE_DIR: /tmp/iron-house-os-bennett-staging-procurement-${{ github.run_id }}-${{ github.run_attempt }}
+      PILOT_OPERATOR: Iron House OS GitHub staging procurement issue 375
+    steps:
+      - name: Initialize evidence directory
+        run: mkdir -p "$EVIDENCE_DIR"
+
+      - name: Check out exact approved release
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+          fetch-depth: 0
+
+      - name: Verify current main and approval marker
+        run: |
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          git fetch --no-tags origin main
+          test "$RELEASE_SHA" = "$(git rev-parse origin/main)"
+          python3 -m json.tool ops/staging-pilots/2026-08-28-bennett-procurement-plan.json >/dev/null
+          python3 - <<'PY' > "$EVIDENCE_DIR/run-metadata.json"
+          import json
+          import os
+
+          print(json.dumps({
+              "issue": 375,
+              "parent_issues": [268, 314, 373],
+              "environment": "staging",
+              "release_sha": os.environ["RELEASE_SHA"],
+              "approval_boundary": "staging_procurement_planning_only_no_commitments",
+              "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+              "job_number": "IH2026002",
+              "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+          }, indent=2, sort_keys=True))
+          PY
+
+      - name: Verify exact live staging release
+        run: |
+          readiness="$(curl --fail --silent --show-error https://staging.os.ironhousecivil.com/readiness)"
+          READINESS_JSON="$readiness" python3 - <<'PY' > "$EVIDENCE_DIR/readiness.json"
+          import json
+          import os
+
+          readiness = json.loads(os.environ["READINESS_JSON"])
+          actual = readiness.get("checks", {}).get("release_id")
+          expected = os.environ["RELEASE_SHA"]
+          if actual != expected:
+              raise SystemExit(f"Live staging release mismatch: expected {expected}, got {actual}")
+          print(json.dumps(readiness, indent=2, sort_keys=True))
+          PY
+
+      - name: Seed and verify approved procurement planning requirements
+        run: |
+          compose=(
+            sudo env IHOS_STAGING_RELEASE_ID="$RELEASE_SHA" docker compose
+            --env-file /etc/iron-house-os/staging.env
+            -f "$GITHUB_WORKSPACE/docker-compose.staging.yml"
+            -p iron-house-os-staging
+          )
+          "${compose[@]}" exec -T backend python -m app.tools.bennett_procurement_staging_pilot \
+            --operator "$PILOT_OPERATOR" \
+            --base-url https://staging.os.ironhousecivil.com \
+            > "$EVIDENCE_DIR/procurement-report.json"
+          EVIDENCE_DIR="$EVIDENCE_DIR" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads((Path(os.environ["EVIDENCE_DIR"]) / "procurement-report.json").read_text())
+          if report.get("status") != "passed":
+              raise SystemExit("Bennett procurement planning pilot did not pass.")
+          if report.get("approval_boundary") != "staging_procurement_planning_only_no_commitments":
+              raise SystemExit("Bennett procurement pilot crossed its approval boundary.")
+          if report.get("project", {}).get("job_number") != "IH2026002":
+              raise SystemExit("Bennett procurement plan attached to the wrong job number.")
+          if report.get("budget", {}).get("total") != "26660.93":
+              raise SystemExit("Bennett original cost budget changed.")
+          procurement = report.get("procurement", {})
+          if procurement.get("status") != "draft" or procurement.get("requirement_count") != 4:
+              raise SystemExit("Bennett procurement plan is not the exact four-item draft.")
+          if procurement.get("ready_mix_order_quantity_confirmed") is not False:
+              raise SystemExit("Bennett ready-mix order quantity was inferred or confirmed.")
+          if report.get("idempotent_retry") is not True:
+              raise SystemExit("Bennett procurement retry was not idempotent.")
+          for field in ("vendors_selected", "commitments_created", "po_requests_created", "actuals_created", "checklist_items_completed"):
+              if report.get(field) != 0:
+                  raise SystemExit(f"Bennett procurement pilot crossed prohibited boundary: {field}")
+          if report.get("external_issuance_performed") is not False:
+              raise SystemExit("Bennett procurement pilot performed prohibited external issuance.")
+          if report.get("production_mutation_performed") is not False:
+              raise SystemExit("Bennett procurement pilot performed prohibited production mutation.")
+          PY
+
+      - name: Upload immutable procurement evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bennett-staging-procurement-${{ github.run_id }}
+          path: ${{ env.EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 90

--- a/backend/app/schemas/finance.py
+++ b/backend/app/schemas/finance.py
@@ -146,12 +146,33 @@ class CompletedWorkCostLedger(BaseModel):
     lines: list[CompletedWorkCostLine]
 
 
+class EstimateProcurementRequirement(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    source_code: str = Field(min_length=1, max_length=32)
+    category: Literal["material", "rental", "trucking", "subcontract"]
+    description: str = Field(min_length=1, max_length=500)
+    order_quantity: Decimal | None = Field(default=None, gt=0, decimal_places=3)
+    order_unit: str = Field(min_length=1, max_length=30)
+    order_quantity_status: Literal["planning_basis", "needs_confirmation"]
+    specification: str | None = Field(default=None, max_length=1000)
+
+    @model_validator(mode="after")
+    def validate_quantity_status(self) -> "EstimateProcurementRequirement":
+        if self.order_quantity_status == "planning_basis" and self.order_quantity is None:
+            raise ValueError("Planning-basis procurement requirements need an order quantity.")
+        if self.order_quantity_status == "needs_confirmation" and self.order_quantity is not None:
+            raise ValueError("Unconfirmed procurement requirements cannot carry an order quantity.")
+        return self
+
+
 class EstimateBudgetImportRequest(BaseModel):
     workspace_id: UUID | None = None
     cost_code_mappings: dict[str, str] = Field(default_factory=dict)
     cost_code_names: dict[str, str] = Field(default_factory=dict)
     risk_cost_code: str | None = Field(default=None, min_length=1, max_length=32)
     risk_cost_code_name: str | None = Field(default=None, min_length=1, max_length=255)
+    procurement_requirements: list[EstimateProcurementRequirement] = Field(default_factory=list)
 
 
 InvoiceStatus = Literal["draft", "approved", "issued", "paid", "void"]

--- a/backend/app/services/finance.py
+++ b/backend/app/services/finance.py
@@ -138,6 +138,8 @@ def import_estimate_budget(db: Session, project_id: UUID, payload: EstimateBudge
                 "workspace_id": str(bid.id),
                 "source_code": spec["source_code"],
                 "cost_code_name": spec["cost_code_name"],
+                "scope_quantity": spec["scope_quantity"],
+                "scope_unit": spec["scope_unit"],
             },
             "created_by": user.email,
         }
@@ -158,6 +160,8 @@ def import_estimate_budget(db: Session, project_id: UUID, payload: EstimateBudge
             "category": spec["category"],
             "description": spec["description"],
             "amount": f'{spec["amount"]:.2f}',
+            "scope_quantity": spec["scope_quantity"],
+            "scope_unit": spec["scope_unit"],
         }
         for spec in specs
     ]
@@ -178,6 +182,13 @@ def import_estimate_budget(db: Session, project_id: UUID, payload: EstimateBudge
         }
     metadata["project_cost_codes"] = list(cost_codes.values())
     project.metadata_json = metadata
+    _apply_estimate_procurement_plan(
+        project,
+        bid,
+        specs,
+        payload,
+        actor_email=user.email,
+    )
     summary = bid.bid_json["summary"]
     if project.contract_value is None and summary.get("final_price"):
         project.contract_value = float(summary["final_price"])
@@ -204,6 +215,8 @@ def _estimate_budget_specs(bid: Bid, payload: EstimateBudgetImportRequest) -> li
         description: str,
         override_code: str | None = None,
         override_name: str | None = None,
+        scope_quantity: object = None,
+        scope_unit: object = None,
     ) -> None:
         numeric = round(float(amount or 0), 2)
         if numeric <= 0:
@@ -221,6 +234,8 @@ def _estimate_budget_specs(bid: Bid, payload: EstimateBudgetImportRequest) -> li
                 "category": category,
                 "amount": numeric,
                 "description": description.strip(),
+                "scope_quantity": str(scope_quantity) if scope_quantity is not None else None,
+                "scope_unit": str(scope_unit).strip() if scope_unit is not None else None,
             }
         )
 
@@ -233,6 +248,8 @@ def _estimate_budget_specs(bid: Bid, payload: EstimateBudgetImportRequest) -> li
             category=_category(line.get("item_type")),
             amount=line.get("direct_cost"),
             description=str(line.get("description") or "Estimate budget line"),
+            scope_quantity=line.get("quantity"),
+            scope_unit=line.get("unit"),
         )
 
     risk_amount = float(summary.get("risk_cost") or 0)
@@ -270,6 +287,135 @@ def _estimate_budget_specs(bid: Bid, payload: EstimateBudgetImportRequest) -> li
     if not specs:
         raise HTTPException(status_code=400, detail="The selected estimate has no cost basis to import.")
     return specs
+
+
+def _apply_estimate_procurement_plan(
+    project: Project,
+    bid: Bid,
+    specs: list[dict],
+    payload: EstimateBudgetImportRequest,
+    *,
+    actor_email: str,
+) -> None:
+    requested = payload.procurement_requirements
+    if not requested:
+        return
+    if project.status != "awarded" or not project.project_number:
+        raise HTTPException(
+            status_code=409,
+            detail="Procurement planning requires an awarded project with a permanent job number.",
+        )
+    metadata = dict(project.metadata_json or {})
+    plan = dict(metadata.get("procurement_plan") or {})
+    if plan and plan.get("status") not in {None, "draft"}:
+        raise HTTPException(
+            status_code=409,
+            detail="The procurement plan has progressed beyond draft and cannot be regenerated.",
+        )
+    if plan.get("automatic_commitment") not in {None, False}:
+        raise HTTPException(
+            status_code=409,
+            detail="Automatic procurement commitments must be disabled before plan generation.",
+        )
+    source_workspace_id = plan.get("source_estimate_workspace_id")
+    if source_workspace_id and str(source_workspace_id) != str(bid.id):
+        raise HTTPException(
+            status_code=409,
+            detail="A procurement plan from another estimate workspace already exists.",
+        )
+    protected_fields = (
+        "vendor_id",
+        "vendor_quote_reference",
+        "required_on_site_date",
+        "approval",
+        "po_number",
+    )
+    safe_statuses = {None, "not_started", "needs_quantity_confirmation"}
+    for requirement in plan.get("requirements") or []:
+        if (
+            requirement.get("status") not in safe_statuses
+            or requirement.get("commitment_created") is True
+            or any(requirement.get(field) is not None for field in protected_fields)
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail="The procurement plan contains a decision or commitment and cannot be regenerated.",
+            )
+
+    by_source: dict[str, dict] = {}
+    for spec in specs:
+        source_code = spec["source_code"]
+        if source_code in by_source:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Estimate source code {source_code} is not unique.",
+            )
+        by_source[source_code] = spec
+    normalized_requests = [item.model_copy(update={"source_code": item.source_code.upper()}) for item in requested]
+    source_codes = [item.source_code for item in normalized_requests]
+    if len(source_codes) != len(set(source_codes)):
+        raise HTTPException(status_code=400, detail="Procurement source codes must be unique.")
+
+    requirements = []
+    for item in normalized_requests:
+        spec = by_source.get(item.source_code)
+        if spec is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Procurement source code {item.source_code} is not in the selected estimate budget.",
+            )
+        requirements.append(
+            {
+                "requirement_id": f"estimate-procurement:{bid.id}:{item.source_code}",
+                "source_type": "estimate_workspace",
+                "source_estimate_workspace_id": str(bid.id),
+                "source_budget_key": spec["source_key"],
+                "source_code": item.source_code,
+                "job_number": project.project_number,
+                "cost_code": spec["cost_code"],
+                "cost_code_name": spec["cost_code_name"],
+                "category": item.category,
+                "description": item.description,
+                "scope_quantity": spec["scope_quantity"],
+                "scope_unit": spec["scope_unit"],
+                "order_quantity": (
+                    str(item.order_quantity.normalize())
+                    if item.order_quantity is not None
+                    else None
+                ),
+                "order_unit": item.order_unit,
+                "order_quantity_status": item.order_quantity_status,
+                "specification": item.specification,
+                "budget_basis": f'{spec["amount"]:.2f}',
+                "budget_basis_type": "source_estimate_line_cost_not_authorized_spend",
+                "status": (
+                    "needs_quantity_confirmation"
+                    if item.order_quantity_status == "needs_confirmation"
+                    else "not_started"
+                ),
+                "vendor_id": None,
+                "vendor_quote_reference": None,
+                "required_on_site_date": None,
+                "approval": None,
+                "po_number": None,
+                "commitment_created": False,
+            }
+        )
+    plan.update(
+        {
+            "source_quote_id": (metadata.get("award_pricing_baseline") or {}).get(
+                "source_quote_id"
+            ),
+            "source_estimate_workspace_id": str(bid.id),
+            "job_number": project.project_number,
+            "status": "draft",
+            "requirements": requirements,
+            "generated_by": actor_email,
+            "automatic_commitment": False,
+        }
+    )
+    metadata["procurement_plan"] = plan
+    project.metadata_json = metadata
 
 
 def project_summary(db: Session, project_id: UUID, user: AuthenticatedUser) -> ProjectFinancialSummary:

--- a/backend/app/tools/bennett_procurement_staging_pilot.py
+++ b/backend/app/tools/bennett_procurement_staging_pilot.py
@@ -1,0 +1,381 @@
+"""Seed and verify the approved Bennett procurement planning requirements in staging."""
+
+from __future__ import annotations
+
+import json
+import os
+from argparse import ArgumentParser
+from datetime import UTC, datetime
+from typing import Any
+
+from app.core.config import get_settings
+from app.services.bennett_strata_staging_import import SOURCE_KEY, SOURCE_REVISION
+from app.services.drive_tender_import import ImportValidationError
+from app.tools.bennett_cost_budget_staging_pilot import (
+    BUDGET_REQUEST,
+    EXPECTED_BUDGET,
+    JOB_NUMBER,
+    PROJECT_ID,
+    QUOTE_ID,
+    STAGING_BASE_URL,
+    WORKSPACE_ID,
+    Api,
+    ApiClient,
+    _money,
+    _verify_exact_source,
+    _verify_financial_summary,
+)
+from app.tools.bennett_estimate_quote_staging_pilot import _require_value
+
+PROCUREMENT_REQUIREMENTS = [
+    {
+        "source_code": "CON-001",
+        "category": "material",
+        "description": "Ready-mix concrete planning requirement",
+        "order_quantity": None,
+        "order_unit": "m3",
+        "order_quantity_status": "needs_confirmation",
+        "specification": (
+            "4 in concrete scope; mix, order quantity, delivery and placement details "
+            "require confirmation."
+        ),
+    },
+    {
+        "source_code": "EQP-001",
+        "category": "rental",
+        "description": "14 in cutoff saw including blade wear and consumables",
+        "order_quantity": "1",
+        "order_unit": "day",
+        "order_quantity_status": "planning_basis",
+    },
+    {
+        "source_code": "EQP-002",
+        "category": "rental",
+        "description": "Skid steer with hydraulic hammer",
+        "order_quantity": "1",
+        "order_unit": "day",
+        "order_quantity_status": "planning_basis",
+    },
+    {
+        "source_code": "TRK-001",
+        "category": "trucking",
+        "description": "Tandem allowance for concrete disposal",
+        "order_quantity": "1",
+        "order_unit": "LS",
+        "order_quantity_status": "planning_basis",
+    },
+]
+PROCUREMENT_REQUEST = {
+    **BUDGET_REQUEST,
+    "procurement_requirements": PROCUREMENT_REQUIREMENTS,
+}
+EXPECTED_REQUIREMENTS = [
+    {
+        "source_code": "CON-001",
+        "cost_code": "4100",
+        "category": "material",
+        "description": "Ready-mix concrete planning requirement",
+        "scope_quantity": "108.6",
+        "scope_unit": "m2",
+        "order_quantity": None,
+        "order_unit": "m3",
+        "order_quantity_status": "needs_confirmation",
+        "budget_basis": "19860.93",
+        "budget_basis_type": "source_estimate_line_cost_not_authorized_spend",
+        "status": "needs_quantity_confirmation",
+        "specification": (
+            "4 in concrete scope; mix, order quantity, delivery and placement details "
+            "require confirmation."
+        ),
+    },
+    {
+        "source_code": "EQP-001",
+        "cost_code": "5100",
+        "category": "rental",
+        "description": "14 in cutoff saw including blade wear and consumables",
+        "scope_quantity": "1.0",
+        "scope_unit": "day",
+        "order_quantity": "1",
+        "order_unit": "day",
+        "order_quantity_status": "planning_basis",
+        "budget_basis": "200.00",
+        "budget_basis_type": "source_estimate_line_cost_not_authorized_spend",
+        "status": "not_started",
+        "specification": None,
+    },
+    {
+        "source_code": "EQP-002",
+        "cost_code": "5110",
+        "category": "rental",
+        "description": "Skid steer with hydraulic hammer",
+        "scope_quantity": "1.0",
+        "scope_unit": "day",
+        "order_quantity": "1",
+        "order_unit": "day",
+        "order_quantity_status": "planning_basis",
+        "budget_basis": "1100.00",
+        "budget_basis_type": "source_estimate_line_cost_not_authorized_spend",
+        "status": "not_started",
+        "specification": None,
+    },
+    {
+        "source_code": "TRK-001",
+        "cost_code": "6100",
+        "category": "trucking",
+        "description": "Tandem allowance for concrete disposal",
+        "scope_quantity": "1.0",
+        "scope_unit": "LS",
+        "order_quantity": "1",
+        "order_unit": "LS",
+        "order_quantity_status": "planning_basis",
+        "budget_basis": "750.00",
+        "budget_basis_type": "source_estimate_line_cost_not_authorized_spend",
+        "status": "not_started",
+        "specification": None,
+    },
+]
+
+
+def _safe_draft_plan(project: dict[str, Any]) -> dict[str, Any]:
+    plan = (project.get("metadata") or {}).get("procurement_plan") or {}
+    if plan.get("status") != "draft" or plan.get("automatic_commitment") is not False:
+        raise ImportValidationError("Bennett procurement baseline is not a safe draft plan.")
+    protected = (
+        "vendor_id",
+        "vendor_quote_reference",
+        "required_on_site_date",
+        "approval",
+        "po_number",
+    )
+    if any(
+        item.get("status") not in {None, "not_started", "needs_quantity_confirmation"}
+        or item.get("commitment_created") is True
+        or any(item.get(field) is not None for field in protected)
+        for item in plan.get("requirements") or []
+    ):
+        raise ImportValidationError("Bennett procurement baseline contains a decision or commitment.")
+    return plan
+
+
+def _verify_procurement_plan(project: dict[str, Any]) -> list[dict[str, Any]]:
+    plan = _safe_draft_plan(project)
+    expected_plan = {
+        "source_quote_id": QUOTE_ID,
+        "source_estimate_workspace_id": WORKSPACE_ID,
+        "job_number": JOB_NUMBER,
+        "status": "draft",
+        "automatic_commitment": False,
+    }
+    mismatches = {
+        key: {"actual": plan.get(key), "expected": value}
+        for key, value in expected_plan.items()
+        if plan.get(key) != value
+    }
+    if mismatches:
+        raise ImportValidationError(f"Bennett procurement plan mismatch: {mismatches}")
+    requirements = plan.get("requirements") or []
+    if len(requirements) != len(EXPECTED_REQUIREMENTS):
+        raise ImportValidationError("Bennett procurement plan must contain four requirements.")
+    actual = [
+        {key: item.get(key) for key in expected}
+        for item, expected in zip(requirements, EXPECTED_REQUIREMENTS, strict=True)
+    ]
+    if actual != EXPECTED_REQUIREMENTS:
+        raise ImportValidationError(f"Bennett procurement requirements mismatch: {actual}")
+    if len({item.get("requirement_id") for item in requirements}) != 4:
+        raise ImportValidationError("Bennett procurement requirement identities are not unique.")
+    if any(
+        item.get("source_type") != "estimate_workspace"
+        or str(item.get("source_estimate_workspace_id")) != WORKSPACE_ID
+        or not str(item.get("source_budget_key") or "").startswith(
+            f"estimate-budget:{WORKSPACE_ID}:"
+        )
+        or item.get("job_number") != JOB_NUMBER
+        or item.get("commitment_created") is not False
+        for item in requirements
+    ):
+        raise ImportValidationError("Bennett procurement requirements lack exact job/budget provenance.")
+    if any(item.get("source_code") == "RISK" for item in requirements):
+        raise ImportValidationError("The Bennett risk allowance became a procurement requirement.")
+    return requirements
+
+
+def _require_safe_dashboard(api: Api) -> dict[str, Any]:
+    dashboard = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}/launch-dashboard"),
+        "Bennett launch dashboard",
+    )
+    expected = {
+        "job_number": JOB_NUMBER,
+        "mobilization_status": "not_ready",
+        "checklist_completed_count": 0,
+        "baseline_budget_total": EXPECTED_BUDGET,
+        "budget_entry_count": 5,
+        "award_cost_budget_status": "allocated",
+        "uncoded_award_line_count": 0,
+        "procurement_plan_status": "draft",
+        "po_request_count": 0,
+        "pending_po_request_count": 0,
+    }
+    actual = {
+        **{key: dashboard.get(key) for key in expected},
+        "baseline_budget_total": _money(dashboard.get("baseline_budget_total")),
+    }
+    mismatches = {
+        key: {"actual": actual.get(key), "expected": value}
+        for key, value in expected.items()
+        if actual.get(key) != value
+    }
+    if mismatches:
+        raise ImportValidationError(f"Bennett launch control mismatch: {mismatches}")
+    return dashboard
+
+
+def run_pilot(api: Api, *, operator: str, email: str, password: str) -> dict[str, Any]:
+    readiness = _require_value(api.request("/readiness"), "Readiness")
+    api.request("/api/v1/auth/login", method="POST", body={"email": email, "password": password})
+    authenticated = _require_value(api.request("/api/v1/auth/me"), "Authenticated user")
+    authenticated_user = authenticated.get("user") or authenticated
+    if authenticated_user.get("role") not in {"admin", "operations_manager"}:
+        raise ImportValidationError("Authenticated staging user lacks procurement planning access.")
+
+    project = _require_value(api.request(f"/api/v1/projects/{PROJECT_ID}"), "Bennett project")
+    quote = _require_value(api.request(f"/api/v1/customer-quotes/{QUOTE_ID}"), "Bennett quote")
+    workspaces = _require_value(
+        api.request(f"/api/v1/estimates/workspace/project/{PROJECT_ID}"),
+        "Bennett workspaces",
+    )
+    matches = [item for item in workspaces.get("items", []) if str(item.get("id")) == WORKSPACE_ID]
+    if len(matches) != 1:
+        raise ImportValidationError("Expected one exact Bennett concrete estimate workspace.")
+    _verify_exact_source(project, matches[0], quote)
+    _safe_draft_plan(project)
+    before = _require_value(
+        api.request(f"/api/v1/finance/projects/{PROJECT_ID}"),
+        "Bennett financial baseline",
+    )
+    _verify_financial_summary(before)
+    before_dashboard = _require_safe_dashboard(api)
+    if before_dashboard.get("procurement_requirement_count") == 4:
+        _verify_procurement_plan(project)
+        transition_action = "reuse_existing_procurement_plan"
+    elif before_dashboard.get("procurement_requirement_count") == 1:
+        transition_action = "replace_safe_quote_procurement_shell"
+    else:
+        raise ImportValidationError("Bennett has an unexpected procurement requirement count.")
+
+    first = _require_value(
+        api.request(
+            f"/api/v1/finance/projects/{PROJECT_ID}/import-estimate",
+            method="POST",
+            body=PROCUREMENT_REQUEST,
+        ),
+        "Generated Bennett procurement plan",
+    )
+    first_entries = _verify_financial_summary(first)
+    first_project = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}"),
+        "Bennett project after procurement generation",
+    )
+    first_requirements = _verify_procurement_plan(first_project)
+    retry = _require_value(
+        api.request(
+            f"/api/v1/finance/projects/{PROJECT_ID}/import-estimate",
+            method="POST",
+            body=PROCUREMENT_REQUEST,
+        ),
+        "Retried Bennett procurement plan",
+    )
+    retry_entries = _verify_financial_summary(retry)
+    retry_project = _require_value(
+        api.request(f"/api/v1/projects/{PROJECT_ID}"),
+        "Bennett project after procurement retry",
+    )
+    retry_requirements = _verify_procurement_plan(retry_project)
+
+    def entry_identity(items: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
+        return sorted(
+            (str(item.get("id")), str(item.get("source_key")), _money(item.get("amount")))
+            for item in items
+        )
+
+    def requirement_identity(items: list[dict[str, Any]]) -> list[tuple[str, str]]:
+        return sorted(
+            (str(item.get("requirement_id")), str(item.get("source_budget_key")))
+            for item in items
+        )
+
+    if entry_identity(first_entries) != entry_identity(retry_entries):
+        raise ImportValidationError("Procurement generation changed original budget-entry identity.")
+    if requirement_identity(first_requirements) != requirement_identity(retry_requirements):
+        raise ImportValidationError("Bennett procurement retry changed requirement identity.")
+    dashboard = _require_safe_dashboard(api)
+    if dashboard.get("procurement_requirement_count") != 4:
+        raise ImportValidationError("Bennett launch dashboard lacks four procurement requirements.")
+
+    api.request("/api/v1/auth/logout", method="POST", expected_status=204)
+    return {
+        "status": "passed",
+        "pilot": "bennett_procurement_planning",
+        "approval_boundary": "staging_procurement_planning_only_no_commitments",
+        "operator": operator,
+        "authenticated_as": authenticated_user.get("email"),
+        "authenticated_role": authenticated_user.get("role"),
+        "release_id": (readiness.get("checks") or {}).get("release_id"),
+        "source": SOURCE_KEY,
+        "source_revision": SOURCE_REVISION,
+        "transition_action": transition_action,
+        "project": {"id": PROJECT_ID, "job_number": JOB_NUMBER, "status": "awarded"},
+        "workspace": {"id": WORKSPACE_ID, "estimate_key": "concrete"},
+        "budget": {"total": EXPECTED_BUDGET, "entry_count": len(first_entries)},
+        "procurement": {
+            "status": "draft",
+            "requirement_count": len(first_requirements),
+            "requirements": EXPECTED_REQUIREMENTS,
+            "ready_mix_order_quantity_confirmed": False,
+        },
+        "idempotent_retry": True,
+        "vendors_selected": 0,
+        "commitments_created": 0,
+        "po_requests_created": 0,
+        "actuals_created": 0,
+        "checklist_items_completed": 0,
+        "external_issuance_performed": False,
+        "production_mutation_performed": False,
+        "verified_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Seed the approved Bennett procurement plan in staging.")
+    parser.add_argument("--operator", required=True)
+    parser.add_argument("--base-url", default=STAGING_BASE_URL)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    settings = get_settings()
+    if settings.environment != "staging":
+        print(json.dumps({"status": "blocked", "issues": ["This procurement pilot is staging-only."]}, indent=2))
+        raise SystemExit(2)
+    email = os.environ.get("BOOTSTRAP_ADMIN_EMAIL", "").strip()
+    password = os.environ.get("BOOTSTRAP_ADMIN_PASSWORD", "")
+    if not email or not password:
+        print(json.dumps({"status": "blocked", "issues": ["Staging administrator credentials are unavailable."]}, indent=2))
+        raise SystemExit(2)
+    try:
+        report = run_pilot(
+            ApiClient(args.base_url),
+            operator=args.operator.strip(),
+            email=email,
+            password=password,
+        )
+    except (ImportValidationError, OSError, ValueError) as error:
+        print(json.dumps({"status": "blocked", "issues": [str(error)]}, indent=2))
+        raise SystemExit(2) from error
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/validation/bennett-staging-procurement-plan.md
+++ b/docs/validation/bennett-staging-procurement-plan.md
@@ -1,0 +1,24 @@
+# Bennett staging procurement plan
+
+## Objective
+
+Complete issue #268 step 8 by turning the awarded Bennett concrete estimate and allocated original budget into four traceable procurement planning requirements for job `IH2026002`.
+
+## Planning boundary
+
+The plan records one material-planning item, two rental-planning items and one trucking-planning item. Every requirement carries its immutable estimate source, budget source key, job number, approved cost code, scope basis and source estimate-line cost. That cost is labelled as provenance, not authorized procurement spend.
+
+The ready-mix order quantity remains `needs_confirmation`. The estimate's 108.60 m² scope quantity is not silently converted into a purchase quantity. The `$4,750.00` subgrade/buried-deficiency allowance remains only in the original cost budget.
+
+## Application controls
+
+- Management-only estimate-budget import accepts explicit procurement planning requirements.
+- Server-side matching derives job number, cost code and budget provenance from the selected estimate and allocated budget.
+- Deterministic requirement keys make exact retries stable.
+- A progressed plan, vendor choice, quote reference, required date, approval, PO or commitment blocks regeneration.
+- Plan status remains draft and automatic commitments remain disabled.
+- No PO request, booking, actual cost, invoice, checklist completion or external issuance is created.
+
+## Execution gate
+
+The staging pilot runs only after a human merges the exact Build 230 pull request and that release deploys successfully to staging. It fails closed on release drift, record drift, source or amount drift, an unsafe procurement baseline, a changed original budget, an inferred ready-mix order quantity, or any prohibited downstream record.

--- a/ops/staging-pilots/2026-08-28-bennett-procurement-plan.json
+++ b/ops/staging-pilots/2026-08-28-bennett-procurement-plan.json
@@ -1,0 +1,88 @@
+{
+  "issue": 375,
+  "parent_issues": [268, 314, 373],
+  "environment": "staging",
+  "source": "bennett_strata_issue_314",
+  "source_revision": "2026-08-27-final",
+  "trigger": "human merge of the exact Build 230 pull request followed by a successful exact-release staging deployment",
+  "approval_scope": "seed four exact source-linked procurement planning requirements for staging job IH2026002",
+  "exact_records": {
+    "project_id": "9ece69c0-cd6b-4d7b-b208-df77ed849e23",
+    "job_number": "IH2026002",
+    "workspace_id": "6f3a07a7-6c9b-48bc-9711-0ae8230bc7b2",
+    "quote_id": "8f854940-e710-45c2-aae4-7d5706c3a9e2",
+    "quote_number": "Q-2026-002"
+  },
+  "original_cost_budget": "26660.93",
+  "planning_requirements": [
+    {
+      "source_code": "CON-001",
+      "cost_code": "4100",
+      "category": "material",
+      "description": "Ready-mix concrete planning requirement",
+      "scope_quantity": "108.6",
+      "scope_unit": "m2",
+      "order_quantity": null,
+      "order_unit": "m3",
+      "order_quantity_status": "needs_confirmation",
+      "budget_basis": "19860.93",
+      "budget_basis_type": "source_estimate_line_cost_not_authorized_spend"
+    },
+    {
+      "source_code": "EQP-001",
+      "cost_code": "5100",
+      "category": "rental",
+      "description": "14 in cutoff saw including blade wear and consumables",
+      "order_quantity": "1",
+      "order_unit": "day",
+      "order_quantity_status": "planning_basis",
+      "budget_basis": "200.00",
+      "budget_basis_type": "source_estimate_line_cost_not_authorized_spend"
+    },
+    {
+      "source_code": "EQP-002",
+      "cost_code": "5110",
+      "category": "rental",
+      "description": "Skid steer with hydraulic hammer",
+      "order_quantity": "1",
+      "order_unit": "day",
+      "order_quantity_status": "planning_basis",
+      "budget_basis": "1100.00",
+      "budget_basis_type": "source_estimate_line_cost_not_authorized_spend"
+    },
+    {
+      "source_code": "TRK-001",
+      "cost_code": "6100",
+      "category": "trucking",
+      "description": "Tandem allowance for concrete disposal",
+      "order_quantity": "1",
+      "order_unit": "LS",
+      "order_quantity_status": "planning_basis",
+      "budget_basis": "750.00",
+      "budget_basis_type": "source_estimate_line_cost_not_authorized_spend"
+    }
+  ],
+  "excluded_allowance": {
+    "source_code": "RISK",
+    "amount": "4750.00",
+    "reason": "Subgrade and buried deficiencies are an original-budget allowance, not an authorized procurement requirement."
+  },
+  "permitted_actions": [
+    "authenticate through the live HTTPS staging origin",
+    "replace the safe quote-derived procurement shell with four deterministic planning requirements",
+    "record exact estimate, budget, job and cost-code provenance",
+    "repeat generation to prove stable identities and values",
+    "upload immutable evidence retained for 90 days"
+  ],
+  "prohibited_actions": [
+    "select or contact vendors",
+    "infer or confirm the ready-mix order quantity",
+    "set required-on-site dates or approve spend",
+    "book rentals or trucking",
+    "create a commitment, purchase order, actual cost, invoice or accounting export",
+    "mark mobilization ready or complete a project-start checklist item",
+    "issue or externally send the quote",
+    "mutate production",
+    "change DNS, certificates, secrets, backups, authentication or infrastructure"
+  ]
+}

--- a/tests/backend/test_bennett_cost_budget_staging_pilot.py
+++ b/tests/backend/test_bennett_cost_budget_staging_pilot.py
@@ -16,6 +16,12 @@ from app.tools.bennett_cost_budget_staging_pilot import (
     _parser,
     run_pilot,
 )
+from app.tools.bennett_procurement_staging_pilot import (
+    EXPECTED_REQUIREMENTS,
+    PROCUREMENT_REQUEST,
+    _parser as procurement_parser,
+    run_pilot as run_procurement_pilot,
+)
 
 
 def test_cli_defaults_to_secure_live_staging_origin() -> None:
@@ -26,7 +32,7 @@ def test_cli_defaults_to_secure_live_staging_origin() -> None:
 
 
 class FakeApi:
-    def __init__(self, *, already_budgeted: bool = False) -> None:
+    def __init__(self, *, already_budgeted: bool = False, already_planned: bool = False) -> None:
         self.calls: list[tuple[str, str, dict[str, Any] | None, int]] = []
         self.project = {
             "id": PROJECT_ID,
@@ -75,8 +81,10 @@ class FakeApi:
             "issued_at": None,
         }
         self.entries: list[dict[str, Any]] = []
-        if already_budgeted:
+        if already_budgeted or already_planned:
             self._apply_budget()
+        if already_planned:
+            self._apply_procurement()
 
     def _apply_budget(self) -> None:
         if self.entries:
@@ -119,6 +127,46 @@ class FakeApi:
             for code, values in EXPECTED_CODES.items()
         ]
 
+    def _apply_procurement(self) -> None:
+        positions = {
+            "CON-001": "line-001",
+            "EQP-001": "line-002",
+            "EQP-002": "line-003",
+            "TRK-001": "line-004",
+        }
+        names = {"4100": "Concrete restoration", "5100": "Small equipment rental", "5110": "Skid steer / hydraulic attachment", "6100": "Trucking, disposal and material hauling"}
+        self.project["metadata"]["procurement_plan"] = {
+            "source_quote_id": QUOTE_ID,
+            "source_estimate_workspace_id": WORKSPACE_ID,
+            "job_number": JOB_NUMBER,
+            "status": "draft",
+            "automatic_commitment": False,
+            "requirements": [
+                {
+                    **expected,
+                    "requirement_id": f"estimate-procurement:{WORKSPACE_ID}:{expected['source_code']}",
+                    "source_type": "estimate_workspace",
+                    "source_estimate_workspace_id": WORKSPACE_ID,
+                    "source_budget_key": f"estimate-budget:{WORKSPACE_ID}:{positions[expected['source_code']]}",
+                    "job_number": JOB_NUMBER,
+                    "cost_code_name": names[expected["cost_code"]],
+                    "description": request["description"],
+                    "specification": request.get("specification"),
+                    "vendor_id": None,
+                    "vendor_quote_reference": None,
+                    "required_on_site_date": None,
+                    "approval": None,
+                    "po_number": None,
+                    "commitment_created": False,
+                }
+                for expected, request in zip(
+                    EXPECTED_REQUIREMENTS,
+                    PROCUREMENT_REQUEST["procurement_requirements"],
+                    strict=True,
+                )
+            ],
+        }
+
     def _financial_summary(self) -> dict[str, Any]:
         return {
             "project_id": PROJECT_ID,
@@ -155,13 +203,17 @@ class FakeApi:
             return self._financial_summary()
         if path == f"/api/v1/finance/projects/{PROJECT_ID}/import-estimate":
             assert method == "POST"
-            assert body == BUDGET_REQUEST
             self._apply_budget()
+            if body == PROCUREMENT_REQUEST:
+                self._apply_procurement()
+            else:
+                assert body == BUDGET_REQUEST
             return self._financial_summary()
         if path == f"/api/v1/projects/{PROJECT_ID}/launch-dashboard":
             return {
                 "job_number": JOB_NUMBER,
                 "mobilization_status": "not_ready",
+                "checklist_completed_count": 0,
                 "baseline_budget_total": "26660.93",
                 "budget_entry_count": 5,
                 "award_baseline_source": "Q-2026-002",
@@ -169,7 +221,11 @@ class FakeApi:
                 "award_cost_budget_status": "allocated",
                 "uncoded_award_line_count": 0,
                 "procurement_plan_status": "draft",
+                "procurement_requirement_count": len(
+                    self.project["metadata"]["procurement_plan"]["requirements"]
+                ),
                 "po_request_count": 0,
+                "pending_po_request_count": 0,
             }
         if path == "/api/v1/daily-timesheets/bootstrap":
             return {
@@ -254,6 +310,72 @@ def test_budget_pilot_fails_closed_on_existing_commitment() -> None:
         run_pilot(
             api,
             operator="GitHub staging budget",
+            email="admin@ironhousecontracting.com",
+            password="not-recorded",
+        )
+
+    assert not any(path.endswith("/import-estimate") for path, *_ in api.calls)
+
+
+def test_procurement_cli_defaults_to_secure_live_staging_origin() -> None:
+    args = procurement_parser().parse_args(["--operator", "GitHub staging procurement"])
+
+    assert args.base_url == STAGING_BASE_URL
+    assert args.base_url == "https://staging.os.ironhousecivil.com"
+
+
+@pytest.mark.parametrize(
+    ("already_planned", "expected_action"),
+    [
+        (False, "replace_safe_quote_procurement_shell"),
+        (True, "reuse_existing_procurement_plan"),
+    ],
+)
+def test_procurement_pilot_is_exact_safe_and_idempotent(
+    already_planned: bool,
+    expected_action: str,
+) -> None:
+    api = FakeApi(already_budgeted=True, already_planned=already_planned)
+
+    report = run_procurement_pilot(
+        api,
+        operator="GitHub staging procurement",
+        email="admin@ironhousecontracting.com",
+        password="not-recorded",
+    )
+
+    assert report["status"] == "passed"
+    assert report["approval_boundary"] == "staging_procurement_planning_only_no_commitments"
+    assert report["transition_action"] == expected_action
+    assert report["project"]["job_number"] == JOB_NUMBER
+    assert report["budget"] == {"total": "26660.93", "entry_count": 5}
+    assert report["procurement"]["status"] == "draft"
+    assert report["procurement"]["requirement_count"] == 4
+    assert report["procurement"]["ready_mix_order_quantity_confirmed"] is False
+    assert report["idempotent_retry"] is True
+    assert report["vendors_selected"] == 0
+    assert report["commitments_created"] == 0
+    assert report["po_requests_created"] == 0
+    assert report["actuals_created"] == 0
+    assert report["checklist_items_completed"] == 0
+    assert report["external_issuance_performed"] is False
+    assert report["production_mutation_performed"] is False
+    assert "not-recorded" not in str(report)
+
+    imports = [call for call in api.calls if call[0].endswith("/import-estimate")]
+    assert len(imports) == 2
+    assert all(call[1] == "POST" and call[2] == PROCUREMENT_REQUEST for call in imports)
+    assert not any("purchase-orders" in path or "quickbooks" in path for path, *_ in api.calls)
+
+
+def test_procurement_pilot_fails_closed_on_vendor_selection() -> None:
+    api = FakeApi(already_planned=True)
+    api.project["metadata"]["procurement_plan"]["requirements"][1]["vendor_id"] = "vendor-1"
+
+    with pytest.raises(ImportValidationError, match="decision or commitment"):
+        run_procurement_pilot(
+            api,
+            operator="GitHub staging procurement",
             email="admin@ironhousecontracting.com",
             password="not-recorded",
         )

--- a/tests/backend/test_bennett_staging_procurement_workflow.py
+++ b/tests/backend/test_bennett_staging_procurement_workflow.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/bennett-staging-procurement-plan.yml"
+MARKER = ROOT / "ops/staging-pilots/2026-08-28-bennett-procurement-plan.json"
+PROCUREMENT_TOOL = ROOT / "backend/app/tools/bennett_procurement_staging_pilot.py"
+
+
+def test_workflow_runs_only_after_exact_human_merged_build_and_staging_deploy() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'workflows: ["Staging deploy"]' in workflow
+    assert "github.event.workflow_run.conclusion == 'success'" in workflow
+    assert "github.event.workflow_run.event == 'push'" in workflow
+    assert "github.event.workflow_run.head_branch == 'main'" in workflow
+    assert "Build 230: seed Bennett procurement planning requirements" in workflow
+    assert "runner.temp" not in workflow
+    assert (
+        "/tmp/iron-house-os-bennett-staging-procurement-${{ github.run_id }}-${{ github.run_attempt }}"
+        in workflow
+    )
+    assert 'test "$RELEASE_SHA" = "$(git rev-parse origin/main)"' in workflow
+    assert "Live staging release mismatch" in workflow
+    assert "bennett_procurement_staging_pilot" in workflow
+    assert "--base-url https://staging.os.ironhousecivil.com" in workflow
+    assert "http://127.0.0.1:8000" not in workflow
+    assert "retention-days: 90" in workflow
+
+
+def test_approval_marker_and_tool_match_the_exact_authorized_boundary() -> None:
+    marker = json.loads(MARKER.read_text(encoding="utf-8"))
+    tool = PROCUREMENT_TOOL.read_text(encoding="utf-8")
+
+    assert marker["issue"] == 375
+    assert marker["environment"] == "staging"
+    assert marker["source_revision"] == "2026-08-27-final"
+    assert "Build 230" in marker["trigger"]
+    assert marker["exact_records"]["job_number"] == "IH2026002"
+    assert marker["original_cost_budget"] == "26660.93"
+    assert len(marker["planning_requirements"]) == 4
+    assert marker["planning_requirements"][0]["order_quantity"] is None
+    assert marker["excluded_allowance"] == {
+        "source_code": "RISK",
+        "amount": "4750.00",
+        "reason": "Subgrade and buried deficiencies are an original-budget allowance, not an authorized procurement requirement.",
+    }
+    assert "infer or confirm the ready-mix order quantity" in marker["prohibited_actions"]
+    assert "book rentals or trucking" in marker["prohibited_actions"]
+    assert "mutate production" in marker["prohibited_actions"]
+
+    assert "/api/v1/auth/login" in tool
+    assert "/api/v1/finance/projects/{PROJECT_ID}/import-estimate" in tool
+    assert '"approval_boundary": "staging_procurement_planning_only_no_commitments"' in tool
+    assert "PROCUREMENT_REQUIREMENTS" in tool
+    assert "purchase-orders" not in tool
+    assert "quickbooks" not in tool

--- a/tests/backend/test_finance.py
+++ b/tests/backend/test_finance.py
@@ -69,10 +69,10 @@ def _bennett_style_estimate(project_id: str) -> UUID:
                 "summary": {
                     "final_price": 36266.67,
                     "line_items": [
-                        {"code": "CON-001", "description": "4 in concrete pull and pour", "item_type": "self_perform", "direct_cost": 19860.93},
-                        {"code": "EQP-001", "description": "14 in cutoff saw", "item_type": "equipment", "direct_cost": 200},
-                        {"code": "EQP-002", "description": "Skid steer with hydraulic hammer", "item_type": "equipment", "direct_cost": 1100},
-                        {"code": "TRK-001", "description": "Concrete disposal tandem", "item_type": "subcontract", "direct_cost": 750},
+                        {"code": "CON-001", "description": "4 in concrete pull and pour", "item_type": "self_perform", "quantity": 108.6, "unit": "m2", "direct_cost": 19860.93},
+                        {"code": "EQP-001", "description": "14 in cutoff saw", "item_type": "equipment", "quantity": 1, "unit": "day", "direct_cost": 200},
+                        {"code": "EQP-002", "description": "Skid steer with hydraulic hammer", "item_type": "equipment", "quantity": 1, "unit": "day", "direct_cost": 1100},
+                        {"code": "TRK-001", "description": "Concrete disposal tandem", "item_type": "subcontract", "quantity": 1, "unit": "LS", "direct_cost": 750},
                     ],
                     "indirect_cost": 0,
                     "risk_cost": 4750,
@@ -107,6 +107,44 @@ def _bennett_budget_payload(workspace_id: UUID) -> dict:
         "risk_cost_code": "4100",
         "risk_cost_code_name": "Concrete restoration",
     }
+
+
+def _bennett_procurement_requirements() -> list[dict]:
+    return [
+        {
+            "source_code": "CON-001",
+            "category": "material",
+            "description": "Ready-mix concrete planning requirement",
+            "order_quantity": None,
+            "order_unit": "m3",
+            "order_quantity_status": "needs_confirmation",
+            "specification": "4 in concrete scope; mix, order quantity, delivery and placement details require confirmation.",
+        },
+        {
+            "source_code": "EQP-001",
+            "category": "rental",
+            "description": "14 in cutoff saw including blade wear and consumables",
+            "order_quantity": "1",
+            "order_unit": "day",
+            "order_quantity_status": "planning_basis",
+        },
+        {
+            "source_code": "EQP-002",
+            "category": "rental",
+            "description": "Skid steer with hydraulic hammer",
+            "order_quantity": "1",
+            "order_unit": "day",
+            "order_quantity_status": "planning_basis",
+        },
+        {
+            "source_code": "TRK-001",
+            "category": "trucking",
+            "description": "Tandem allowance for concrete disposal",
+            "order_quantity": "1",
+            "order_unit": "LS",
+            "order_quantity_status": "planning_basis",
+        },
+    ]
 
 
 def test_estimate_budget_actual_commitment_and_forecast_summary() -> None:
@@ -224,6 +262,117 @@ def test_estimate_budget_reactivates_a_previously_voided_source_key() -> None:
     )
     assert restored.json()["budget"] == 26660.93
     assert restored_trucking["id"] == trucking["id"]
+
+
+def test_estimate_budget_seeds_source_linked_procurement_planning_without_commitments() -> None:
+    project = _project()
+    awarded = client.patch(f"/api/v1/projects/{project['id']}", json={"status": "awarded"})
+    assert awarded.status_code == 200
+    workspace_id = _bennett_style_estimate(project["id"])
+    payload = _bennett_budget_payload(workspace_id)
+    payload["procurement_requirements"] = _bennett_procurement_requirements()
+
+    first = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+    second = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+
+    assert first.status_code == second.status_code == 200
+    assert first.json()["budget"] == second.json()["budget"] == 26660.93
+    assert {item["id"] for item in first.json()["entries"]} == {
+        item["id"] for item in second.json()["entries"]
+    }
+    refreshed = client.get(f"/api/v1/projects/{project['id']}").json()
+    plan = refreshed["metadata"]["procurement_plan"]
+    assert plan["status"] == "draft"
+    assert plan["job_number"] == awarded.json()["project_number"]
+    assert plan["source_estimate_workspace_id"] == str(workspace_id)
+    assert plan["automatic_commitment"] is False
+    requirements = plan["requirements"]
+    assert len(requirements) == 4
+    assert len({item["requirement_id"] for item in requirements}) == 4
+    assert [item["source_code"] for item in requirements] == [
+        "CON-001",
+        "EQP-001",
+        "EQP-002",
+        "TRK-001",
+    ]
+    assert [item["cost_code"] for item in requirements] == ["4100", "5100", "5110", "6100"]
+    assert [item["budget_basis"] for item in requirements] == [
+        "19860.93",
+        "200.00",
+        "1100.00",
+        "750.00",
+    ]
+    assert all(
+        item["budget_basis_type"] == "source_estimate_line_cost_not_authorized_spend"
+        for item in requirements
+    )
+    concrete = requirements[0]
+    assert concrete["scope_quantity"] == "108.6"
+    assert concrete["scope_unit"] == "m2"
+    assert concrete["order_quantity"] is None
+    assert concrete["order_unit"] == "m3"
+    assert concrete["order_quantity_status"] == "needs_confirmation"
+    assert concrete["status"] == "needs_quantity_confirmation"
+    assert all(
+        item[field] is None
+        for item in requirements
+        for field in (
+            "vendor_id",
+            "vendor_quote_reference",
+            "required_on_site_date",
+            "approval",
+            "po_number",
+        )
+    )
+    assert all(item["commitment_created"] is False for item in requirements)
+    assert not any(item["source_code"] == "RISK" for item in requirements)
+    launch = client.get(f"/api/v1/projects/{project['id']}/launch-dashboard").json()
+    assert launch["procurement_requirement_count"] == 4
+    assert launch["procurement_plan_status"] == "draft"
+    assert launch["po_request_count"] == 0
+
+
+def test_estimate_procurement_plan_does_not_replace_a_vendor_decision() -> None:
+    project = _project()
+    awarded = client.patch(f"/api/v1/projects/{project['id']}", json={"status": "awarded"})
+    assert awarded.status_code == 200
+    workspace_id = _bennett_style_estimate(project["id"])
+    payload = _bennett_budget_payload(workspace_id)
+    payload["procurement_requirements"] = _bennett_procurement_requirements()
+    created = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+    assert created.status_code == 200
+
+    with TestingSessionLocal() as db:
+        row = db.get(Project, UUID(project["id"]))
+        assert row is not None
+        metadata = deepcopy(row.metadata_json)
+        metadata["procurement_plan"]["requirements"][1]["approval"] = {
+            "status": "approved",
+            "by": "manager@ironhousecontracting.com",
+        }
+        row.metadata_json = metadata
+        db.commit()
+    blocked = client.post(
+        f"/api/v1/finance/projects/{project['id']}/import-estimate",
+        json=payload,
+    )
+
+    assert blocked.status_code == 409
+    assert "decision or commitment" in blocked.json()["detail"]
+    unchanged = client.get(f"/api/v1/projects/{project['id']}").json()
+    assert unchanged["metadata"]["procurement_plan"]["requirements"][1]["approval"] == {
+        "status": "approved",
+        "by": "manager@ironhousecontracting.com",
+    }
 
 
 def test_estimate_budget_import_does_not_replace_a_manual_budget() -> None:


### PR DESCRIPTION
Closes #375

## Outcome

Replaces the Bennett quote-derived generic procurement shell with four deterministic, estimate- and budget-linked planning requirements for awarded staging job `IH2026002`.

| Source | Job cost code | Planning requirement | Quantity state | Source estimate-line cost |
| --- | --- | --- | --- | ---: |
| CON-001 | 4100 | Ready-mix concrete planning | Order quantity needs confirmation | $19,860.93 |
| EQP-001 | 5100 | 14 in cutoff saw rental | 1 day planning basis | $200.00 |
| EQP-002 | 5110 | Skid steer / hydraulic hammer rental | 1 day planning basis | $1,100.00 |
| TRK-001 | 6100 | Concrete disposal tandem | 1 LS planning basis | $750.00 |

The amounts are labelled as source-estimate provenance, not authorized spend. The $4,750.00 subgrade/buried-deficiency allowance remains only in the original cost budget.

## Controls

- Management-only controlled generation against an awarded job and selected estimate workspace.
- Server derives job number, cost code and budget provenance from existing records.
- Deterministic keys make exact retries stable without changing original budget-entry identity.
- Regeneration fails closed after any vendor choice, quote reference, required date, approval, PO or commitment.
- Ready-mix scope area is not converted into a purchase quantity.
- Plan remains draft with no vendors, bookings, approvals, POs, commitments, actuals, invoices, checklist completions, issuance or production mutation.
- Exact staging transition runs only after human merge and successful exact-release staging deployment.

## Verification

- Backend: 615 passed
- Frontend: 140 passed
- Focused finance/award/staging contracts: 39 passed
- Ruff: passed
- TypeScript: passed
- Production build: passed
- Visual design lock: passed
- React Router RSC security boundary: passed
- Hosted browser/mobile/accessibility and Release Readiness gates remain required before ready-for-review.
