### PR TITLE
Build 234: enable fail-closed project safety and crew release

### DIFF
--- a/backend/app/api/v1/routes/projects.py
+++ b/backend/app/api/v1/routes/projects.py
@@ -21,7 +21,11 @@ from app.schemas.project_closeout import (
 )
 from app.schemas.project_launch import ProjectLaunchDashboard
 from app.schemas.project_readiness import ProjectReadinessResponse
-from app.schemas.project_safety_launch import ProjectSafetyLaunchRead
+from app.schemas.project_safety_launch import (
+    ProjectSafetyLaunchControls,
+    ProjectSafetyLaunchRead,
+    ProjectSafetyLaunchUpdate,
+)
 from app.schemas.project_start import ProjectStartChecklistRead, ProjectStartChecklistUpdate
 from app.services import project_folders, project_launch, project_readiness, projects
 
@@ -130,6 +134,31 @@ def initialize_project_safety_launch(
     db: DBSession,
 ) -> ProjectSafetyLaunchRead:
     return projects.initialize_project_safety_launch(db, project_id, user)
+
+
+@router.get(
+    "/{project_id}/safety-launch/controls",
+    response_model=ProjectSafetyLaunchControls,
+)
+def read_project_safety_launch_controls(
+    project_id: UUID,
+    user: CurrentUser,
+    db: DBSession,
+) -> ProjectSafetyLaunchControls:
+    return projects.get_project_safety_launch_controls(db, project_id, user)
+
+
+@router.patch(
+    "/{project_id}/safety-launch",
+    response_model=ProjectSafetyLaunchControls,
+)
+def update_project_safety_launch(
+    project_id: UUID,
+    payload: ProjectSafetyLaunchUpdate,
+    user: CurrentUser,
+    db: DBSession,
+) -> ProjectSafetyLaunchControls:
+    return projects.update_project_safety_launch(db, project_id, payload, user)
 
 
 @router.get("/{project_id}/closeout-checklist", response_model=ProjectCloseoutChecklistRead)

--- a/backend/app/schemas/project_safety_launch.py
+++ b/backend/app/schemas/project_safety_launch.py
@@ -1,17 +1,30 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+ProjectSafetyRequirementCode = Literal[
+    "project_safety_plan",
+    "emergency_action_card",
+    "field_hazard_assessment",
+    "toolbox_talk",
+    "safety_permit",
+    "orientation_verification",
+]
 
 
 class ProjectSafetyRecordRequirement(BaseModel):
-    code: str
+    code: ProjectSafetyRequirementCode
     label: str
     applicability_status: Literal["unconfirmed", "applicable", "not_applicable"]
     status: Literal["not_started", "in_progress", "blocked", "ready"]
     record_id: UUID | None
     evidence_document_ids: list[UUID]
+    not_applicable_basis: str | None = None
+    reviewed_by: str | None = None
+    reviewed_at: datetime | None = None
 
 
 class ProjectPortalAssignment(BaseModel):
@@ -26,6 +39,15 @@ class ProjectPortalAccessControl(BaseModel):
     assignments: list[ProjectPortalAssignment]
 
 
+class ProjectSafetyReviewEvent(BaseModel):
+    reviewed_by: str
+    reviewed_at: datetime
+    review_note: str
+    release_status: Literal["blocked", "at_risk", "ready"]
+    portal_status: Literal["not_started", "active", "suspended"]
+    active_assignment_count: int
+
+
 class ProjectSafetyLaunchRead(BaseModel):
     project_id: UUID
     job_number: str
@@ -36,3 +58,63 @@ class ProjectSafetyLaunchRead(BaseModel):
     portal_access: ProjectPortalAccessControl
     initialized_by: str
     initialized_at: datetime
+    last_reviewed_by: str | None = None
+    last_reviewed_at: datetime | None = None
+    last_review_note: str | None = None
+    review_history: list[ProjectSafetyReviewEvent] = Field(default_factory=list)
+
+
+class ProjectSafetyRecordRequirementUpdate(BaseModel):
+    code: ProjectSafetyRequirementCode
+    applicability_status: Literal["unconfirmed", "applicable", "not_applicable"]
+    status: Literal["not_started", "in_progress", "blocked", "ready"]
+    record_id: UUID | None = None
+    evidence_document_ids: list[UUID] = Field(default_factory=list)
+    not_applicable_basis: str | None = Field(default=None, max_length=2000)
+
+
+class ProjectPortalAccessUpdate(BaseModel):
+    status: Literal["not_started", "active", "suspended"]
+    assignments: list[ProjectPortalAssignment] = Field(default_factory=list)
+
+
+class ProjectSafetyLaunchUpdate(BaseModel):
+    release_status: Literal["blocked", "at_risk", "ready"]
+    record_requirements: list[ProjectSafetyRecordRequirementUpdate]
+    portal_access: ProjectPortalAccessUpdate
+    review_note: str = Field(min_length=10, max_length=2000)
+    release_confirmation: bool = False
+
+
+class ProjectSafetyEvidenceDocument(BaseModel):
+    id: UUID
+    title: str
+    category: str
+    status: str
+
+
+class ProjectSafetyRecordOption(BaseModel):
+    id: UUID
+    record_type: str
+    title: str
+    status: str
+    work_date: date
+
+
+class ProjectSafetyEmployeeOption(BaseModel):
+    id: UUID
+    display_name: str
+    portal_role: Literal["employee", "operator", "foreman"]
+
+
+class ProjectSafetyPostingBlocker(BaseModel):
+    code: str
+    message: str
+
+
+class ProjectSafetyLaunchControls(BaseModel):
+    launch: ProjectSafetyLaunchRead
+    evidence_documents: list[ProjectSafetyEvidenceDocument]
+    record_options: list[ProjectSafetyRecordOption]
+    active_employees: list[ProjectSafetyEmployeeOption]
+    posting_blockers: list[ProjectSafetyPostingBlocker]

--- a/backend/app/services/project_production_records.py
+++ b/backend/app/services/project_production_records.py
@@ -4,7 +4,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.core.errors import AppError
-from app.models.field_operations import FieldRecord
 from app.models.project import Project, ProjectStartChecklistItem
 from app.models.user import Employee
 from app.schemas.project_folder import ProjectFolderEntry
@@ -69,22 +68,7 @@ def posting_blockers(db: Session, project: Project) -> list[dict[str, str]]:
                     "message": "Safety release must be Ready before field production can post.",
                 }
             )
