### PR TITLE
Build 233: pin CI actions and enforce workflow security

### DIFF
--- a/.github/workflows/bennett-staging-award.yml
+++ b/.github/workflows/bennett-staging-award.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p "$EVIDENCE_DIR"
 
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload immutable award evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bennett-staging-award-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}

--- a/.github/workflows/bennett-staging-cost-budget.yml
+++ b/.github/workflows/bennett-staging-cost-budget.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p "$EVIDENCE_DIR"
 
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload immutable budget evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bennett-staging-cost-budget-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}

--- a/.github/workflows/bennett-staging-draft-pilot.yml
+++ b/.github/workflows/bennett-staging-draft-pilot.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p "$EVIDENCE_DIR"
 
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload immutable pilot evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bennett-staging-draft-pilot-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}

--- a/.github/workflows/bennett-staging-procurement-plan.yml
+++ b/.github/workflows/bennett-staging-procurement-plan.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p "$EVIDENCE_DIR"
 
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload immutable procurement evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bennett-staging-procurement-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}

--- a/.github/workflows/bennett-staging-production-gate.yml
+++ b/.github/workflows/bennett-staging-production-gate.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p "$EVIDENCE_DIR"
 
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload immutable production-gate evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bennett-staging-production-gate-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}

--- a/.github/workflows/bennett-staging-safety-launch.yml
+++ b/.github/workflows/bennett-staging-safety-launch.yml
@@ -32,7 +32,7 @@ jobs:
         run: mkdir -p "$EVIDENCE_DIR"
 
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -131,7 +131,7 @@ jobs:
 
       - name: Upload immutable safety launch evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bennett-staging-safety-launch-${{ github.run_id }}
           path: ${{ env.EVIDENCE_DIR }}

--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,28 @@ on:
   pull_request:
     branches: [main, release/v1-staging]
 
+permissions:
+  contents: read
+
 jobs:
+  workflow-security:
+    name: Workflow supply-chain security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Verify immutable actions and least-privilege workflow permissions
+        run: python3 scripts/check_workflow_security.py
+
   backend:
     name: Backend checks
     runs-on: ubuntu-latest
+    needs: workflow-security
     defaults:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install backend dependencies
@@ -31,12 +43,13 @@ jobs:
   frontend:
     name: Frontend checks
     runs-on: ubuntu-latest
+    needs: workflow-security
     defaults:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -62,8 +75,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -80,7 +93,7 @@ jobs:
         run: npm run test:e2e
       - name: Upload browser failure evidence
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: frontend/playwright-report

--- a/.github/workflows/finish-approved-production-deploy.yml
+++ b/.github/workflows/finish-approved-production-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       RELEASE_SHA: ${{ inputs.release_sha }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/production-awarded-invoice-import.yml
+++ b/.github/workflows/production-awarded-invoice-import.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha || github.sha }}
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out approved main revision without credentials
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha }}
           persist-credentials: false
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload immutable import evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: production-awarded-invoice-import-${{ github.run_id }}
           path: ${{ runner.temp }}/production-awarded-invoice-import-evidence.json

--- a/.github/workflows/production-business-import.yml
+++ b/.github/workflows/production-business-import.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out proposed change without credentials
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha || github.sha }}
           persist-credentials: false
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out approved main revision without credentials
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha }}
           persist-credentials: false
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload immutable import evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: production-business-import-${{ github.run_id }}
           path: ${{ runner.temp }}/production-business-import-evidence.json

--- a/.github/workflows/production-project-cleanup.yml
+++ b/.github/workflows/production-project-cleanup.yml
@@ -27,7 +27,7 @@ jobs:
     environment: production
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload cleanup evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: production-project-cleanup-${{ github.run_id }}
           path: production-project-cleanup-evidence.json

--- a/.github/workflows/production-project-import.yml
+++ b/.github/workflows/production-project-import.yml
@@ -30,7 +30,7 @@ jobs:
       EVIDENCE_FILE: production-project-import-evidence.json
     steps:
       - name: Check out owner-approved import
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload immutable import evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: production-project-import-${{ github.run_id }}
           path: production-project-import-evidence.json

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -13,8 +13,7 @@ on:
       - ".env.production.example"
       - "scripts/**"
       - "ops/**"
-      - ".github/workflows/staging-deploy.yml"
-      - ".github/workflows/release-readiness.yml"
+      - ".github/workflows/**"
   pull_request:
     branches: [main, release/v1-staging]
     paths:
@@ -26,18 +25,26 @@ on:
       - ".env.production.example"
       - "scripts/**"
       - "ops/**"
-      - ".github/workflows/staging-deploy.yml"
-      - ".github/workflows/release-readiness.yml"
+      - ".github/workflows/**"
 
 permissions:
   contents: read
 
 jobs:
+  workflow-security:
+    name: Workflow supply-chain security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Verify immutable actions and least-privilege workflow permissions
+        run: python3 scripts/check_workflow_security.py
+
   staging-configuration:
     name: Staging isolation gate
     runs-on: ubuntu-latest
+    needs: workflow-security
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Validate staging shell and Compose configuration
         run: |
           bash -n scripts/staging-compose.sh
@@ -56,12 +63,13 @@ jobs:
   backend:
     name: Release backend gate
     runs-on: ubuntu-latest
+    needs: workflow-security
     defaults:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install backend dependencies
@@ -76,12 +84,13 @@ jobs:
   frontend:
     name: Release frontend gate
     runs-on: ubuntu-latest
+    needs: workflow-security
     defaults:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -107,8 +116,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -143,7 +152,7 @@ jobs:
       VITE_PERFORMANCE_OBSERVABILITY_ENABLED: "true"
       IHOS_STAGING_ENV_FILE: .env.staging.example
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Start isolated staging stack
         run: scripts/staging-compose.sh up -d --build --wait
       - name: Run anonymous, session, role, and synthetic staging smoke
@@ -229,7 +238,7 @@ jobs:
             --release "$GITHUB_SHA" \
             --profile staging
       - name: Upload staging release evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: staging-release-evidence-${{ github.sha }}
           path: staging-release-evidence
@@ -259,7 +268,7 @@ jobs:
       IHOS_ALLOW_SECURE_COOKIE_OVER_LOOPBACK: "true"
       IHOS_PORT: "8080"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Validate production configuration
         run: docker compose --env-file .env.production.example -f docker-compose.production.yml config --quiet
       - name: Validate Build 216 host assets
@@ -337,7 +346,7 @@ jobs:
           --gate production_stack_smoke=passed
           --gate backup_restore=passed
       - name: Upload release-candidate evidence
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-candidate-evidence-${{ github.sha }}
           path: release-candidate-evidence

--- a/.github/workflows/staging-approved-imports.yml
+++ b/.github/workflows/staging-approved-imports.yml
@@ -39,7 +39,7 @@ jobs:
       RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
       - name: Check out exact approved release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload immutable staging import evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: approved-staging-imports-${{ github.run_id }}
           path: ${{ runner.temp }}/approved-staging-import-evidence

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: [self-hosted, linux, ihos-staging]
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.release_sha || github.sha }}
           fetch-depth: 0