-        unresolved = []
-        for item in launch.record_requirements:
-            if item.applicability_status == "unconfirmed":
-                unresolved.append(item)
-                continue
-            if item.applicability_status != "applicable":
-                continue
-            record = db.get(FieldRecord, item.record_id) if item.record_id else None
-            if (
-                item.status != "ready"
-                or record is None
-                or record.project_id != project.id
-                or record.record_type != item.code
-                or record.status != "ready"
-            ):
-                unresolved.append(item)
+        unresolved = project_safety_launch.unresolved_requirements(db, project, launch)
         if unresolved:
             blockers.append(
                 {

--- a/backend/app/services/project_safety_launch.py
+++ b/backend/app/services/project_safety_launch.py
@@ -4,11 +4,21 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from pydantic import ValidationError
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
 
 from app.core.errors import AppError
+from app.models.document import Document
+from app.models.field_operations import FieldRecord
 from app.models.project import Project
+from app.models.user import Employee, UserAccount
 from app.schemas.project_folder import ProjectFolderEntry
-from app.schemas.project_safety_launch import ProjectSafetyLaunchRead
+from app.schemas.project_safety_launch import (
+    ProjectSafetyLaunchRead,
+    ProjectSafetyLaunchUpdate,
+    ProjectSafetyRecordRequirement,
+    ProjectSafetyReviewEvent,
+)
 
 
 SAFETY_FOLDER_RELATIVE_PATH = "13_Award_Handoff/Safety"
@@ -23,6 +33,15 @@ SAFETY_RECORD_REQUIREMENTS: tuple[tuple[str, str], ...] = (
     ("safety_permit", "Task permit or safety-control record, if applicable"),
     ("orientation_verification", "Crew orientation and qualification verification"),
 )
+SUPPORTED_RECORD_TYPES: dict[str, tuple[str, set[str]] | None] = {
+    "project_safety_plan": None,
+    "emergency_action_card": ("emergency_action_card", {"ready"}),
+    "field_hazard_assessment": ("daily_hazard_assessment", {"released"}),
+    "toolbox_talk": ("toolbox_talk", {"submitted", "ready", "completed", "closed"}),
+    "safety_permit": ("safety_permit", {"ready"}),
+    "orientation_verification": None,
+}
+VALID_EVIDENCE_DOCUMENT_STATUSES = {"registered", "active", "current"}
 
 
 def initialize(project: Project, *, actor: str) -> ProjectSafetyLaunchRead:
@@ -85,6 +104,160 @@ def initialize(project: Project, *, actor: str) -> ProjectSafetyLaunchRead:
     return launch
 
 
+def update(
+    db: Session,
+    project: Project,
+    payload: ProjectSafetyLaunchUpdate,
+    *,
+    actor: str,
+) -> ProjectSafetyLaunchRead:
+    launch = read(project)
+    if launch is None:
+        raise AppError("Project safety launch controls are not initialized.", status_code=404)
+    if project.status not in {"awarded", "construction"}:
+        raise AppError(
+            "Safety launch controls can only be updated for awarded or construction projects.",
+            status_code=409,
+        )
+
+    expected_codes = [code for code, _label in SAFETY_RECORD_REQUIREMENTS]
+    submitted_codes = [item.code for item in payload.record_requirements]
+    if len(submitted_codes) != len(set(submitted_codes)):
+        raise AppError("Safety launch requirements cannot contain duplicate control codes.", status_code=409)
+    if set(submitted_codes) != set(expected_codes) or len(submitted_codes) != len(expected_codes):
+        raise AppError("Every safety launch requirement must be supplied exactly once.", status_code=409)
+
+    assignment_ids = [item.employee_id for item in payload.portal_access.assignments]
+    if len(assignment_ids) != len(set(assignment_ids)):
+        raise AppError("Project portal assignments cannot contain duplicate employees.", status_code=409)
+    employees = {
+        item.id: item
+        for item in db.scalars(select(Employee).where(Employee.id.in_(assignment_ids))).all()
+    } if assignment_ids else {}
+    for assignment in payload.portal_access.assignments:
+        employee = employees.get(assignment.employee_id)
+        if employee is None or employee.status != "active":
+            raise AppError("Project portal assignments require active employee records.", status_code=409)
+        account = db.scalar(
+            select(UserAccount).where(func.lower(UserAccount.email) == employee.email.lower())
+        )
+        if account is None or not account.is_active:
+            raise AppError(
+                "Project portal assignments require an active portal account created through onboarding or employee activation.",
+                status_code=409,
+            )
+        if employee.portal_role not in {"employee", "operator", "foreman"}:
+            raise AppError("Management profiles cannot be assigned as project crew portal users.", status_code=409)
+        if assignment.portal_role != employee.portal_role:
+            raise AppError("A project portal assignment must use the employee's approved portal role.", status_code=409)
+    if payload.portal_access.status == "active" and not any(
+        item.status == "active" for item in payload.portal_access.assignments
+    ):
+        raise AppError("Active project portal access requires at least one active employee assignment.", status_code=409)
+    if payload.portal_access.status == "not_started" and any(
+        item.status == "active" for item in payload.portal_access.assignments
+    ):
+        raise AppError("Portal access cannot remain not started while employee assignments are active.", status_code=409)
+
+    labels = {code: label for code, label in SAFETY_RECORD_REQUIREMENTS}
+    now = datetime.now(UTC)
+    requirements: list[ProjectSafetyRecordRequirement] = []
+    for code in expected_codes:
+        item = next(candidate for candidate in payload.record_requirements if candidate.code == code)
+        basis = (item.not_applicable_basis or "").strip() or None
+        if len(item.evidence_document_ids) != len(set(item.evidence_document_ids)):
+            raise AppError(f"{labels[code]} contains duplicate evidence documents.", status_code=409)
+        if item.applicability_status == "unconfirmed":
+            if item.status != "not_started" or item.record_id or item.evidence_document_ids or basis:
+                raise AppError(
+                    f"{labels[code]} must remain empty and not started until applicability is confirmed.",
+                    status_code=409,
+                )
+        elif item.applicability_status == "not_applicable":
+            if item.status != "ready" or not basis or len(basis) < 10:
+                raise AppError(
+                    f"{labels[code]} requires a written not-applicable basis of at least 10 characters.",
+                    status_code=409,
+                )
+            if item.record_id or item.evidence_document_ids:
+                raise AppError(
+                    f"{labels[code]} cannot retain evidence links when marked not applicable.",
+                    status_code=409,
+                )
+        else:
+            if basis:
+                raise AppError(
+                    f"{labels[code]} cannot include a not-applicable basis when it is applicable.",
+                    status_code=409,
+                )
+            _require_valid_documents(db, project, item.evidence_document_ids, labels[code])
+            if item.record_id:
+                _require_valid_record(db, project, code, item.record_id, labels[code])
+            if item.status == "ready" and not item.evidence_document_ids:
+                raise AppError(
+                    f"{labels[code]} requires at least one current project document before it can be ready.",
+                    status_code=409,
+                )
+        requirements.append(
+            ProjectSafetyRecordRequirement(
+                code=code,
+                label=labels[code],
+                applicability_status=item.applicability_status,
+                status=item.status,
+                record_id=item.record_id,
+                evidence_document_ids=item.evidence_document_ids,
+                not_applicable_basis=basis,
+                reviewed_by=actor,
+                reviewed_at=now,
+            )
+        )
+
+    candidate = launch.model_copy(
+        update={
+            "release_status": payload.release_status,
+            "record_requirements": requirements,
+            "portal_access": launch.portal_access.model_copy(
+                update={
+                    "status": payload.portal_access.status,
+                    "assignments": payload.portal_access.assignments,
+                    "automatic_provisioning": False,
+                }
+            ),
+            "last_reviewed_by": actor,
+            "last_reviewed_at": now,
+            "last_review_note": payload.review_note.strip(),
+        }
+    )
+    if payload.release_status == "ready":
+        if not payload.release_confirmation:
+            raise AppError("An explicit human confirmation is required for a Ready safety release.", status_code=409)
+        unresolved = unresolved_requirements(db, project, candidate)
+        if unresolved:
+            raise AppError(
+                "Safety release cannot be Ready until every requirement has valid project evidence or a documented not-applicable basis.",
+                status_code=409,
+            )
+
+    history = [
+        *launch.review_history,
+        ProjectSafetyReviewEvent(
+            reviewed_by=actor,
+            reviewed_at=now,
+            review_note=payload.review_note.strip(),
+            release_status=payload.release_status,
+            portal_status=payload.portal_access.status,
+            active_assignment_count=sum(
+                1 for item in payload.portal_access.assignments if item.status == "active"
+            ),
+        ),
+    ][-100:]
+    candidate = candidate.model_copy(update={"review_history": history})
+    metadata = dict(project.metadata_json or {})
+    metadata["safety_launch"] = candidate.model_dump(mode="json")
+    project.metadata_json = metadata
+    return candidate
+
+
 def read(project: Project) -> ProjectSafetyLaunchRead | None:
     value = (project.metadata_json or {}).get("safety_launch")
     if value is None:
@@ -116,6 +289,90 @@ def require_portal_access(project: Project, employee_id: UUID) -> None:
             "Project portal access has not been assigned for this controlled job.",
             status_code=403,
         )
+
+
+def unresolved_requirements(
+    db: Session,
+    project: Project,
+    launch: ProjectSafetyLaunchRead,
+) -> list[ProjectSafetyRecordRequirement]:
+    return [item for item in launch.record_requirements if not requirement_resolved(db, project, item)]
+
+
+def requirement_resolved(
+    db: Session,
+    project: Project,
+    item: ProjectSafetyRecordRequirement,
+) -> bool:
+    if item.applicability_status == "unconfirmed":
+        return False
+    if item.applicability_status == "not_applicable":
+        return item.status == "ready" and len((item.not_applicable_basis or "").strip()) >= 10
+    if item.status != "ready" or not item.evidence_document_ids:
+        return False
+    if not _documents_are_valid(db, project, item.evidence_document_ids):
+        return False
+    if item.record_id and not _record_is_valid(db, project, item.code, item.record_id):
+        return False
+    return True
+
+
+def _require_valid_documents(
+    db: Session,
+    project: Project,
+    document_ids: list[UUID],
+    label: str,
+) -> None:
+    if not _documents_are_valid(db, project, document_ids):
+        raise AppError(
+            f"{label} evidence must use current, stored documents linked to this exact project.",
+            status_code=409,
+        )
+
+
+def _documents_are_valid(db: Session, project: Project, document_ids: list[UUID]) -> bool:
+    if not document_ids:
+        return True
+    documents = list(db.scalars(select(Document).where(Document.id.in_(document_ids))).all())
+    return len(documents) == len(set(document_ids)) and all(
+        item.project_id == project.id
+        and item.status in VALID_EVIDENCE_DOCUMENT_STATUSES
+        and bool((item.storage_uri or "").strip())
+        for item in documents
+    )
+
+
+def _require_valid_record(
+    db: Session,
+    project: Project,
+    requirement_code: str,
+    record_id: UUID,
+    label: str,
+) -> None:
+    if not _record_is_valid(db, project, requirement_code, record_id):
+        raise AppError(
+            f"{label} references an unsupported, incomplete, or wrong-project operational record.",
+            status_code=409,
+        )
+
+
+def _record_is_valid(
+    db: Session,
+    project: Project,
+    requirement_code: str,
+    record_id: UUID,
+) -> bool:
+    supported = SUPPORTED_RECORD_TYPES.get(requirement_code)
+    if supported is None:
+        return False
+    expected_type, accepted_statuses = supported
+    record = db.get(FieldRecord, record_id)
+    return bool(
+        record
+        and record.project_id == project.id
+        and record.record_type == expected_type
+        and record.status in accepted_statuses
+    )
 
 
 def _read(value: object) -> ProjectSafetyLaunchRead:

--- a/backend/app/services/projects.py
+++ b/backend/app/services/projects.py
@@ -13,6 +13,7 @@ from app.core.errors import AppError
 from app.core.workflow_values import workflow_enum
 from app.models.bid import Bid
 from app.models.document import Document, Drawing
+from app.models.field_operations import FieldRecord
 from app.models.project import (
     Project,
     ProjectCloseoutChecklistItem,
@@ -25,6 +26,7 @@ from app.schemas.project_closeout import (
     ProjectCloseoutChecklistUpdate,
 )
 from app.models.rfq import RFQPackage
+from app.models.user import Employee, UserAccount
 from app.schemas.project import (
     ProjectCreate,
     ProjectDashboard,
@@ -38,8 +40,16 @@ from app.schemas.project_start import (
     ProjectStartChecklistItemRead,
     ProjectStartChecklistRead,
 )
-from app.schemas.project_safety_launch import ProjectSafetyLaunchRead
-from app.services import project_folders, project_safety_launch
+from app.schemas.project_safety_launch import (
+    ProjectSafetyEmployeeOption,
+    ProjectSafetyEvidenceDocument,
+    ProjectSafetyLaunchControls,
+    ProjectSafetyLaunchRead,
+    ProjectSafetyLaunchUpdate,
+    ProjectSafetyPostingBlocker,
+    ProjectSafetyRecordOption,
+)
+from app.services import project_folders, project_production_records, project_safety_launch
 from app.services.auth import AuthenticatedUser
 
 JOB_NUMBER_PREFIX = "IH"
@@ -498,6 +508,124 @@ def initialize_project_safety_launch(
     launch = project_safety_launch.initialize(project, actor=user.email)
     db.commit()
     return launch
+
+
+def get_project_safety_launch_controls(
+    db: Session,
+    project_id: UUID,
+    user: AuthenticatedUser,
+) -> ProjectSafetyLaunchControls:
+    if user.role not in MANAGEMENT_PROJECT_ROLES:
+        raise AppError(
+            "Management access is required to manage project safety launch controls.",
+            status_code=403,
+        )
+    project = _load_project(db, project_id)
+    launch = project_safety_launch.read(project)
+    if launch is None:
+        raise AppError("Project safety launch controls are not initialized.", status_code=404)
+
+    documents = [
+        item
+        for item in db.scalars(
+            select(Document)
+            .where(Document.project_id == project.id)
+            .order_by(Document.title, Document.created_at)
+        ).all()
+        if item.status in project_safety_launch.VALID_EVIDENCE_DOCUMENT_STATUSES
+        and bool((item.storage_uri or "").strip())
+    ]
+    supported_types = {
+        value[0]
+        for value in project_safety_launch.SUPPORTED_RECORD_TYPES.values()
+        if value is not None
+    }
+    records = [
+        item
+        for item in db.scalars(
+            select(FieldRecord)
+            .where(
+                FieldRecord.project_id == project.id,
+                FieldRecord.record_type.in_(supported_types),
+            )
+            .order_by(FieldRecord.work_date.desc(), FieldRecord.created_at.desc())
+        ).all()
+        if any(
+            supported is not None
+            and item.record_type == supported[0]
+            and item.status in supported[1]
+            for supported in project_safety_launch.SUPPORTED_RECORD_TYPES.values()
+        )
+    ]
+    active_account_emails = {
+        email.lower()
+        for email in db.scalars(
+            select(UserAccount.email).where(UserAccount.is_active.is_(True))
+        ).all()
+    }
+    employees = [
+        item
+        for item in db.scalars(
+            select(Employee)
+            .where(
+                Employee.status == "active",
+                Employee.portal_role.in_({"employee", "operator", "foreman"}),
+            )
+            .order_by(Employee.last_name, Employee.first_name)
+        ).all()
+        if item.email.lower() in active_account_emails
+    ]
+    return ProjectSafetyLaunchControls(
+        launch=launch,
+        evidence_documents=[
+            ProjectSafetyEvidenceDocument(
+                id=item.id,
+                title=item.title,
+                category=item.category,
+                status=item.status,
+            )
+            for item in documents
+        ],
+        record_options=[
+            ProjectSafetyRecordOption(
+                id=item.id,
+                record_type=item.record_type,
+                title=item.title,
+                status=item.status,
+                work_date=item.work_date,
+            )
+            for item in records
+        ],
+        active_employees=[
+            ProjectSafetyEmployeeOption(
+                id=item.id,
+                display_name=f"{item.first_name} {item.last_name}".strip(),
+                portal_role=item.portal_role,
+            )
+            for item in employees
+        ],
+        posting_blockers=[
+            ProjectSafetyPostingBlocker.model_validate(item)
+            for item in project_production_records.posting_blockers(db, project)
+        ],
+    )
+
+
+def update_project_safety_launch(
+    db: Session,
+    project_id: UUID,
+    payload: ProjectSafetyLaunchUpdate,
+    user: AuthenticatedUser,
+) -> ProjectSafetyLaunchControls:
+    if user.role not in MANAGEMENT_PROJECT_ROLES:
+        raise AppError(
+            "Management access is required to update project safety launch controls.",
+            status_code=403,
+        )
+    project = _load_project(db, project_id, for_update=True)
+    project_safety_launch.update(db, project, payload, actor=user.email)
+    db.commit()
+    return get_project_safety_launch_controls(db, project_id, user)
 
 
 def update_project_start_checklist_item(

--- a/frontend/e2e/project-safety-release.spec.ts
+++ b/frontend/e2e/project-safety-release.spec.ts
@@ -1,0 +1,245 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, Page, test } from "@playwright/test";
+
+const projectId = "23400000-0000-4000-8000-000000000001";
+const documentId = "23400000-0000-4000-8000-000000000002";
+const employeeId = "23400000-0000-4000-8000-000000000003";
+const project = {
+  id: projectId,
+  name: "Controlled Crew Launch",
+  client_owner: "Verified Owner",
+  municipality: "Surrey",
+  project_number: "IH2026234",
+  tender_number: null,
+  tender_source: null,
+  tender_closing_date: null,
+  bid_due_date: null,
+  estimated_construction_start: null,
+  estimated_construction_finish: null,
+  project_address: "100 Verified Project Road",
+  latitude: null,
+  longitude: null,
+  contract_value: null,
+  status: "awarded",
+  notes: null,
+  metadata: {},
+  workspace_root: "IH2026234_ControlledCrewLaunch",
+  workspace_provisioned_at: "2026-08-28T15:00:00Z",
+  deleted_at: null,
+  supplier_ids: [],
+  created_at: "2026-08-28T15:00:00Z",
+  updated_at: "2026-08-28T15:00:00Z",
+};
+const requirementDefinitions = [
+  ["project_safety_plan", "Project-specific safety plan"],
+  ["emergency_action_card", "Emergency action card"],
+  ["field_hazard_assessment", "Field-level hazard assessment"],
+  ["toolbox_talk", "Crew toolbox talk"],
+  ["safety_permit", "Task permit or safety-control record, if applicable"],
+  ["orientation_verification", "Crew orientation and qualification verification"],
+] as const;
+
+function safetyControls() {
+  return {
+    launch: {
+      project_id: projectId,
+      job_number: project.project_number,
+      release_status: "blocked",
+      folder_path: `${project.workspace_root}/13_Award_Handoff/Safety`,
+      folder_status: "prepared",
+      record_requirements: requirementDefinitions.map(([code, label]) => ({
+        code,
+        label,
+        applicability_status: "applicable",
+        status: "ready",
+        record_id: null,
+        evidence_document_ids: [documentId],
+        not_applicable_basis: null,
+        reviewed_by: "release-gate@ironhousecontracting.com",
+        reviewed_at: "2026-08-28T15:30:00Z",
+      })),
+      portal_access: { status: "not_started", automatic_provisioning: false, assignments: [] },
+      initialized_by: "release-gate@ironhousecontracting.com",
+      initialized_at: "2026-08-28T15:00:00Z",
+      last_reviewed_by: null,
+      last_reviewed_at: null,
+      last_review_note: null,
+      review_history: [],
+    },
+    evidence_documents: [{ id: documentId, title: "Current controlled safety package", category: "other", status: "current" }],
+    record_options: [],
+    active_employees: [{ id: employeeId, display_name: "Sam Foreperson", portal_role: "foreman" }],
+    posting_blockers: [
+      { code: "safety_release", message: "Safety release must be Ready before field production can post." },
+      { code: "portal_access", message: "Project portal access and at least one worker assignment must be active before field production can post." },
+      { code: "mobilization", message: "The project-start checklist must be complete before field production can post." },
+    ],
+  };
+}
+
+async function mockApi(page: Page) {
+  let authenticated = false;
+  let controls = safetyControls();
+  let savedPayload: Record<string, unknown> | null = null;
+  await page.route("**/api/v1/**", async (route) => {
+    const request = route.request();
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith("/auth/me")) {
+      await route.fulfill(authenticated ? {
+        status: 200,
+        json: {
+          authentication: "authenticated",
+          user: {
+            id: "23400000-0000-4000-8000-000000000004",
+            email: "release-gate@ironhousecontracting.com",
+            display_name: "Release Gate Admin",
+            role: "admin",
+            is_active: true,
+            password_reset_required: false,
+            last_login_at: null,
+            created_at: "2026-08-28T15:00:00Z",
+            updated_at: "2026-08-28T15:00:00Z",
+          },
+        },
+      } : { status: 401, json: { detail: "Sign in is required." } });
+      return;
+    }
+    if (path.endsWith("/auth/login") && request.method() === "POST") {
+      authenticated = true;
+      await route.fulfill({
+        status: 200,
+        json: {
+          authentication: "authenticated",
+          user: {
+            id: "23400000-0000-4000-8000-000000000004",
+            email: "release-gate@ironhousecontracting.com",
+            display_name: "Release Gate Admin",
+            role: "admin",
+            is_active: true,
+            password_reset_required: false,
+          },
+        },
+      });
+      return;
+    }
+    if (path.endsWith("/auth/me/permissions")) {
+      await route.fulfill({ status: 200, json: { role: "admin", modules: { projects: ["read", "write"] } } });
+      return;
+    }
+    if (path === "/api/v1/projects") {
+      await route.fulfill({ status: 200, json: { items: [project], total: 1 } });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/dashboard`)) {
+      await route.fulfill({ status: 200, json: { project_id: projectId, rfq_count: 0, supplier_count: 0, document_count: 1, drawing_count: 0, bid_status: "draft", readiness_percentage: 60 } });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/workspace`)) {
+      await route.fulfill({ status: 200, json: { project_id: projectId, job_number: project.project_number, root_folder: project.workspace_root, entries: [], project_index: "# Project", provisioned_at: project.workspace_provisioned_at } });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/start-checklist`)) {
+      await route.fulfill({ status: 200, json: { project_id: projectId, status: "not_ready", completed_count: 0, total_count: 1, items: [{ code: "safety_mobilization", category: "Safety", label: "Project-specific safety controls are complete.", sort_order: 1, completed: false, changed_by: null, changed_at: null }] } });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/launch-dashboard`)) {
+      await route.fulfill({
+        status: 200,
+        json: {
+          project_id: projectId, job_number: project.project_number, mobilization_status: "not_ready",
+          checklist_completed_count: 0, checklist_total_count: 1,
+          next_incomplete_control: { code: "safety_mobilization", category: "Safety", label: "Project-specific safety controls are complete." },
+          estimate_workspace_count: 0, priced_estimate_available: false, baseline_budget_total: 0, budget_entry_count: 0,
+          po_request_count: 0, pending_po_request_count: 0, safety_record_counts: {}, safety_release_status: controls.launch.release_status,
+          safety_requirement_count: 6, safety_folder_status: "prepared", portal_access_status: controls.launch.portal_access.status,
+          portal_assignment_count: controls.launch.portal_access.assignments.length, production_posting_status: "blocked",
+          production_blockers: controls.posting_blockers.map((item) => item.code), daily_sheet_count: 0, production_post_count: 0,
+          latest_daily_sheet_status: "not_started", field_production_folder_status: "not_initialized", document_count: 1,
+          award_baseline_source: null, award_pricing_subtotal: 0, award_cost_budget_status: "not_initialized",
+          uncoded_award_line_count: 0, procurement_requirement_count: 0, procurement_plan_status: "not_initialized",
+        },
+      });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/safety-launch/controls`)) {
+      await route.fulfill({ status: 200, json: controls });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/safety-launch`) && request.method() === "PATCH") {
+      savedPayload = request.postDataJSON();
+      controls = {
+        ...controls,
+        launch: {
+          ...controls.launch,
+          release_status: "ready",
+          portal_access: {
+            status: "active",
+            automatic_provisioning: false,
+            assignments: [{ employee_id: employeeId, portal_role: "foreman", status: "active" }],
+          },
+          last_reviewed_by: "release-gate@ironhousecontracting.com",
+          last_reviewed_at: "2026-08-28T16:00:00Z",
+          last_review_note: "Reviewed current evidence and exact crew assignment.",
+        },
+        posting_blockers: [{ code: "mobilization", message: "The project-start checklist must be complete before field production can post." }],
+      };
+      await route.fulfill({ status: 200, json: controls });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}`)) {
+      await route.fulfill({ status: 200, json: project });
+      return;
+    }
+    if (path.endsWith(`/projects/${projectId}/closeout-checklist`)) {
+      await route.fulfill({ status: 404, json: { detail: "Not initialized" } });
+      return;
+    }
+    await route.fulfill({ status: 404, json: { detail: "Not found" } });
+  });
+  return () => savedPayload;
+}
+
+test("management safety and crew release stays explicit, responsive, and accessible", async ({ page }) => {
+  const savedPayload = await mockApi(page);
+  await page.goto("/");
+  await page.getByLabel("Email").fill("release-gate@ironhousecontracting.com");
+  await page.getByLabel("Password").fill("Local-release-gate-only");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.goto(`/projects/${projectId}`);
+
+  const release = page.getByRole("region", { name: "Project safety and crew release" });
+  await expect(release).toBeVisible();
+  await expect(release.getByText("Field posting remains blocked")).toBeVisible();
+  const save = release.getByRole("button", { name: "Save controlled release" });
+  await expect(save).toBeDisabled();
+
+  await release.getByRole("checkbox", { name: /Sam Foreperson/ }).check();
+  await release.getByLabel("Safety release status").selectOption("ready");
+  await release.getByLabel("Safety release review note").fill("Reviewed current evidence and exact crew assignment.");
+  await expect(save).toBeDisabled();
+  await release.getByRole("checkbox", { name: /I confirm every requirement/ }).check();
+  await expect(save).toBeEnabled();
+  await save.click();
+
+  await expect(page.getByText(/Last reviewed by release-gate@ironhousecontracting.com/)).toBeVisible();
+  expect(savedPayload()).toMatchObject({
+    release_status: "ready",
+    release_confirmation: true,
+    portal_access: {
+      status: "active",
+      assignments: [{ employee_id: employeeId, portal_role: "foreman", status: "active" }],
+    },
+  });
+  const overflow = await page.evaluate(() => ({
+    width: document.documentElement.scrollWidth,
+    viewport: document.documentElement.clientWidth,
+  }));
+  expect(overflow.width).toBe(overflow.viewport);
+  const accessibility = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .analyze();
+  expect(
+    accessibility.violations.filter(({ impact }) => impact === "critical" || impact === "serious"),
+    JSON.stringify(accessibility.violations, null, 2),
+  ).toEqual([]);
+});

--- a/frontend/e2e/project-safety-release.spec.ts
+++ b/frontend/e2e/project-safety-release.spec.ts
@@ -200,6 +200,7 @@ async function mockApi(page: Page) {
 }
 
 test("management safety and crew release stays explicit, responsive, and accessible", async ({ page }) => {
+  test.slow();
   const savedPayload = await mockApi(page);
   await page.goto("/");
   await page.getByLabel("Email").fill("release-gate@ironhousecontracting.com");

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -164,6 +164,95 @@ export type ProjectLaunchDashboard = {
   procurement_plan_status: string;
 };
 
+export type ProjectSafetyRequirementCode =
+  | "project_safety_plan"
+  | "emergency_action_card"
+  | "field_hazard_assessment"
+  | "toolbox_talk"
+  | "safety_permit"
+  | "orientation_verification";
+
+export type ProjectSafetyRequirement = {
+  code: ProjectSafetyRequirementCode;
+  label: string;
+  applicability_status: "unconfirmed" | "applicable" | "not_applicable";
+  status: "not_started" | "in_progress" | "blocked" | "ready";
+  record_id: string | null;
+  evidence_document_ids: string[];
+  not_applicable_basis: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+};
+
+export type ProjectPortalAssignment = {
+  employee_id: string;
+  portal_role: "employee" | "operator" | "foreman";
+  status: "active" | "revoked";
+};
+
+export type ProjectSafetyLaunch = {
+  project_id: string;
+  job_number: string;
+  release_status: "blocked" | "at_risk" | "ready";
+  folder_path: string;
+  folder_status: "prepared";
+  record_requirements: ProjectSafetyRequirement[];
+  portal_access: {
+    status: "not_started" | "active" | "suspended";
+    automatic_provisioning: false;
+    assignments: ProjectPortalAssignment[];
+  };
+  initialized_by: string;
+  initialized_at: string;
+  last_reviewed_by: string | null;
+  last_reviewed_at: string | null;
+  last_review_note: string | null;
+  review_history: Array<{
+    reviewed_by: string;
+    reviewed_at: string;
+    review_note: string;
+    release_status: "blocked" | "at_risk" | "ready";
+    portal_status: "not_started" | "active" | "suspended";
+    active_assignment_count: number;
+  }>;
+};
+
+export type ProjectSafetyLaunchControls = {
+  launch: ProjectSafetyLaunch;
+  evidence_documents: Array<{ id: string; title: string; category: string; status: string }>;
+  record_options: Array<{
+    id: string;
+    record_type: string;
+    title: string;
+    status: string;
+    work_date: string;
+  }>;
+  active_employees: Array<{
+    id: string;
+    display_name: string;
+    portal_role: "employee" | "operator" | "foreman";
+  }>;
+  posting_blockers: Array<{ code: string; message: string }>;
+};
+
+export type ProjectSafetyLaunchUpdate = {
+  release_status: "blocked" | "at_risk" | "ready";
+  record_requirements: Array<{
+    code: ProjectSafetyRequirementCode;
+    applicability_status: "unconfirmed" | "applicable" | "not_applicable";
+    status: "not_started" | "in_progress" | "blocked" | "ready";
+    record_id: string | null;
+    evidence_document_ids: string[];
+    not_applicable_basis: string | null;
+  }>;
+  portal_access: {
+    status: "not_started" | "active" | "suspended";
+    assignments: ProjectPortalAssignment[];
+  };
+  review_note: string;
+  release_confirmation: boolean;
+};
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
@@ -257,5 +346,12 @@ export const projectsApi = {
     request<ProjectCloseoutChecklist>(`/projects/${id}/closeout-checklist/${encodeURIComponent(code)}`, {
       method: "PATCH",
       body: JSON.stringify({ completed, evidence: evidence || null }),
+    }),
+  safetyLaunchControls: (id: string) =>
+    requestOptional<ProjectSafetyLaunchControls>(`/projects/${id}/safety-launch/controls`),
+  updateSafetyLaunch: (id: string, payload: ProjectSafetyLaunchUpdate) =>
+    request<ProjectSafetyLaunchControls>(`/projects/${id}/safety-launch`, {
+      method: "PATCH",
+      body: JSON.stringify(payload),
     }),
 };

--- a/frontend/src/pages/ProjectWorkspacePage.test.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.test.tsx
@@ -9,6 +9,7 @@ import {
   ProjectCloseoutChecklist,
   ProjectDashboard,
   ProjectLaunchDashboard,
+  ProjectSafetyLaunchControls,
   ProjectStartChecklist,
 } from "../api/projects";
 import { ProjectInvoicePackageReadiness } from "../api/finance";
@@ -197,6 +198,65 @@ const awardedLaunchDashboard: ProjectLaunchDashboard = {
   uncoded_award_line_count: 4,
   procurement_requirement_count: 3,
   procurement_plan_status: "draft",
+};
+
+const safetyRequirementDefinitions = [
+  ["project_safety_plan", "Project-specific safety plan"],
+  ["emergency_action_card", "Emergency action card"],
+  ["field_hazard_assessment", "Field-level hazard assessment"],
+  ["toolbox_talk", "Crew toolbox talk"],
+  ["safety_permit", "Task permit or safety-control record, if applicable"],
+  ["orientation_verification", "Crew orientation and qualification verification"],
+] as const;
+
+const safetyLaunchControls: ProjectSafetyLaunchControls = {
+  launch: {
+    project_id: awardedProject.id,
+    job_number: awardedProject.project_number ?? "IH-2026-014",
+    release_status: "blocked",
+    folder_path: `${awardedWorkspace.root_folder}/13_Award_Handoff/Safety`,
+    folder_status: "prepared",
+    record_requirements: safetyRequirementDefinitions.map(([code, itemLabel]) => ({
+      code,
+      label: itemLabel,
+      applicability_status: "unconfirmed",
+      status: "not_started",
+      record_id: null,
+      evidence_document_ids: [],
+      not_applicable_basis: null,
+      reviewed_by: null,
+      reviewed_at: null,
+    })),
+    portal_access: {
+      status: "not_started",
+      automatic_provisioning: false,
+      assignments: [],
+    },
+    initialized_by: "test-admin@ironhousecontracting.com",
+    initialized_at: "2026-08-28T15:00:00Z",
+    last_reviewed_by: null,
+    last_reviewed_at: null,
+    last_review_note: null,
+    review_history: [],
+  },
+  evidence_documents: [{
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    title: "Current project safety package",
+    category: "other",
+    status: "current",
+  }],
+  record_options: [],
+  active_employees: [{
+    id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    display_name: "Sam Foreperson",
+    portal_role: "foreman",
+  }],
+  posting_blockers: [
+    { code: "safety_release", message: "Safety release must be Ready before field production can post." },
+    { code: "safety_records", message: "Applicable safety records and their evidence must be resolved before field production can post." },
+    { code: "portal_access", message: "Project portal access and at least one worker assignment must be active before field production can post." },
+    { code: "mobilization", message: "The project-start checklist must be complete before field production can post." },
+  ],
 };
 
 let releaseChecklistUpdate: (() => void) | null = null;
@@ -479,6 +539,67 @@ describe("ProjectWorkspacePage", () => {
         .getAllByRole("checkbox")
         .every((checkbox) => (checkbox as HTMLInputElement).checked),
     ).toBe(true);
+  });
+
+  it("requires project evidence, exact crew selection, and explicit confirmation for safety release", async () => {
+    const fetchMock = mockProjectApi(
+      awardedProject,
+      awardedWorkspace,
+      awardedStartChecklist,
+      false,
+      awardedLaunchDashboard,
+      undefined,
+      safetyLaunchControls,
+    );
+    const user = userEvent.setup();
+    renderWorkspace(`/projects/${awardedProject.id}`);
+
+    const release = await screen.findByRole("region", { name: "Project safety and crew release" });
+    const save = within(release).getByRole("button", { name: "Save controlled release" });
+    expect(save).toBeDisabled();
+    expect(release).toHaveTextContent("IHOS does not infer applicability");
+    expect(release).toHaveTextContent("Field posting remains blocked");
+
+    for (const [, itemLabel] of safetyRequirementDefinitions) {
+      await user.selectOptions(within(release).getByLabelText(`${itemLabel} applicability`), "applicable");
+      await user.selectOptions(within(release).getByLabelText(`${itemLabel} status`), "ready");
+    }
+    for (const checkbox of within(release).getAllByRole("checkbox", { name: /Current project safety package/ })) {
+      await user.click(checkbox);
+    }
+    await user.click(within(release).getByRole("checkbox", { name: /Sam Foreperson/ }));
+    await user.selectOptions(within(release).getByLabelText("Safety release status"), "ready");
+    await user.type(
+      within(release).getByLabelText("Safety release review note"),
+      "Reviewed current evidence and exact crew access.",
+    );
+    expect(save).toBeDisabled();
+    await user.click(within(release).getByRole("checkbox", { name: /I confirm every requirement/ }));
+    expect(save).toBeEnabled();
+    await user.click(save);
+
+    await waitFor(() => {
+      const updateCall = fetchMock.mock.calls.find(
+        ([url, options]) => url.toString().endsWith(`/projects/${awardedProject.id}/safety-launch`) && options?.method === "PATCH",
+      );
+      expect(updateCall).toBeDefined();
+      const payload = JSON.parse(String(updateCall?.[1]?.body));
+      expect(payload.release_status).toBe("ready");
+      expect(payload.release_confirmation).toBe(true);
+      expect(payload.record_requirements).toHaveLength(6);
+      expect(payload.record_requirements.every((item: { evidence_document_ids: string[] }) => (
+        item.evidence_document_ids[0] === safetyLaunchControls.evidence_documents[0].id
+      ))).toBe(true);
+      expect(payload.portal_access).toEqual({
+        status: "active",
+        assignments: [{
+          employee_id: safetyLaunchControls.active_employees[0].id,
+          portal_role: "foreman",
+          status: "active",
+        }],
+      });
+    });
+    expect(await screen.findByText(/Last reviewed by test-admin/)).toBeInTheDocument();
   });
 
   it("serializes checklist updates so an older response cannot replace newer state", async () => {
@@ -767,6 +888,7 @@ function mockProjectApi(
   delayChecklistUpdates = false,
   launchDashboard: ProjectLaunchDashboard = awardedLaunchDashboard,
   closeout?: ProjectCloseoutChecklist,
+  safetyControls?: ProjectSafetyLaunchControls,
 ) {
   let currentStartChecklist = startChecklist;
   let currentCloseoutChecklist = closeout;
@@ -811,6 +933,40 @@ function mockProjectApi(
           ? currentStartChecklist.items.find((item) => !item.completed) ?? null
           : launchDashboard.next_incomplete_control,
       });
+    }
+
+    if (url.endsWith(`/projects/${currentProject.id}/safety-launch/controls`) && safetyControls) {
+      return jsonResponse(safetyControls);
+    }
+
+    if (url.endsWith(`/projects/${currentProject.id}/safety-launch`) && options?.method === "PATCH" && safetyControls) {
+      const payload = JSON.parse(String(options.body));
+      safetyControls = {
+        ...safetyControls,
+        launch: {
+          ...safetyControls.launch,
+          release_status: payload.release_status,
+          record_requirements: safetyControls.launch.record_requirements.map((item) => ({
+            ...item,
+            ...payload.record_requirements.find((candidate: { code: string }) => candidate.code === item.code),
+            reviewed_by: "test-admin@ironhousecontracting.com",
+            reviewed_at: "2026-08-28T16:00:00Z",
+          })),
+          portal_access: {
+            status: payload.portal_access.status,
+            automatic_provisioning: false,
+            assignments: payload.portal_access.assignments,
+          },
+          last_reviewed_by: "test-admin@ironhousecontracting.com",
+          last_reviewed_at: "2026-08-28T16:00:00Z",
+          last_review_note: payload.review_note,
+        },
+        posting_blockers: [{
+          code: "mobilization",
+          message: "The project-start checklist must be complete before field production can post.",
+        }],
+      };
+      return jsonResponse(safetyControls);
     }
 
     const closeoutItemPath = `/projects/${currentProject.id}/closeout-checklist/`;

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -9,6 +9,8 @@ import {
   ProjectCreatePayload,
   ProjectDashboard,
   ProjectLaunchDashboard,
+  ProjectSafetyLaunchControls,
+  ProjectSafetyLaunchUpdate,
   ProjectStartChecklist,
   ProjectStatus,
   projectStatuses,
@@ -66,6 +68,7 @@ export function ProjectWorkspacePage() {
   const [dashboard, setDashboard] = useState<ProjectDashboard | null>(null);
   const [workspace, setWorkspace] = useState<AwardedProjectWorkspace | null>(null);
   const [launchDashboard, setLaunchDashboard] = useState<ProjectLaunchDashboard | null>(null);
+  const [safetyLaunchControls, setSafetyLaunchControls] = useState<ProjectSafetyLaunchControls | null>(null);
   const [startChecklist, setStartChecklist] = useState<ProjectStartChecklist | null>(null);
   const [closeoutChecklist, setCloseoutChecklist] = useState<ProjectCloseoutChecklist | null>(null);
   const [invoicePackageReadiness, setInvoicePackageReadiness] = useState<ProjectInvoicePackageReadiness | null>(null);
@@ -73,6 +76,7 @@ export function ProjectWorkspacePage() {
   const [savingChecklistCode, setSavingChecklistCode] = useState<string | null>(null);
   const [savingCloseoutCode, setSavingCloseoutCode] = useState<string | null>(null);
   const [initializingCloseout, setInitializingCloseout] = useState(false);
+  const [savingSafetyLaunch, setSavingSafetyLaunch] = useState(false);
   const [dashboardByProjectId, setDashboardByProjectId] = useState<Record<string, ProjectDashboard>>({});
   const [statusFilter, setStatusFilter] = useState("");
   const [searchFilter, setSearchFilter] = useState("");
@@ -103,6 +107,7 @@ export function ProjectWorkspacePage() {
         setDashboard(summary);
         setWorkspace(null);
         setLaunchDashboard(null);
+        setSafetyLaunchControls(null);
         setStartChecklist(null);
         setCloseoutChecklist(null);
         setInvoicePackageReadiness(null);
@@ -110,12 +115,16 @@ export function ProjectWorkspacePage() {
         const closeoutEligible = Boolean(
           detail.project_number && ["awarded", "construction", "completed"].includes(detail.status),
         );
-        const [workspaceResult, checklistResult, launchResult, closeoutResult, invoicePackageResult] = await Promise.allSettled([
+        const safetyEligible = Boolean(
+          isManagement && detail.workspace_root && ["awarded", "construction"].includes(detail.status),
+        );
+        const [workspaceResult, checklistResult, launchResult, safetyResult, closeoutResult, invoicePackageResult] = await Promise.allSettled([
           detail.workspace_root ? projectsApi.workspace(projectId) : Promise.resolve(null),
           detail.workspace_root ? projectsApi.startChecklist(projectId) : Promise.resolve(null),
           detail.workspace_root && detail.status === "awarded"
             ? projectsApi.launchDashboard(projectId)
             : Promise.resolve(null),
+          safetyEligible ? projectsApi.safetyLaunchControls(projectId) : Promise.resolve(null),
           closeoutEligible ? projectsApi.closeoutChecklist(projectId) : Promise.resolve(null),
           isManagement && detail.status === "completed"
             ? financeApi.getProjectInvoicePackageReadiness(projectId)
@@ -124,6 +133,7 @@ export function ProjectWorkspacePage() {
         setWorkspace(workspaceResult.status === "fulfilled" ? workspaceResult.value : null);
         setStartChecklist(checklistResult.status === "fulfilled" ? checklistResult.value : null);
         setLaunchDashboard(launchResult.status === "fulfilled" ? launchResult.value : null);
+        setSafetyLaunchControls(safetyResult.status === "fulfilled" ? safetyResult.value : null);
         setCloseoutChecklist(closeoutResult.status === "fulfilled" ? closeoutResult.value : null);
         setInvoicePackageReadiness(invoicePackageResult.status === "fulfilled" ? invoicePackageResult.value : null);
 
@@ -133,6 +143,7 @@ export function ProjectWorkspacePage() {
           detail.workspace_root && detail.status === "awarded" && launchResult.status === "rejected"
             ? "launch dashboard"
             : null,
+          safetyEligible && safetyResult.status === "rejected" ? "safety and crew release controls" : null,
           closeoutEligible && closeoutResult.status === "rejected" ? "closeout checklist" : null,
           isManagement && detail.status === "completed" && invoicePackageResult.status === "rejected"
             ? "draft invoice package readiness"
@@ -148,6 +159,7 @@ export function ProjectWorkspacePage() {
         setDashboard(null);
         setWorkspace(null);
         setLaunchDashboard(null);
+        setSafetyLaunchControls(null);
         setStartChecklist(null);
         setCloseoutChecklist(null);
         setInvoicePackageReadiness(null);
@@ -310,6 +322,29 @@ export function ProjectWorkspacePage() {
     }
   }
 
+  async function updateSafetyLaunch(payload: ProjectSafetyLaunchUpdate) {
+    if (!selectedProject || !isManagement || savingSafetyLaunch) return;
+    setSavingSafetyLaunch(true);
+    setError(null);
+    try {
+      const controls = await projectsApi.updateSafetyLaunch(selectedProject.id, payload);
+      setSafetyLaunchControls(controls);
+      setLaunchDashboard((current) => current ? {
+        ...current,
+        safety_release_status: controls.launch.release_status,
+        safety_requirement_count: controls.launch.record_requirements.length,
+        portal_access_status: controls.launch.portal_access.status,
+        portal_assignment_count: controls.launch.portal_access.assignments.filter((item) => item.status === "active").length,
+        production_posting_status: controls.posting_blockers.length ? "blocked" : "ready",
+        production_blockers: controls.posting_blockers.map((item) => item.code),
+      } : current);
+    } catch (currentError) {
+      setError(currentError instanceof Error ? currentError.message : "Unable to update safety and crew release controls");
+    } finally {
+      setSavingSafetyLaunch(false);
+    }
+  }
+
   const normalizedSearch = searchFilter.trim().toLocaleLowerCase();
   const filteredProjects = filterProjects(projects, normalizedSearch, smokeTestOnly);
 
@@ -393,12 +428,14 @@ export function ProjectWorkspacePage() {
             dashboard={dashboard}
             workspace={workspace}
             launchDashboard={launchDashboard}
+            safetyLaunchControls={safetyLaunchControls}
             startChecklist={startChecklist}
             closeoutChecklist={closeoutChecklist}
             invoicePackageReadiness={invoicePackageReadiness}
             savingChecklistCode={savingChecklistCode}
             savingCloseoutCode={savingCloseoutCode}
             initializingCloseout={initializingCloseout}
+            savingSafetyLaunch={savingSafetyLaunch}
             activeTab={activeTab}
             onTabChange={setActiveTab}
             onStatusChange={(value) => void updateStatus(value)}
@@ -406,6 +443,7 @@ export function ProjectWorkspacePage() {
             onDelete={() => void deleteProject()}
             canDelete={isAdmin}
             canManageCloseout={isManagement}
+            onSafetyLaunchChange={(payload) => void updateSafetyLaunch(payload)}
             onStartChecklistChange={(code, completed) => void updateStartChecklistItem(code, completed)}
             onInitializeCloseout={() => void initializeCloseoutChecklist()}
             onCloseoutChecklistChange={(code, completed, evidence) => void updateCloseoutChecklistItem(code, completed, evidence)}
@@ -635,12 +673,14 @@ function ProjectDetail({
   dashboard,
   workspace,
   launchDashboard,
+  safetyLaunchControls,
   startChecklist,
   closeoutChecklist,
   invoicePackageReadiness,
   savingChecklistCode,
   savingCloseoutCode,
   initializingCloseout,
+  savingSafetyLaunch,
   activeTab,
   onTabChange,
   onStatusChange,
@@ -648,6 +688,7 @@ function ProjectDetail({
   onDelete,
   canDelete,
   canManageCloseout,
+  onSafetyLaunchChange,
   onStartChecklistChange,
   onInitializeCloseout,
   onCloseoutChecklistChange,
@@ -657,12 +698,14 @@ function ProjectDetail({
   dashboard: ProjectDashboard;
   workspace: AwardedProjectWorkspace | null;
   launchDashboard: ProjectLaunchDashboard | null;
+  safetyLaunchControls: ProjectSafetyLaunchControls | null;
   startChecklist: ProjectStartChecklist | null;
   closeoutChecklist: ProjectCloseoutChecklist | null;
   invoicePackageReadiness: ProjectInvoicePackageReadiness | null;
   savingChecklistCode: string | null;
   savingCloseoutCode: string | null;
   initializingCloseout: boolean;
+  savingSafetyLaunch: boolean;
   activeTab: string;
   onTabChange: (tab: string) => void;
   onStatusChange: (status: ProjectStatus) => void;
@@ -670,6 +713,7 @@ function ProjectDetail({
   onDelete: () => void;
   canDelete: boolean;
   canManageCloseout: boolean;
+  onSafetyLaunchChange: (payload: ProjectSafetyLaunchUpdate) => void;
   onStartChecklistChange: (code: string, completed: boolean) => void;
   onInitializeCloseout: () => void;
   onCloseoutChecklistChange: (code: string, completed: boolean, evidence?: string | null) => void;
@@ -718,6 +762,14 @@ function ProjectDetail({
 
       {workspace ? <AwardedWorkspaceCard workspace={workspace} /> : null}
       {launchDashboard ? <ProjectLaunchDashboardCard dashboard={launchDashboard} project={project} /> : null}
+      {safetyLaunchControls ? (
+        <ProjectSafetyLaunchCard
+          key={safetyLaunchControls.launch.last_reviewed_at ?? safetyLaunchControls.launch.initialized_at}
+          controls={safetyLaunchControls}
+          saving={savingSafetyLaunch}
+          onSave={onSafetyLaunchChange}
+        />
+      ) : null}
       {startChecklist ? (
         <ProjectStartChecklistCard
           checklist={startChecklist}
@@ -769,6 +821,365 @@ function ProjectDetail({
         </div>
       </div>
     </div>
+  );
+}
+
+const safetyRecordTypeByRequirement: Partial<Record<
+  ProjectSafetyLaunchUpdate["record_requirements"][number]["code"],
+  string
+>> = {
+  emergency_action_card: "emergency_action_card",
+  field_hazard_assessment: "daily_hazard_assessment",
+  toolbox_talk: "toolbox_talk",
+  safety_permit: "safety_permit",
+};
+
+function ProjectSafetyLaunchCard({
+  controls,
+  saving,
+  onSave,
+}: {
+  controls: ProjectSafetyLaunchControls;
+  saving: boolean;
+  onSave: (payload: ProjectSafetyLaunchUpdate) => void;
+}) {
+  const [requirements, setRequirements] = useState<ProjectSafetyLaunchUpdate["record_requirements"]>(
+    controls.launch.record_requirements.map((item) => ({
+      code: item.code,
+      applicability_status: item.applicability_status,
+      status: item.status,
+      record_id: item.record_id,
+      evidence_document_ids: item.evidence_document_ids,
+      not_applicable_basis: item.not_applicable_basis,
+    })),
+  );
+  const eligibleEmployeeIds = new Set(controls.active_employees.map((item) => item.id));
+  const unavailableAssignmentCount = controls.launch.portal_access.assignments.filter(
+    (item) => !eligibleEmployeeIds.has(item.employee_id),
+  ).length;
+  const [assignments, setAssignments] = useState(
+    controls.launch.portal_access.assignments.filter((item) => eligibleEmployeeIds.has(item.employee_id)),
+  );
+  const [portalStatus, setPortalStatus] = useState(controls.launch.portal_access.status);
+  const [releaseStatus, setReleaseStatus] = useState(controls.launch.release_status);
+  const [reviewNote, setReviewNote] = useState("");
+  const [releaseConfirmation, setReleaseConfirmation] = useState(false);
+
+  const activeAssignmentIds = new Set(
+    assignments.filter((item) => item.status === "active").map((item) => item.employee_id),
+  );
+  const invalidRequirement = requirements.some((item) => {
+    if (item.applicability_status === "unconfirmed") return item.status !== "not_started";
+    if (item.applicability_status === "not_applicable") {
+      return item.status !== "ready" || (item.not_applicable_basis ?? "").trim().length < 10;
+    }
+    return item.status === "ready" && item.evidence_document_ids.length === 0;
+  });
+  const unresolvedForRelease = requirements.some((item) => (
+    item.applicability_status === "unconfirmed"
+    || item.status !== "ready"
+    || (item.applicability_status === "applicable" && item.evidence_document_ids.length === 0)
+    || (item.applicability_status === "not_applicable" && (item.not_applicable_basis ?? "").trim().length < 10)
+  ));
+  const saveBlocked = saving
+    || reviewNote.trim().length < 10
+    || invalidRequirement
+    || (portalStatus === "active" && activeAssignmentIds.size === 0)
+    || (portalStatus === "not_started" && activeAssignmentIds.size > 0)
+    || (releaseStatus === "ready" && (unresolvedForRelease || !releaseConfirmation));
+
+  function updateRequirement(
+    code: ProjectSafetyLaunchUpdate["record_requirements"][number]["code"],
+    updates: Partial<ProjectSafetyLaunchUpdate["record_requirements"][number]>,
+  ) {
+    setRequirements((current) => current.map((item) => item.code === code ? { ...item, ...updates } : item));
+  }
+
+  function changeApplicability(
+    code: ProjectSafetyLaunchUpdate["record_requirements"][number]["code"],
+    applicability: ProjectSafetyLaunchUpdate["record_requirements"][number]["applicability_status"],
+  ) {
+    if (applicability === "unconfirmed") {
+      updateRequirement(code, {
+        applicability_status: applicability,
+        status: "not_started",
+        record_id: null,
+        evidence_document_ids: [],
+        not_applicable_basis: null,
+      });
+      return;
+    }
+    if (applicability === "not_applicable") {
+      updateRequirement(code, {
+        applicability_status: applicability,
+        status: "ready",
+        record_id: null,
+        evidence_document_ids: [],
+      });
+      return;
+    }
+    updateRequirement(code, {
+      applicability_status: applicability,
+      status: "in_progress",
+      not_applicable_basis: null,
+    });
+  }
+
+  function toggleEvidence(
+    code: ProjectSafetyLaunchUpdate["record_requirements"][number]["code"],
+    documentId: string,
+    checked: boolean,
+  ) {
+    const item = requirements.find((candidate) => candidate.code === code);
+    if (!item) return;
+    updateRequirement(code, {
+      evidence_document_ids: checked
+        ? [...item.evidence_document_ids, documentId]
+        : item.evidence_document_ids.filter((id) => id !== documentId),
+    });
+  }
+
+  function toggleEmployee(employeeId: string, checked: boolean) {
+    const employee = controls.active_employees.find((item) => item.id === employeeId);
+    if (!employee) return;
+    setAssignments((current) => checked
+      ? [
+          ...current.filter((item) => item.employee_id !== employeeId),
+          { employee_id: employeeId, portal_role: employee.portal_role, status: "active" },
+        ]
+      : current.filter((item) => item.employee_id !== employeeId));
+    if (checked && portalStatus === "not_started") setPortalStatus("active");
+  }
+
+  return (
+    <section aria-label="Project safety and crew release" className="rounded-md border border-brand-gold/40 bg-white p-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-brand-gold" aria-hidden="true" />
+            <h2 className="text-base font-semibold text-iron-950">Project safety and crew release</h2>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-iron-500">
+            Management records project evidence and exact crew access here. IHOS does not infer applicability, approve evidence, or activate workers automatically.
+          </p>
+        </div>
+        <span className="w-fit rounded-md bg-brand-gold/10 px-3 py-2 text-xs font-semibold text-iron-800">
+          Safety {label(controls.launch.release_status)} · Portal {label(controls.launch.portal_access.status)}
+        </span>
+      </div>
+
+      {controls.posting_blockers.length ? (
+        <div className="mt-4 rounded-md border border-brand-gold/40 bg-brand-gold/5 p-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-iron-700">Field posting remains blocked</div>
+          <ul className="mt-2 space-y-1 text-sm text-iron-700">
+            {controls.posting_blockers.map((item) => <li key={item.code}>{item.message}</li>)}
+          </ul>
+        </div>
+      ) : (
+        <Notice tone="neutral" message="Safety, portal access, crew assignment, and mobilization controls currently permit field posting." />
+      )}
+
+      <div className="mt-5 space-y-4">
+        {requirements.map((item) => {
+          const definition = controls.launch.record_requirements.find((candidate) => candidate.code === item.code);
+          const expectedRecordType = safetyRecordTypeByRequirement[item.code];
+          const recordOptions = controls.record_options.filter((record) => record.record_type === expectedRecordType);
+          return (
+            <fieldset key={item.code} className="rounded-md border border-iron-100 p-4">
+              <legend className="px-1 text-sm font-semibold text-iron-950">{definition?.label ?? label(item.code)}</legend>
+              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                <Field label="Applicability">
+                  <select
+                    aria-label={`${definition?.label ?? item.code} applicability`}
+                    value={item.applicability_status}
+                    disabled={saving}
+                    onChange={(event) => changeApplicability(item.code, event.target.value as typeof item.applicability_status)}
+                    className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+                  >
+                    <option value="unconfirmed">Unconfirmed</option>
+                    <option value="applicable">Applicable</option>
+                    <option value="not_applicable">Not applicable</option>
+                  </select>
+                </Field>
+                <Field label="Control status">
+                  <select
+                    aria-label={`${definition?.label ?? item.code} status`}
+                    value={item.status}
+                    disabled={saving || item.applicability_status !== "applicable"}
+                    onChange={(event) => updateRequirement(item.code, { status: event.target.value as typeof item.status })}
+                    className="w-full rounded-md border border-iron-100 px-3 py-2 text-sm disabled:bg-iron-50"
+                  >
+                    <option value="not_started">Not started</option>
+                    <option value="in_progress">In progress</option>
+                    <option value="blocked">Blocked</option>
+                    <option value="ready">Ready</option>
+                  </select>
+                </Field>
+              </div>
+
+              {item.applicability_status === "not_applicable" ? (
+                <Field label="Written not-applicable basis">
+                  <textarea
+                    aria-label={`${definition?.label ?? item.code} not-applicable basis`}
+                    value={item.not_applicable_basis ?? ""}
+                    disabled={saving}
+                    onChange={(event) => updateRequirement(item.code, { not_applicable_basis: event.target.value })}
+                    className="mt-2 min-h-20 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+                    placeholder="Record the project-specific basis (minimum 10 characters)."
+                  />
+                </Field>
+              ) : null}
+
+              {item.applicability_status === "applicable" ? (
+                <div className="mt-3 grid gap-3 lg:grid-cols-2">
+                  <div>
+                    <div className="text-xs font-semibold uppercase tracking-wide text-iron-500">Current project evidence</div>
+                    {controls.evidence_documents.length ? (
+                      <div className="mt-2 max-h-40 space-y-2 overflow-y-auto rounded-md border border-iron-100 p-3">
+                        {controls.evidence_documents.map((document) => (
+                          <label key={document.id} className="flex cursor-pointer items-start gap-2 text-sm text-iron-800">
+                            <input
+                              type="checkbox"
+                              checked={item.evidence_document_ids.includes(document.id)}
+                              disabled={saving}
+                              onChange={(event) => toggleEvidence(item.code, document.id, event.target.checked)}
+                              className="mt-0.5 h-4 w-4 accent-signal-green"
+                            />
+                            <span>{document.title} · {label(document.status)}</span>
+                          </label>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="mt-2 text-sm text-iron-500">No current stored documents are linked to this project. Add them in Documents first.</p>
+                    )}
+                  </div>
+                  <Field label="Supporting IHOS record (optional)">
+                    <select
+                      aria-label={`${definition?.label ?? item.code} supporting IHOS record`}
+                      value={item.record_id ?? ""}
+                      disabled={saving || !expectedRecordType}
+                      onChange={(event) => updateRequirement(item.code, { record_id: event.target.value || null })}
+                      className="mt-2 w-full rounded-md border border-iron-100 px-3 py-2 text-sm disabled:bg-iron-50"
+                    >
+                      <option value="">No supporting record selected</option>
+                      {recordOptions.map((record) => (
+                        <option key={record.id} value={record.id}>{record.work_date} · {record.title} · {label(record.status)}</option>
+                      ))}
+                    </select>
+                  </Field>
+                </div>
+              ) : null}
+            </fieldset>
+          );
+        })}
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        <fieldset className="rounded-md border border-iron-100 p-4">
+          <legend className="px-1 text-sm font-semibold text-iron-950">Controlled crew access</legend>
+          <Field label="Project portal status">
+            <select
+              aria-label="Project portal status"
+              value={portalStatus}
+              disabled={saving}
+              onChange={(event) => setPortalStatus(event.target.value as typeof portalStatus)}
+              className="mt-2 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+            >
+              <option value="not_started">Not started</option>
+              <option value="active">Active</option>
+              <option value="suspended">Suspended</option>
+            </select>
+          </Field>
+          <div className="mt-3 text-xs font-semibold uppercase tracking-wide text-iron-500">Active employees</div>
+          {unavailableAssignmentCount ? (
+            <p className="mt-2 text-sm text-signal-red">
+              {unavailableAssignmentCount} prior assignment(s) no longer have an active employee and portal account. Saving removes them.
+            </p>
+          ) : null}
+          <div className="mt-2 max-h-48 space-y-2 overflow-y-auto rounded-md border border-iron-100 p-3">
+            {controls.active_employees.length ? controls.active_employees.map((employee) => (
+              <label key={employee.id} className="flex cursor-pointer items-start gap-2 text-sm text-iron-800">
+                <input
+                  type="checkbox"
+                  checked={activeAssignmentIds.has(employee.id)}
+                  disabled={saving}
+                  onChange={(event) => toggleEmployee(employee.id, event.target.checked)}
+                  className="mt-0.5 h-4 w-4 accent-signal-green"
+                />
+                <span>{employee.display_name} · {label(employee.portal_role)}</span>
+              </label>
+            )) : <p className="text-sm text-iron-500">No active crew profiles are available. Complete onboarding first.</p>}
+          </div>
+        </fieldset>
+
+        <fieldset className="rounded-md border border-iron-100 p-4">
+          <legend className="px-1 text-sm font-semibold text-iron-950">Human release decision</legend>
+          <Field label="Safety release status">
+            <select
+              aria-label="Safety release status"
+              value={releaseStatus}
+              disabled={saving}
+              onChange={(event) => {
+                const value = event.target.value as typeof releaseStatus;
+                setReleaseStatus(value);
+                if (value !== "ready") setReleaseConfirmation(false);
+              }}
+              className="mt-2 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+            >
+              <option value="blocked">Blocked</option>
+              <option value="at_risk">At risk</option>
+              <option value="ready">Ready</option>
+            </select>
+          </Field>
+          <Field label="Review note">
+            <textarea
+              aria-label="Safety release review note"
+              value={reviewNote}
+              disabled={saving}
+              onChange={(event) => setReviewNote(event.target.value)}
+              className="mt-2 min-h-24 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+              placeholder="Record what was reviewed and any remaining constraints."
+            />
+          </Field>
+          {releaseStatus === "ready" ? (
+            <label className="mt-3 flex cursor-pointer items-start gap-2 rounded-md border border-brand-gold/40 bg-brand-gold/5 p-3 text-sm text-iron-800">
+              <input
+                type="checkbox"
+                checked={releaseConfirmation}
+                disabled={saving}
+                onChange={(event) => setReleaseConfirmation(event.target.checked)}
+                className="mt-0.5 h-4 w-4 accent-signal-green"
+              />
+              <span>I confirm every requirement was reviewed against the linked project evidence. This is a human safety decision.</span>
+            </label>
+          ) : null}
+          <button
+            type="button"
+            disabled={saveBlocked}
+            onClick={() => onSave({
+              release_status: releaseStatus,
+              record_requirements: requirements,
+              portal_access: { status: portalStatus, assignments },
+              review_note: reviewNote.trim(),
+              release_confirmation: releaseConfirmation,
+            })}
+            className="mt-4 inline-flex min-h-11 items-center gap-2 rounded-md bg-iron-950 px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            {saving ? "Saving controlled release..." : "Save controlled release"}
+          </button>
+          <p className="mt-2 text-xs leading-5 text-iron-500">
+            A 10-character review note is required. Ready also requires resolved evidence and explicit confirmation.
+          </p>
+        </fieldset>
+      </div>
+
+      {controls.launch.last_reviewed_by && controls.launch.last_reviewed_at ? (
+        <p className="mt-4 text-xs text-iron-500">
+          Last reviewed by {controls.launch.last_reviewed_by} on {formatDateTime(controls.launch.last_reviewed_at)}.
+        </p>
+      ) : null}
+    </section>
   );
 }
 
@@ -1546,6 +1957,13 @@ function formatCurrency(value: number) {
     currency: "CAD",
     maximumFractionDigits: 0,
   }).format(value);
+}
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("en-CA", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
 }
 
 function Field({ label: itemLabel, children }: { label: string; children: React.ReactNode }) {

--- a/frontend/src/pages/ProjectWorkspacePage.tsx
+++ b/frontend/src/pages/ProjectWorkspacePage.tsx
@@ -720,7 +720,7 @@ function ProjectDetail({
   onInvoicePackageGenerated: () => Promise<void>;
 }) {
   return (
-    <div className="space-y-6">
+    <div className="min-w-0 space-y-6">
       <div className="rounded-md border border-iron-100 bg-white p-5">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
@@ -952,7 +952,7 @@ function ProjectSafetyLaunchCard({
   }
 
   return (
-    <section aria-label="Project safety and crew release" className="rounded-md border border-brand-gold/40 bg-white p-5">
+    <section aria-label="Project safety and crew release" className="min-w-0 rounded-md border border-brand-gold/40 bg-white p-5">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div>
           <div className="flex items-center gap-2">
@@ -985,7 +985,7 @@ function ProjectSafetyLaunchCard({
           const expectedRecordType = safetyRecordTypeByRequirement[item.code];
           const recordOptions = controls.record_options.filter((record) => record.record_type === expectedRecordType);
           return (
-            <fieldset key={item.code} className="rounded-md border border-iron-100 p-4">
+            <fieldset key={item.code} className="min-w-0 rounded-md border border-iron-100 p-4">
               <legend className="px-1 text-sm font-semibold text-iron-950">{definition?.label ?? label(item.code)}</legend>
               <div className="mt-2 grid gap-3 md:grid-cols-2">
                 <Field label="Applicability">
@@ -1031,8 +1031,8 @@ function ProjectSafetyLaunchCard({
               ) : null}
 
               {item.applicability_status === "applicable" ? (
-                <div className="mt-3 grid gap-3 lg:grid-cols-2">
-                  <div>
+                <div className="mt-3 grid min-w-0 gap-3 2xl:grid-cols-2">
+                  <div className="min-w-0">
                     <div className="text-xs font-semibold uppercase tracking-wide text-iron-500">Current project evidence</div>
                     {controls.evidence_documents.length ? (
                       <div className="mt-2 max-h-40 space-y-2 overflow-y-auto rounded-md border border-iron-100 p-3">
@@ -1059,7 +1059,7 @@ function ProjectSafetyLaunchCard({
                       value={item.record_id ?? ""}
                       disabled={saving || !expectedRecordType}
                       onChange={(event) => updateRequirement(item.code, { record_id: event.target.value || null })}
-                      className="mt-2 w-full rounded-md border border-iron-100 px-3 py-2 text-sm disabled:bg-iron-50"
+                      className="mt-2 min-w-0 max-w-full rounded-md border border-iron-100 px-3 py-2 text-sm disabled:bg-iron-50"
                     >
                       <option value="">No supporting record selected</option>
                       {recordOptions.map((record) => (
@@ -1074,8 +1074,8 @@ function ProjectSafetyLaunchCard({
         })}
       </div>
 
-      <div className="mt-5 grid gap-4 lg:grid-cols-2">
-        <fieldset className="rounded-md border border-iron-100 p-4">
+      <div className="mt-5 grid min-w-0 gap-4 2xl:grid-cols-2">
+        <fieldset className="min-w-0 rounded-md border border-iron-100 p-4">
           <legend className="px-1 text-sm font-semibold text-iron-950">Controlled crew access</legend>
           <Field label="Project portal status">
             <select
@@ -1083,7 +1083,7 @@ function ProjectSafetyLaunchCard({
               value={portalStatus}
               disabled={saving}
               onChange={(event) => setPortalStatus(event.target.value as typeof portalStatus)}
-              className="mt-2 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+              className="mt-2 min-w-0 max-w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
             >
               <option value="not_started">Not started</option>
               <option value="active">Active</option>
@@ -1112,7 +1112,7 @@ function ProjectSafetyLaunchCard({
           </div>
         </fieldset>
 
-        <fieldset className="rounded-md border border-iron-100 p-4">
+        <fieldset className="min-w-0 rounded-md border border-iron-100 p-4">
           <legend className="px-1 text-sm font-semibold text-iron-950">Human release decision</legend>
           <Field label="Safety release status">
             <select
@@ -1124,7 +1124,7 @@ function ProjectSafetyLaunchCard({
                 setReleaseStatus(value);
                 if (value !== "ready") setReleaseConfirmation(false);
               }}
-              className="mt-2 w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
+              className="mt-2 min-w-0 max-w-full rounded-md border border-iron-100 px-3 py-2 text-sm"
             >
               <option value="blocked">Blocked</option>
               <option value="at_risk">At risk</option>
@@ -1968,7 +1968,7 @@ function formatDateTime(value: string) {
 
 function Field({ label: itemLabel, children }: { label: string; children: React.ReactNode }) {
   return (
-    <label className="block">
+    <label className="block min-w-0">
       <span className="mb-1 block text-sm font-medium text-iron-800">{itemLabel}</span>
       {children}
     </label>

--- a/tests/backend/test_daily_timesheets.py
+++ b/tests/backend/test_daily_timesheets.py
@@ -284,52 +284,49 @@ def _controlled_project(data: dict) -> dict:
             )
             for index in range(1, 3)
         ]
-        db.add_all([bid, *photos, *tickets])
+        safety_documents = [
+            Document(
+                title=f"Controlled safety evidence {index}",
+                category="other",
+                status="current",
+                project_id=project_id,
+                storage_uri=f"drive://controlled-project/safety-evidence-{index}.pdf",
+                metadata_json={},
+            )
+            for index in range(1, 7)
+        ]
+        db.add_all([bid, *photos, *tickets, *safety_documents])
         db.commit()
-        for item in [*photos, *tickets]:
+        for item in [*photos, *tickets, *safety_documents]:
             db.refresh(item)
         return {
             "project": project,
             "photo_document_ids": [str(item.id) for item in photos],
             "ticket_document_ids": [str(item.id) for item in tickets],
+            "safety_document_ids": [str(item.id) for item in safety_documents],
         }
 
 
 def _release_controlled_project(data: dict, controlled: dict) -> None:
     project_id = UUID(controlled["project"]["id"])
-    with TestingSessionLocal() as db:
-        project = db.get(Project, project_id)
-        metadata = deepcopy(project.metadata_json)
-        launch = deepcopy(metadata["safety_launch"])
-        safety_rows = []
-        for requirement in launch["record_requirements"]:
-            row = FieldRecord(
-                record_type=requirement["code"],
-                project_id=project_id,
-                work_date=date.today(),
-                title=requirement["label"],
-                status="ready",
-                severity="none",
-                details={},
-                document_ids=[],
-                signatures=[],
-                alert_recipients=[],
-            )
-            db.add(row)
-            safety_rows.append((requirement, row))
-        db.flush()
-        for requirement, row in safety_rows:
-            requirement.update(
+    launch = client.get(f"/api/v1/projects/{project_id}/safety-launch").json()
+    release = client.patch(
+        f"/api/v1/projects/{project_id}/safety-launch",
+        json={
+            "release_status": "ready",
+            "record_requirements": [
                 {
+                    "code": requirement["code"],
                     "applicability_status": "applicable",
                     "status": "ready",
-                    "record_id": str(row.id),
+                    "record_id": None,
+                    "evidence_document_ids": [controlled["safety_document_ids"][index]],
+                    "not_applicable_basis": None,
                 }
-            )
-        launch["release_status"] = "ready"
-        launch["portal_access"] = {
+                for index, requirement in enumerate(launch["record_requirements"])
+            ],
+            "portal_access": {
             "status": "active",
-            "automatic_provisioning": False,
             "assignments": [
                 {
                     "employee_id": data["foreman"]["id"],
@@ -342,10 +339,12 @@ def _release_controlled_project(data: dict, controlled: dict) -> None:
                     "status": "active",
                 },
             ],
-        }
-        metadata["safety_launch"] = launch
-        project.metadata_json = metadata
-        db.commit()
+            },
+            "review_note": "Controlled test release using exact project evidence and crew records.",
+            "release_confirmation": True,
+        },
+    )
+    assert release.status_code == 200, release.text
     checklist = client.get(f"/api/v1/projects/{project_id}/start-checklist").json()
     for item in checklist["items"]:
         response = client.patch(

--- a/tests/backend/test_projects.py
+++ b/tests/backend/test_projects.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import UTC, datetime
 from unittest.mock import patch
 from uuid import UUID
@@ -11,6 +12,7 @@ from app.api.dependencies.auth import require_authenticated_user
 from app.main import app
 from app.models.field_operations import FieldRecord
 from app.models.project import Project, ProjectCloseoutChecklistItem, ProjectStartChecklistItem
+from app.models.user import Employee
 from app.services.auth import AuthenticatedUser
 from app.services.projects import (
     _provision_project_closeout_checklist,
@@ -312,6 +314,321 @@ def test_safety_launch_initialization_requires_management() -> None:
 
     assert client.get(f"/api/v1/projects/{project['id']}/safety-launch").status_code == 403
     assert client.post(f"/api/v1/projects/{project['id']}/safety-launch").status_code == 403
+
+
+def _safety_launch_update_payload(
+    launch: dict,
+    *,
+    document_id: str,
+    employee_id: str,
+    release_confirmation: bool = True,
+) -> dict:
+    return {
+        "release_status": "ready",
+        "record_requirements": [
+            {
+                "code": item["code"],
+                "applicability_status": "applicable",
+                "status": "ready",
+                "record_id": None,
+                "evidence_document_ids": [document_id],
+                "not_applicable_basis": None,
+            }
+            for item in launch["record_requirements"]
+        ],
+        "portal_access": {
+            "status": "active",
+            "assignments": [
+                {
+                    "employee_id": employee_id,
+                    "portal_role": "foreman",
+                    "status": "active",
+                }
+            ],
+        },
+        "review_note": "Reviewed against the current controlled project evidence.",
+        "release_confirmation": release_confirmation,
+    }
+
+
+def test_management_updates_fail_closed_safety_and_crew_release_with_project_evidence() -> None:
+    project = client.post(
+        "/api/v1/projects",
+        json={"name": "Evidence Controlled Safety Launch", "status": "awarded"},
+    ).json()
+    launch = client.post(f"/api/v1/projects/{project['id']}/safety-launch").json()
+    employee = client.post(
+        "/api/v1/field-operations/employees",
+        json={
+            "first_name": "Sam",
+            "last_name": "Foreperson",
+            "email": "sam.foreperson@ironhousecontracting.com",
+            "portal_role": "foreman",
+        },
+    ).json()
+    evidence = client.post(
+        "/api/v1/documents",
+        json={
+            "title": "Controlled project safety package",
+            "category": "other",
+            "status": "current",
+            "project_id": project["id"],
+            "storage_uri": "drive://projects/controlled-safety-package.pdf",
+        },
+    ).json()
+    payload = _safety_launch_update_payload(
+        launch,
+        document_id=evidence["id"],
+        employee_id=employee["id"],
+    )
+
+    no_confirmation = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json={**payload, "release_confirmation": False},
+    )
+    assert no_confirmation.status_code == 409
+    assert "explicit human confirmation" in no_confirmation.json()["error"]["message"]
+
+    released = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=payload,
+    )
+    assert released.status_code == 200, released.text
+    controls = released.json()
+    assert controls["launch"]["release_status"] == "ready"
+    assert controls["launch"]["portal_access"]["status"] == "active"
+    assert controls["launch"]["last_reviewed_by"] == "test-admin@ironhousecontracting.com"
+    assert controls["launch"]["last_reviewed_at"]
+    assert controls["launch"]["review_history"][-1]["review_note"] == payload["review_note"]
+    assert [item["code"] for item in controls["posting_blockers"]] == ["mobilization"]
+    assert controls["evidence_documents"][0]["id"] == evidence["id"]
+    assert controls["active_employees"][0]["id"] == employee["id"]
+
+    checklist = client.get(f"/api/v1/projects/{project['id']}/start-checklist").json()
+    for item in checklist["items"]:
+        assert client.patch(
+            f"/api/v1/projects/{project['id']}/start-checklist/{item['code']}",
+            json={"completed": True},
+        ).status_code == 200
+    refreshed = client.get(f"/api/v1/projects/{project['id']}/safety-launch/controls")
+    assert refreshed.status_code == 200
+    assert refreshed.json()["posting_blockers"] == []
+    with TestingSessionLocal() as db:
+        assert db.scalar(
+            select(func.count())
+            .select_from(FieldRecord)
+            .where(FieldRecord.project_id == UUID(project["id"]))
+        ) == 0
+
+
+def test_safety_release_rejects_wrong_project_evidence_inactive_or_duplicate_crew_and_short_basis() -> None:
+    project = client.post(
+        "/api/v1/projects",
+        json={"name": "Rejected Safety Release", "status": "awarded"},
+    ).json()
+    other = client.post(
+        "/api/v1/projects",
+        json={"name": "Other Safety Evidence Job", "status": "awarded"},
+    ).json()
+    launch = client.post(f"/api/v1/projects/{project['id']}/safety-launch").json()
+    wrong_document = client.post(
+        "/api/v1/documents",
+        json={
+            "title": "Wrong project safety package",
+            "category": "other",
+            "status": "current",
+            "project_id": other["id"],
+            "storage_uri": "drive://projects/wrong-safety-package.pdf",
+        },
+    ).json()
+    employee = client.post(
+        "/api/v1/field-operations/employees",
+        json={
+            "first_name": "Alex",
+            "last_name": "Crew",
+            "email": "alex.crew@ironhousecontracting.com",
+            "portal_role": "employee",
+        },
+    ).json()
+    payload = _safety_launch_update_payload(
+        launch,
+        document_id=wrong_document["id"],
+        employee_id=employee["id"],
+    )
+    payload["portal_access"]["assignments"][0]["portal_role"] = "employee"
+
+    accountless_employee = client.post(
+        "/api/v1/field-operations/employees",
+        json={
+            "first_name": "No",
+            "last_name": "Account",
+            "email": "no.account@ironhousecontracting.com",
+            "portal_role": "employee",
+            "provision_portal_access": False,
+        },
+    ).json()
+    accountless_payload = deepcopy(payload)
+    accountless_payload["portal_access"]["assignments"][0]["employee_id"] = accountless_employee["id"]
+    accountless = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=accountless_payload,
+    )
+    assert accountless.status_code == 409
+    assert "active portal account" in accountless.json()["error"]["message"]
+
+    wrong_project = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=payload,
+    )
+    assert wrong_project.status_code == 409
+    assert "exact project" in wrong_project.json()["error"]["message"]
+
+    duplicate_crew = deepcopy(payload)
+    duplicate_crew["portal_access"]["assignments"].append(
+        deepcopy(duplicate_crew["portal_access"]["assignments"][0])
+    )
+    duplicate = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=duplicate_crew,
+    )
+    assert duplicate.status_code == 409
+    assert "duplicate employees" in duplicate.json()["error"]["message"]
+
+    short_basis = deepcopy(payload)
+    short_basis["release_status"] = "blocked"
+    short_basis["record_requirements"][0].update(
+        {
+            "applicability_status": "not_applicable",
+            "status": "ready",
+            "evidence_document_ids": [],
+            "not_applicable_basis": "No",
+        }
+    )
+    rejected_basis = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=short_basis,
+    )
+    assert rejected_basis.status_code == 409
+    assert "at least 10 characters" in rejected_basis.json()["error"]["message"]
+
+    current_document = client.post(
+        "/api/v1/documents",
+        json={
+            "title": "Current project safety package",
+            "category": "other",
+            "status": "current",
+            "project_id": project["id"],
+            "storage_uri": "drive://projects/current-safety-package.pdf",
+        },
+    ).json()
+    with TestingSessionLocal() as db:
+        unsupported_record = FieldRecord(
+            record_type="journal",
+            project_id=UUID(project["id"]),
+            work_date=datetime.now(UTC).date(),
+            title="Not a controlled safety record",
+            status="ready",
+            severity="none",
+            details={},
+            document_ids=[],
+            signatures=[],
+            alert_recipients=[],
+        )
+        db.add(unsupported_record)
+        db.commit()
+        unsupported_record_id = str(unsupported_record.id)
+    unsupported_payload = deepcopy(payload)
+    for item in unsupported_payload["record_requirements"]:
+        item["evidence_document_ids"] = [current_document["id"]]
+    unsupported_payload["record_requirements"][1]["record_id"] = unsupported_record_id
+    unsupported = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=unsupported_payload,
+    )
+    assert unsupported.status_code == 409
+    assert "unsupported, incomplete, or wrong-project" in unsupported.json()["error"]["message"]
+
+    with TestingSessionLocal() as db:
+        stored_employee = db.get(Employee, UUID(employee["id"]))
+        assert stored_employee is not None
+        stored_employee.status = "inactive"
+        db.commit()
+    inactive = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json=payload,
+    )
+    assert inactive.status_code == 409
+    assert "active employee records" in inactive.json()["error"]["message"]
+
+
+def test_viewer_cannot_read_or_update_safety_release_controls() -> None:
+    project = client.post(
+        "/api/v1/projects",
+        json={"name": "Management Only Release", "status": "awarded"},
+    ).json()
+    launch = client.post(f"/api/v1/projects/{project['id']}/safety-launch").json()
+    _authenticate_as("viewer")
+
+    assert client.get(f"/api/v1/projects/{project['id']}/safety-launch/controls").status_code == 403
+    denied = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json={
+            "release_status": "blocked",
+            "record_requirements": [
+                {
+                    "code": item["code"],
+                    "applicability_status": "unconfirmed",
+                    "status": "not_started",
+                    "record_id": None,
+                    "evidence_document_ids": [],
+                    "not_applicable_basis": None,
+                }
+                for item in launch["record_requirements"]
+            ],
+            "portal_access": {"status": "not_started", "assignments": []},
+            "review_note": "Viewer must not save controlled release decisions.",
+            "release_confirmation": False,
+        },
+    )
+    assert denied.status_code == 403
+
+
+def test_operations_manager_can_record_a_blocked_safety_review_without_creating_facts() -> None:
+    project = client.post(
+        "/api/v1/projects",
+        json={"name": "Operations Manager Safety Review", "status": "awarded"},
+    ).json()
+    launch = client.post(f"/api/v1/projects/{project['id']}/safety-launch").json()
+    _authenticate_as("operations_manager")
+
+    reviewed = client.patch(
+        f"/api/v1/projects/{project['id']}/safety-launch",
+        json={
+            "release_status": "blocked",
+            "record_requirements": [
+                {
+                    "code": item["code"],
+                    "applicability_status": "unconfirmed",
+                    "status": "not_started",
+                    "record_id": None,
+                    "evidence_document_ids": [],
+                    "not_applicable_basis": None,
+                }
+                for item in launch["record_requirements"]
+            ],
+            "portal_access": {"status": "not_started", "assignments": []},
+            "review_note": "Evidence and crew assignments remain outstanding.",
+            "release_confirmation": False,
+        },
+    )
+
+    assert reviewed.status_code == 200
+    assert reviewed.json()["launch"]["release_status"] == "blocked"
+    assert reviewed.json()["launch"]["last_reviewed_by"] == "operations_manager@ironhousecontracting.com"
+    assert all(
+        item["applicability_status"] == "unconfirmed"
+        for item in reviewed.json()["launch"]["record_requirements"]
+    )
 
 
 def test_safety_launch_metadata_cannot_be_injected_or_changed_by_generic_project_writes() -> None:


### PR DESCRIPTION
## Outcome

Adds the final pre-freeze administrative control path required to make controlled awarded jobs operable for crew without fabricating or auto-approving safety facts.

Authorized administrators and operations managers can now:

- attach current, stored documents from the exact project to each safety requirement;
- optionally link only supported, ready project operational records;
- record a not-applicable decision only with a written basis;
- assign only active crew whose IHOS portal account is active, using the employee's approved portal role;
- activate or suspend project portal access;
- set safety release to Blocked, At risk, or Ready with an auditable review note;
- set Ready only after every requirement is resolved and an explicit human confirmation is checked.

Field-production posting remains fail closed until safety release, evidence, active portal access, at least one active crew assignment, and the existing project-start checklist all pass.

## Safety and authorization boundaries

- Management-only read/write controls.
- No safety fact, evidence, applicability, assignment, or approval is inferred.
- Wrong-project or unstored evidence is rejected.
- Unsupported/incomplete operational records are rejected.
- Unknown, inactive, accountless, duplicate, or role-mismatched crew assignments are rejected.
- Generic project metadata writes still cannot bypass the controlled safety-launch endpoint.
- No database migration and no production data mutation.
- No Bennett or other project is released by this change.
- Locked visual design is preserved.

## Validation

Final head: `6eb54d0faca5d6aadfa50a4f06231c73eb1713eb`

- Local backend: 679 passed (one existing Pydantic warning).
- Local frontend: 142 passed.
- Ruff, TypeScript lint, production build, visual design lock, and React Router RSC boundary: passed.
- CI run 1046: passed.
- Release Readiness run 528: passed.
- Desktop Chromium, mobile Chromium, and iPad WebKit interaction/responsiveness/accessibility: passed.
- Staging isolation: passed.
- Disposable staging smoke, backup/restore, rollback, and evidence: passed.
- Production-stack smoke: passed.
- The browser gate caught a real standard-desktop containment defect in the new control card; the final head stacks the internal controls at the correct breakpoint and the zero-horizontal-overflow assertion now passes.

## Rollback

Revert the issue-linked commits. Existing safety-launch metadata remains backward compatible; no schema rollback is required.

Closes #383