--- a/scripts/check_workflow_security.py
+++ b/scripts/check_workflow_security.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Fail closed when GitHub workflows use mutable or unapproved actions."""
+
+from argparse import ArgumentParser
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+
+APPROVED_REMOTE_ACTIONS = {
+    "actions/checkout": {
+        "sha": "11d5960a326750d5838078e36cf38b85af677262",
+        "version": "v4",
+    },
+    "actions/setup-node": {
+        "sha": "49933ea5288caeca8642d1e84afbd3f7d6820020",
+        "version": "v4",
+    },
+    "actions/setup-python": {
+        "sha": "a26af69be951a213d495a4c3e4e4022e16d87065",
+        "version": "v5",
+    },
+    "actions/upload-artifact": {
+        "sha": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+        "version": "v4",
+    },
+}
+FULL_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+REMOTE_ACTION = re.compile(r"^(?P<action>[^@\s]+)@(?P<ref>[^@\s]+)$")
+USES_LINE = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<value>[^\s#]+)(?:\s+#\s*(?P<comment>.*?))?\s*$"
+)
+USES_PREFIX = re.compile(r"^\s*(?:-\s*)?uses:")
+
+
+def workflow_files(root: Path) -> list[Path]:
+    workflow_root = root / ".github" / "workflows"
+    return sorted(
+        {
+            *workflow_root.glob("*.yml"),
+            *workflow_root.glob("*.yaml"),
+        }
+    )
+
+
+def _check_local_action(root: Path, workflow: Path, line_number: int, value: str) -> list[str]:
+    if not value.startswith("./.github/actions/"):
+        return [
+            f"{workflow.relative_to(root)}:{line_number}: local action must be under "
+            f"./.github/actions/: {value}"
+        ]
+
+    relative = Path(value.removeprefix("./"))
+    candidate = (root / relative).resolve()
+    actions_root = (root / ".github" / "actions").resolve()
+    try:
+        candidate.relative_to(actions_root)
+    except ValueError:
+        return [
+            f"{workflow.relative_to(root)}:{line_number}: local action escapes "
+            f".github/actions: {value}"
+        ]
+
+    if not candidate.is_dir() or not any(
+        (candidate / manifest).is_file() for manifest in ("action.yml", "action.yaml")
+    ):
+        return [
+            f"{workflow.relative_to(root)}:{line_number}: local action has no "
+            f"action.yml or action.yaml: {value}"
+        ]
+    return []
+
+
+def _check_remote_action(
+    root: Path,
+    workflow: Path,
+    line_number: int,
+    value: str,
+    comment: str | None,
+) -> list[str]:
+    relative = workflow.relative_to(root)
+    match = REMOTE_ACTION.fullmatch(value)
+    if not match:
+        return [f"{relative}:{line_number}: malformed remote action reference: {value}"]
+
+    action = match.group("action")
+    ref = match.group("ref")
+    errors: list[str] = []
+    if not FULL_COMMIT_SHA.fullmatch(ref):
+        errors.append(
+            f"{relative}:{line_number}: remote action must use a full 40-character "
+            f"commit SHA: {value}"
+        )
+
+    approved = APPROVED_REMOTE_ACTIONS.get(action)
+    if approved is None:
+        errors.append(
+            f"{relative}:{line_number}: remote action is not in the approved allowlist: {action}"
+        )
+        return errors
+
+    if ref != approved["sha"]:
+        errors.append(
+            f"{relative}:{line_number}: {action} must use approved SHA "
+            f"{approved['sha']}, got {ref}"
+        )
+
+    version = approved["version"]
+    comment_version = (comment or "").strip().split(maxsplit=1)[0:1]
+    if comment_version != [version]:
+        errors.append(
+            f"{relative}:{line_number}: pinned {action} must retain '# {version}' "
+            "for update visibility"
+        )
+    return errors
+
+
+def inspect_workflows(root: Path) -> dict[str, Any]:
+    root = root.resolve()
+    files = workflow_files(root)
+    errors: list[str] = []
+    action_references = 0
+
+    if not files:
+        errors.append("No GitHub workflow files were found under .github/workflows.")
+
+    for workflow in files:
+        try:
+            lines = workflow.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            errors.append(f"{workflow.relative_to(root)}: unable to read workflow: {exc}")
+            continue
+
+        if not any(line.startswith("permissions:") for line in lines):
+            errors.append(
+                f"{workflow.relative_to(root)}: missing explicit top-level permissions"
+            )
+
+        for line_number, line in enumerate(lines, start=1):
+            if not USES_PREFIX.match(line):
+                continue
+            action_references += 1
+            match = USES_LINE.fullmatch(line)
+            if not match:
+                errors.append(
+                    f"{workflow.relative_to(root)}:{line_number}: malformed uses declaration"
+                )
+                continue
+
+            value = match.group("value")
+            if value.startswith("./"):
+                errors.extend(_check_local_action(root, workflow, line_number, value))
+                continue
+            if value.startswith("docker://"):
+                errors.append(
+                    f"{workflow.relative_to(root)}:{line_number}: docker actions require "
+                    "an explicit approved digest policy before use"
+                )
+                continue
+            errors.extend(
+                _check_remote_action(
+                    root,
+                    workflow,
+                    line_number,
+                    value,
+                    match.group("comment"),
+                )
+            )
+
+    return {
+        "action_references": action_references,
+        "approved_remote_actions": {
+            action: details["sha"] for action, details in APPROVED_REMOTE_ACTIONS.items()
+        },
+        "errors": errors,
+        "status": "passed" if not errors else "failed",
+        "workflow_files": len(files),
+    }
+
+
+def main() -> int:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+
+    try:
+        result = inspect_workflows(args.root)
+    except OSError as exc:
+        print(f"Workflow security check failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/backend/test_staging_config.py
+++ b/tests/backend/test_staging_config.py
@@ -78,7 +78,7 @@ def test_live_staging_deploy_is_isolated_and_keeps_secrets_on_host() -> None:
 def test_release_workflow_uses_disposable_staging_and_immutable_evidence() -> None:
     workflow = (ROOT / ".github/workflows/release-readiness.yml").read_text()
 
-    assert workflow.count('- ".github/workflows/staging-deploy.yml"') == 2
+    assert workflow.count('- ".github/workflows/**"') == 2
     assert "Disposable staging smoke, rollback, and evidence" in workflow
     assert "scripts/staging-smoke-test.sh" in workflow
     assert "STAGING_SYNTHETIC_DATA: \"true\"" in workflow

--- a/tests/backend/test_workflow_security.py
+++ b/tests/backend/test_workflow_security.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.check_workflow_security import (  # noqa: E402
+    APPROVED_REMOTE_ACTIONS,
+    inspect_workflows,
+)
+
+
+def write_workflow(root: Path, content: str) -> None:
+    workflow_root = root / ".github" / "workflows"
+    workflow_root.mkdir(parents=True)
+    (workflow_root / "test.yml").write_text(content, encoding="utf-8")
+
+
+def valid_workflow(action: str = "actions/checkout") -> str:
+    approved = APPROVED_REMOTE_ACTIONS[action]
+    return f"""name: Test
+on: workflow_dispatch
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: {action}@{approved['sha']} # {approved['version']}
+"""
+
+
+def test_current_workflows_use_immutable_approved_actions_and_explicit_permissions() -> None:
+    result = inspect_workflows(ROOT)
+
+    assert result["status"] == "passed", result["errors"]
+    assert result["workflow_files"] > 0
+    assert result["action_references"] > 0
+
+
+def test_mutable_major_action_tag_fails_closed(tmp_path: Path) -> None:
+    write_workflow(
+        tmp_path,
+        valid_workflow().replace(
+            f"actions/checkout@{APPROVED_REMOTE_ACTIONS['actions/checkout']['sha']}",
+            "actions/checkout@v4",
+        ),
+    )
+
+    result = inspect_workflows(tmp_path)
+
+    assert result["status"] == "failed"
+    assert any("full 40-character commit SHA" in error for error in result["errors"])
+
+
+def test_missing_top_level_permissions_fails_closed(tmp_path: Path) -> None:
+    write_workflow(tmp_path, valid_workflow().replace("permissions:\n  contents: read\n", ""))
+
+    result = inspect_workflows(tmp_path)
+
+    assert result["status"] == "failed"
+    assert any("missing explicit top-level permissions" in error for error in result["errors"])
+
+
+def test_unapproved_remote_action_fails_closed(tmp_path: Path) -> None:
+    write_workflow(
+        tmp_path,
+        valid_workflow().replace(
+            "actions/checkout@",
+            "third-party/example@",
+        ),
+    )
+
+    result = inspect_workflows(tmp_path)
+
+    assert result["status"] == "failed"
+    assert any("not in the approved allowlist" in error for error in result["errors"])
+
+
+def test_unapproved_local_action_path_fails_closed(tmp_path: Path) -> None:
+    write_workflow(
+        tmp_path,
+        valid_workflow().replace(
+            f"actions/checkout@{APPROVED_REMOTE_ACTIONS['actions/checkout']['sha']} # v4",
+            "./scripts/build-action",
+        ),
+    )
+
+    result = inspect_workflows(tmp_path)
+
+    assert result["status"] == "failed"
+    assert any("must be under ./.github/actions/" in error for error in result["errors"])


### PR DESCRIPTION
Closes #381

## Summary

- pins all 52 remote GitHub Action references in 18 workflows to four audited immutable commit SHAs;
- adds an explicit read-only token permission baseline to CI;
- adds a fail-closed workflow-security checker with regression tests for mutable tags, missing top-level permissions, unapproved remote actions, and unapproved local paths;
- gates CI and Release Readiness on the checker;
- makes every workflow-file change trigger Release Readiness.

The remote commit tree `d3e5bf616f7750a4755be78ee0245a98b70ee249` exactly matches the fully validated local commit tree. The connector-generated commit SHA is `9c9bb461c9e46012931d903c658e45a90d5297a9`.

## Validation

- `python3 scripts/check_workflow_security.py` — passed: 18 workflows / 52 action references / 0 errors
- focused backend tests — 14 passed
- full backend suite — 675 passed, 1 existing Pydantic warning
- Ruff — passed
- frontend TypeScript lint — passed
- frontend unit/component tests — 41 files / 141 tests passed
- frontend production build — passed
- locked visual-design check — passed
- React Router RSC security boundary — passed
- all 18 workflow YAML files parsed successfully
- `git diff --check` — passed

Local Playwright browsers are not installed in this scratch environment. CI and Release Readiness install Chromium/WebKit and remain the required browser/mobile/accessibility evidence.

## Security and protected-boundary review

- no application behavior, visual design, database schema, business data, production data, secrets, DNS, certificates, backups, authentication, or infrastructure changed;
- existing workflow permissions, protected environments, reviewers, concurrency, exact-release checks, and no-bypass gates are preserved;
- existing write permissions remain only in workflows that already required them;
- no deployment is authorized by this PR.

## Risk

Low runtime risk; medium build-chain scope because all workflows are covered. Exact SHAs are the current official major-tag commits resolved from the upstream `actions/*` repositories on 2026-08-28.

## Rollback

Revert this commit. No data or migration rollback is required.